### PR TITLE
Fixes #14 - restore stylelint dollar-variable-default

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -11,7 +11,7 @@
       "border-bottom-left-radius",
       "transition"
     ],
+    "function-blacklist": ["calc"],
     "scss/dollar-variable-default": null
-    "function-blacklist": ["calc"]
   }
 }

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -11,6 +11,7 @@
       "border-bottom-left-radius",
       "transition"
     ],
+    "scss/dollar-variable-default": null
     "function-blacklist": ["calc"]
   }
 }


### PR DESCRIPTION
Restores the stylelint config to disable "dollar-variable-default"