### PR TITLE
Provide an environment variable to override the default host name — Fixes #52

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "docs-compile-review": "bundle exec jekyll build --baseurl $UAZ_REVIEW_BASEURL",
     "docs-production": "cross-env JEKYLL_ENV=production npm run docs-compile",
     "docs-lint": "node build/vnu-jar.js",
-    "docs-serve": "bundle exec jekyll serve",
+    "docs-serve": "bundle exec jekyll serve --host $UAZ_HOST",
     "docs-serve-only": "npm run docs-serve -- --skip-initial-build --no-watch",
     "js": "npm-run-all js-copy-*",
     "js-copy-bs": "cross-env-shell shx cp -r node_modules/bootstrap/dist/js/ dist/ && for f in dist/js/bootstrap*; do sed -i \"\" -e s/sourceMappingURL=bootstrap/sourceMappingURL=arizona-bootstrap/ \"$f\"; mv \"$f\" $(echo \"$f\" | sed s/bootstrap/arizona-bootstrap/); done",


### PR DESCRIPTION
## Description
An environment variable passed to Jekyll with the `--host` command-line option can override the hard-coded default, potentially revealing a demo site built within a Docker container to the outside world.
 
## Related Issue
Issue #52 

## How Has This Been Tested?
Setting `-e "UAZ_HOST=0.0.0.0"` as a command-line option to docker run revealed the demo site without needing config file changes. Omitting this option restored the default `localhost` setting.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.