### PR TITLE
Add action to build and deploy CDN assets

### DIFF
--- a/.github/workflows/cdn-deploy.yml
+++ b/.github/workflows/cdn-deploy.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v2
 
       - run: echo "::set-env name=AZ_TRIMMED_REF::${GITHUB_REF#refs/*/}"
+
       - name: Build CDN assets
         # uses: actions/github-script@5d03ada4b0a753e9460b312e61cc4f8fdeacf163
         run: |
@@ -34,3 +35,9 @@ jobs:
         run: |
             aws s3 sync --cache-control max-age=691200 dist/ s3://${{ secrets.AZ_DIGITAL_CDN_BUCKET }}/lib/arizona-bootstrap/${AZ_TRIMMED_REF}/
             aws cloudfront create-invalidation --distribution-id ${{ secrets.AZ_DIGITAL_CDN }} --paths /lib/arizona-bootstrap/${AZ_TRIMMED_REF}/*
+
+      - name: Deploy CDN assets to S3 + CloudFront (latest)
+        if: github.event_name == 'tag'
+        run: |
+          aws s3 sync --cache-control max-age=691200 dist/ s3://${{ secrets.AZ_DIGITAL_CDN_BUCKET }}/lib/arizona-bootstrap/latest/
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.AZ_DIGITAL_CDN }} --paths /lib/arizona-bootstrap/latest/*

--- a/.github/workflows/cdn-deploy.yml
+++ b/.github/workflows/cdn-deploy.yml
@@ -15,10 +15,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - run: echo "::set-env name=AZ_TRIMMED_REF::${GITHUB_REF#refs/*/}"
       - name: Build CDN assets
         # uses: actions/github-script@5d03ada4b0a753e9460b312e61cc4f8fdeacf163
         run: |
-          export AZ_REVIEW_BASEURL="/arizona-bootstrap/${{ github.head_ref }}"
+          export AZ_REVIEW_BASEURL="/arizona-bootstrap/${AZ_TRIMMED_REF}"
           docker run --rm -e "UAZ_REVIEW_BASEURL=$AZ_REVIEW_BASEURL" -v $(pwd):/arizona-bootstrap azdigital/az-node-jre-jekyll:0.0.2 /arizona-bootstrap/scripts/build-cdn-assets.sh
 
       - name: Configure AWS credentials
@@ -30,5 +31,5 @@ jobs:
 
       - name: Deploy CDN assets to S3 + CloudFront
         run: |
-            aws s3 sync --cache-control max-age=691200 dist/ s3://${{ secrets.AZ_DIGITAL_CDN_BUCKET }}/lib/arizona-bootstrap/${{ github.head_ref }}/
-            aws cloudfront create-invalidation --distribution-id ${{ secrets.AZ_DIGITAL_CDN }} --paths /lib/arizona-bootstrap/${{ github.head_ref }}/*
+            aws s3 sync --cache-control max-age=691200 dist/ s3://${{ secrets.AZ_DIGITAL_CDN_BUCKET }}/lib/arizona-bootstrap/${AZ_TRIMMED_REF}/
+            aws cloudfront create-invalidation --distribution-id ${{ secrets.AZ_DIGITAL_CDN }} --paths /lib/arizona-bootstrap/${AZ_TRIMMED_REF}/*

--- a/.github/workflows/cdn-deploy.yml
+++ b/.github/workflows/cdn-deploy.yml
@@ -4,13 +4,12 @@ on:
   push:
     branches:
       - master
-      - feature/59
     tags:
       - '[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   deploy:
-    name: Upload to Amazon S3
+    name: Build & deploy CDN assets
     runs-on: ubuntu-18.04
 
     steps:
@@ -20,7 +19,6 @@ jobs:
       - run: echo "::set-env name=AZ_TRIMMED_REF::${GITHUB_REF#refs/*/}"
 
       - name: Build CDN assets
-        # uses: actions/github-script@5d03ada4b0a753e9460b312e61cc4f8fdeacf163
         run: |
           docker run --rm -v $(pwd):/arizona-bootstrap azdigital/az-node-jre-jekyll:0.0.2 /arizona-bootstrap/scripts/build-cdn-assets.sh
 
@@ -36,7 +34,7 @@ jobs:
             aws s3 sync --cache-control max-age=691200 dist/ s3://${{ secrets.AZ_DIGITAL_CDN_BUCKET }}/lib/arizona-bootstrap/${AZ_TRIMMED_REF}/
             aws cloudfront create-invalidation --distribution-id ${{ secrets.AZ_DIGITAL_CDN }} --paths /lib/arizona-bootstrap/${AZ_TRIMMED_REF}/*
 
-      - name: Deploy CDN assets to S3 + CloudFront (latest)
+      - name: Update 'latest' CDN assets to S3 + CloudFront
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           aws s3 sync --cache-control max-age=691200 dist/ s3://${{ secrets.AZ_DIGITAL_CDN_BUCKET }}/lib/arizona-bootstrap/latest/

--- a/.github/workflows/cdn-deploy.yml
+++ b/.github/workflows/cdn-deploy.yml
@@ -37,7 +37,7 @@ jobs:
             aws cloudfront create-invalidation --distribution-id ${{ secrets.AZ_DIGITAL_CDN }} --paths /lib/arizona-bootstrap/${AZ_TRIMMED_REF}/*
 
       - name: Deploy CDN assets to S3 + CloudFront (latest)
-        if: github.event_name == 'tags'
+        if: startsWith('refs/tags/', github.ref)
         run: |
           aws s3 sync --cache-control max-age=691200 dist/ s3://${{ secrets.AZ_DIGITAL_CDN_BUCKET }}/lib/arizona-bootstrap/latest/
           aws cloudfront create-invalidation --distribution-id ${{ secrets.AZ_DIGITAL_CDN }} --paths /lib/arizona-bootstrap/latest/*

--- a/.github/workflows/cdn-deploy.yml
+++ b/.github/workflows/cdn-deploy.yml
@@ -37,7 +37,7 @@ jobs:
             aws cloudfront create-invalidation --distribution-id ${{ secrets.AZ_DIGITAL_CDN }} --paths /lib/arizona-bootstrap/${AZ_TRIMMED_REF}/*
 
       - name: Deploy CDN assets to S3 + CloudFront (latest)
-        if: github.event_name == 'tag'
+        if: github.event_name == 'tags'
         run: |
           aws s3 sync --cache-control max-age=691200 dist/ s3://${{ secrets.AZ_DIGITAL_CDN_BUCKET }}/lib/arizona-bootstrap/latest/
           aws cloudfront create-invalidation --distribution-id ${{ secrets.AZ_DIGITAL_CDN }} --paths /lib/arizona-bootstrap/latest/*

--- a/.github/workflows/cdn-deploy.yml
+++ b/.github/workflows/cdn-deploy.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
       - feature/59
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   deploy:
@@ -19,8 +21,7 @@ jobs:
       - name: Build CDN assets
         # uses: actions/github-script@5d03ada4b0a753e9460b312e61cc4f8fdeacf163
         run: |
-          export AZ_REVIEW_BASEURL="/arizona-bootstrap/${AZ_TRIMMED_REF}"
-          docker run --rm -e "UAZ_REVIEW_BASEURL=$AZ_REVIEW_BASEURL" -v $(pwd):/arizona-bootstrap azdigital/az-node-jre-jekyll:0.0.2 /arizona-bootstrap/scripts/build-cdn-assets.sh
+          docker run --rm -v $(pwd):/arizona-bootstrap azdigital/az-node-jre-jekyll:0.0.2 /arizona-bootstrap/scripts/build-cdn-assets.sh
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@b77dc228388218453070969c00c26dc392ecb114

--- a/.github/workflows/cdn-deploy.yml
+++ b/.github/workflows/cdn-deploy.yml
@@ -1,0 +1,34 @@
+name: Build & deploy CDN assets
+
+on:
+  push:
+    branches:
+      - master
+      - feature/59
+
+jobs:
+  deploy:
+    name: Upload to Amazon S3
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build CDN assets
+        # uses: actions/github-script@5d03ada4b0a753e9460b312e61cc4f8fdeacf163
+        run: |
+          export AZ_REVIEW_BASEURL="/arizona-bootstrap/${{ github.head_ref }}"
+          docker run --rm -e "UAZ_REVIEW_BASEURL=$AZ_REVIEW_BASEURL" -v $(pwd):/arizona-bootstrap azdigital/az-node-jre-jekyll:0.0.2 /arizona-bootstrap/scripts/build-cdn-assets.sh
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@b77dc228388218453070969c00c26dc392ecb114
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: Deploy CDN assets to S3 + CloudFront
+        run: |
+            aws s3 sync --cache-control max-age=691200 dist/ s3://${{ secrets.AZ_DIGITAL_CDN_BUCKET }}/lib/arizona-bootstrap/${{ github.head_ref }}/
+            aws cloudfront create-invalidation --distribution-id ${{ secrets.AZ_DIGITAL_CDN }} --paths /lib/arizona-bootstrap/${{ github.head_ref }}/*

--- a/.github/workflows/cdn-deploy.yml
+++ b/.github/workflows/cdn-deploy.yml
@@ -37,7 +37,7 @@ jobs:
             aws cloudfront create-invalidation --distribution-id ${{ secrets.AZ_DIGITAL_CDN }} --paths /lib/arizona-bootstrap/${AZ_TRIMMED_REF}/*
 
       - name: Deploy CDN assets to S3 + CloudFront (latest)
-        if: startsWith('refs/tags/', github.ref)
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           aws s3 sync --cache-control max-age=691200 dist/ s3://${{ secrets.AZ_DIGITAL_CDN_BUCKET }}/lib/arizona-bootstrap/latest/
           aws cloudfront create-invalidation --distribution-id ${{ secrets.AZ_DIGITAL_CDN }} --paths /lib/arizona-bootstrap/latest/*

--- a/scripts/build-cdn-assets.sh
+++ b/scripts/build-cdn-assets.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -ex
+
+cd /arizona-bootstrap
+npm install
+bundle install
+npm run dist


### PR DESCRIPTION
This PR adds a github action to deploy a built copy of Arizona Bootstrap to cdn.digital.arizona.edu on when a new semver tag is pushed of when changes are merged to master. It also updates the `latest` path whenever a new semver tag is pushed.