### PR TITLE
Bootstrap Release Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ on:
   push:
     branches:
       - master
+      - user-story/*
     paths:
       - package.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,8 @@ jobs:
         run: |
           jq --arg suffix '-dev' '.version |= . + $suffix' package.json > package.json.new
           mv package.json.new package.json
+          jq --arg suffix '-dev' '.version |= . + $suffix' package-lock.json > package-lock.json.new
+          mv package-lock.json.new package-lock.json
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global user.name "${GITHUB_ACTOR}"
           git add package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           echo "::set-env name=AZ_VERSION::$(jq -r '.version' package.json)"
           echo "::set-env name=AZ_SHORT_VERSION::$(jq -r '.version_short' package.json)"
       - name: Create Release
-        if: ${{ endsWith(env.AZ_VERSION, '-dev') != false }}
+        if: ${{ endsWith(env.AZ_VERSION, '-dev') == 'false' }}
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -49,7 +49,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Back to dev
-        if: ${{ endsWith(env.AZ_VERSION, '-dev') != false }}
+        if: ${{ endsWith(env.AZ_VERSION, '-dev') == 'false' }}
         run: |
           jq --arg suffix '-dev' '.version |= . + $suffix | .version_short |= . + $suffix' package.json > package.json.new
           mv package.json.new package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           echo "::set-env name=AZ_VERSION::$(jq -r '.version' package.json)"
           echo "::set-env name=AZ_SHORT_VERSION::$(jq -r '.version_short' package.json)"
       - name: Create Release
-        if: ${{ endsWith(env.AZ_VERSION, '-dev') != 'false' }}
+        if: ${{ endsWith(env.AZ_VERSION, '-dev') != false }}
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -49,7 +49,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Back to dev
-        if: ${{ endsWith(env.AZ_VERSION, '-dev') != 'false' }}
+        if: ${{ endsWith(env.AZ_VERSION, '-dev') != false }}
         run: |
           jq --arg suffix '-dev' '.version |= . + $suffix | .version_short |= . + $suffix' package.json > package.json.new
           mv package.json.new package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: "v${{ env.AZ_VERSION }}"
-          release_name: Release ${{ env.AZ_VERSION }}
+          release_name: "v${{ env.AZ_VERSION }}"
           draft: false
           prerelease: ${{ contains(env.AZ_VERSION, '-alpha') }}
       - name: Back to dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,8 @@ jobs:
         run: |
           echo "::set-env name=AZ_VERSION::$(jq -r '.version' package.json)"
           echo "::set-env name=AZ_SHORT_VERSION::$(jq -r '.version_short' package.json)"
-      - name: Release Guard
-        if: ${{ endsWith(env.AZ_VERSION, '-dev') }}
-        run: |
-          exit 1
       - name: Create Release
+        if: ${{ endsWith(env.AZ_VERSION, '-dev') == 'false' }}
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -51,6 +48,7 @@ jobs:
           draft: false
           prerelease: false #${{ contains(env.AZ_VERSION, '-alpha') }}
       - name: Back to dev
+        if: ${{ endsWith(env.AZ_VERSION, '-dev') == 'false' }}
         run: |
           jq --arg suffix '-dev' '.version |= . + $suffix' package.json > package.json.new
           mv package.json.new package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ on:
   push:
     branches:
       - master
-      - user-story/*
     paths:
       - package.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,6 @@ jobs:
           mv package-lock.json.new package-lock.json
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global user.name "${GITHUB_ACTOR}"
-          git add package.json
+          git add package.json package-lock.json
           git commit -m 'Back to dev'
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           tag_name: "v${{ env.AZ_VERSION }}"
           release_name: "v${{ env.AZ_VERSION }}"
           draft: false
-          prerelease: ${{ contains(env.AZ_VERSION, '-alpha') }}
+          prerelease: false #${{ contains(env.AZ_VERSION, '-alpha') }}
       - name: Back to dev
         run: |
           jq --arg suffix '-dev' '.version |= . + $suffix' package.json > package.json.new

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ on:
   push:
     branches:
       - master
+      - user-story/*
     paths:
       - package.json
 
@@ -48,7 +49,7 @@ jobs:
           prerelease: false
       - name: Back to dev
         run: |
-          jq ".version |= . + \"-dev\" | .version_short |= . + \"-dev\"" package.json > package.json.new
+          jq --arg suffix '-dev' '.version |= . + $suffix | .version_short |= . + $suffix' package.json > package.json.new
           mv package.json.new package.json
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global user.name "${GITHUB_ACTOR}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           echo "::set-env name=AZ_VERSION::$(jq -r '.version' package.json)"
           echo "::set-env name=AZ_SHORT_VERSION::$(jq -r '.version_short' package.json)"
       - name: Create Release
-        if: !endsWith(env.AZ_VERSION, '-dev')
+        if: ! endsWith(env.AZ_VERSION, '-dev')
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -49,7 +49,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Back to dev
-        if: !endsWith(env.AZ_VERSION, '-dev')
+        if: ! endsWith(env.AZ_VERSION, '-dev')
         run: |
           jq --arg suffix '-dev' '.version |= . + $suffix | .version_short |= . + $suffix' package.json > package.json.new
           mv package.json.new package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
           echo "::set-env name=AZ_VERSION::$(jq -r '.version' package.json)"
           echo "::set-env name=AZ_SHORT_VERSION::$(jq -r '.version_short' package.json)"
       - name: Create Release
+        if: !endsWith(env.AZ_VERSION, '-dev')
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -48,6 +49,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Back to dev
+        if: !endsWith(env.AZ_VERSION, '-dev')
         run: |
           jq --arg suffix '-dev' '.version |= . + $suffix | .version_short |= . + $suffix' package.json > package.json.new
           mv package.json.new package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Build Variables
         run: |
-          echo "::set-env name=AZ_VERSION::$(cat package.json | jq -r '.version')"
-          echo "::set-env name=AZ_SHORT_VERSION::$(cat package.json | jq -r '.version_short')"
+          echo "::set-env name=AZ_VERSION::$(jq -r '.version' package.json)"
+          echo "::set-env name=AZ_SHORT_VERSION::$(jq -r '.version_short' package.json)"
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ on:
   push:
     branches:
       - master
+      - user-story/*
     paths:
       - package.json
 
@@ -46,7 +47,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.AZ_VERSION }}
+          tag_name: "v${{ env.AZ_VERSION }}"
           release_name: Release ${{ env.AZ_VERSION }}
           draft: false
           prerelease: ${{ contains(env.AZ_VERSION, '-alpha') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,6 @@ jobs:
         run: |
           exit 1
       - name: Create Release
-        # if: ${{ endsWith(env.AZ_VERSION, '-dev') == 'false' && endsWith(env.AZ_SHORT_VERSION, '-dev') == 'false' }}
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -53,7 +52,6 @@ jobs:
           draft: false
           prerelease: false
       - name: Back to dev
-        # if: ${{ endsWith(env.AZ_VERSION, '-dev') == 'false' && endsWith(env.AZ_SHORT_VERSION, '-dev') == 'false' }}
         run: |
           jq --arg suffix '-dev' '.version |= . + $suffix | .version_short |= . + $suffix' package.json > package.json.new
           mv package.json.new package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           tag_name: ${{ env.AZ_VERSION }}
           release_name: Release ${{ env.AZ_VERSION }}
           draft: false
-          prerelease: false
+          prerelease: ${{ endsWith(env.AZ_VERSION, '-alpha[0-9]+') }}
       - name: Back to dev
         run: |
           jq --arg suffix '-dev' '.version |= . + $suffix | .version_short |= . + $suffix' package.json > package.json.new

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           echo "::set-env name=AZ_VERSION::$(jq -r '.version' package.json)"
           echo "::set-env name=AZ_SHORT_VERSION::$(jq -r '.version_short' package.json)"
       - name: Create Release
-        if: ! endsWith(env.AZ_VERSION, '-dev')
+        if: ${{ endsWith(env.AZ_VERSION, '-dev') != 'false' }}
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -49,7 +49,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Back to dev
-        if: ! endsWith(env.AZ_VERSION, '-dev')
+        if: ${{ endsWith(env.AZ_VERSION, '-dev') != 'false' }}
         run: |
           jq --arg suffix '-dev' '.version |= . + $suffix | .version_short |= . + $suffix' package.json > package.json.new
           mv package.json.new package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,12 @@ jobs:
         run: |
           echo "::set-env name=AZ_VERSION::$(jq -r '.version' package.json)"
           echo "::set-env name=AZ_SHORT_VERSION::$(jq -r '.version_short' package.json)"
+      - name: Release Guard
+        if: ${{ endsWith(env.AZ_VERSION, '-dev') || endsWith(env.AZ_SHORT_VERSION, '-dev') }}
+        run: |
+          exit 1
       - name: Create Release
-        if: ${{ endsWith(env.AZ_VERSION, '-dev') == 'false' }}
+        # if: ${{ endsWith(env.AZ_VERSION, '-dev') == 'false' && endsWith(env.AZ_SHORT_VERSION, '-dev') == 'false' }}
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -49,7 +53,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Back to dev
-        if: ${{ endsWith(env.AZ_VERSION, '-dev') == 'false' }}
+        # if: ${{ endsWith(env.AZ_VERSION, '-dev') == 'false' && endsWith(env.AZ_SHORT_VERSION, '-dev') == 'false' }}
         run: |
           jq --arg suffix '-dev' '.version |= . + $suffix | .version_short |= . + $suffix' package.json > package.json.new
           mv package.json.new package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           echo "::set-env name=AZ_VERSION::$(jq -r '.version' package.json)"
           echo "::set-env name=AZ_SHORT_VERSION::$(jq -r '.version_short' package.json)"
       - name: Release Guard
-        if: ${{ endsWith(env.AZ_VERSION, '-dev') || endsWith(env.AZ_SHORT_VERSION, '-dev') }}
+        if: ${{ endsWith(env.AZ_VERSION, '-dev') }}
         run: |
           exit 1
       - name: Create Release
@@ -53,7 +53,7 @@ jobs:
           prerelease: ${{ contains(env.AZ_VERSION, '-alpha') }}
       - name: Back to dev
         run: |
-          jq --arg suffix '-dev' '.version |= . + $suffix | .version_short |= . + $suffix' package.json > package.json.new
+          jq --arg suffix '-dev' '.version |= . + $suffix' package.json > package.json.new
           mv package.json.new package.json
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global user.name "${GITHUB_ACTOR}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           echo "::set-env name=AZ_VERSION::$(jq -r '.version' package.json)"
           echo "::set-env name=AZ_SHORT_VERSION::$(jq -r '.version_short' package.json)"
       - name: Create Release
-        if: ${{ endsWith(env.AZ_VERSION, '-dev') == 'false' }}
+        if: ${{ endsWith(env.AZ_VERSION, '-dev') == false }}
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -49,7 +49,7 @@ jobs:
           draft: false
           prerelease: false #${{ contains(env.AZ_VERSION, '-alpha') }}
       - name: Back to dev
-        if: ${{ endsWith(env.AZ_VERSION, '-dev') == 'false' }}
+        if: ${{ endsWith(env.AZ_VERSION, '-dev') == false }}
         run: |
           jq --arg suffix '-dev' '.version |= . + $suffix' package.json > package.json.new
           mv package.json.new package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           tag_name: ${{ env.AZ_VERSION }}
           release_name: Release ${{ env.AZ_VERSION }}
           draft: false
-          prerelease: ${{ endsWith(env.AZ_VERSION, '-alpha[0-9]+') }}
+          prerelease: ${{ contains(env.AZ_VERSION, '-alpha') }}
       - name: Back to dev
         run: |
           jq --arg suffix '-dev' '.version |= . + $suffix | .version_short |= . + $suffix' package.json > package.json.new

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.24",
+  "version": "0.0.24-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.20-dev",
+  "version": "0.0.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.3",
+  "version": "0.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.2",
+  "version": "0.0.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.24-dev",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.21",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.18",
+  "version": "0.0.20-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.19-alpha1",
+  "version": "0.0.19-alpha1-dev",
   "version_short": "0.0",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.13-dev",
-  "version_short": "0.0-dev",
+  "version": "0.0.13-dev-dev",
+  "version_short": "0.0-dev-dev",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {
     "start": "npm-run-all --parallel watch docs-serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "version_short": "0.0",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "arizona-bootstrap",
   "version": "0.0.24-dev",
   "version_short": "0.0",
-  "description": "University of Arizona theme for Bootstrap.",
+  "description": "University of Arizona theme for Bootstrap!",
   "scripts": {
     "start": "npm-run-all --parallel watch docs-serve",
     "css": "npm-run-all css-compile css-prefix css-minify css-copy",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.18-dev",
-  "version_short": "0.0-dev",
+  "version": "0.0.18-alpha1",
+  "version_short": "0.0-alpha1",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {
     "start": "npm-run-all --parallel watch docs-serve",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.10-dev",
-  "version_short": "0.0-dev",
+  "version": "0.0.11",
+  "version_short": "0.0",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {
     "start": "npm-run-all --parallel watch docs-serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.13-dev-dev",
+  "version": "0.0.14-dev",
   "version_short": "0.0-dev-dev",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.8-dev",
-  "version_short": "0.0-dev",
+  "version": "0.0.9",
+  "version_short": "0.0",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {
     "start": "npm-run-all --parallel watch docs-serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.21",
+  "version": "0.0.2",
   "version_short": "0.0",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.18",
-  "version_short": "0.0",
+  "version": "0.0.18-dev",
+  "version_short": "0.0-dev",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {
     "start": "npm-run-all --parallel watch docs-serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.20",
+  "version": "0.0.20-dev",
   "version_short": "0.0",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "js-minify-docs": "cross-env-shell terser --mangle --comments \\\"/^!/\\\" --output site/docs/$npm_package_version_short/assets/js/docs.min.js site/docs/$npm_package_version_short/assets/js/vendor/anchor.min.js site/docs/$npm_package_version_short/assets/js/vendor/clipboard.min.js site/docs/$npm_package_version_short/assets/js/vendor/bs-custom-file-input.min.js \"site/docs/$npm_package_version_short/assets/js/src/*.js\"",
     "lint": "npm-run-all --parallel css-lint-*",
     "test": "npm-run-all lint dist docs-compile docs-lint",
-    "version": "npm run build && git add -A dist",
+    "version": "npm run dist && git add -A dist",
     "watch": "npm-run-all --parallel watch-*",
     "watch-css-main": "nodemon --watch scss/ --ext scss --exec \"npm run css-main\"",
     "watch-css-docs": "nodemon --watch \"site/docs/**/assets/scss/\" --ext scss --exec \"npm run css-docs\""

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.18-alpha1",
-  "version_short": "0.0-alpha1",
+  "version": "0.0.18-alpha1-dev",
+  "version_short": "0.0-alpha1-dev",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {
     "start": "npm-run-all --parallel watch docs-serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "version_short": "0.0",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.20-dev",
+  "version": "0.0.21",
   "version_short": "0.0",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.15-dev",
-  "version_short": "0.0-dev-dev-dev",
+  "version": "0.0.17-dev",
+  "version_short": "0.0",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {
     "start": "npm-run-all --parallel watch docs-serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.14-dev-dev",
+  "version": "0.0.15-dev",
   "version_short": "0.0-dev-dev-dev",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.17-dev",
+  "version": "0.0.18",
   "version_short": "0.0",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.8",
-  "version_short": "0.0",
+  "version": "0.0.8-dev",
+  "version_short": "0.0-dev",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {
     "start": "npm-run-all --parallel watch docs-serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.24",
+  "version": "0.0.24-dev",
   "version_short": "0.0",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.11",
-  "version_short": "0.0",
+  "version": "0.0.11-dev",
+  "version_short": "0.0-dev",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {
     "start": "npm-run-all --parallel watch docs-serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.18-alpha2-dev",
+  "version": "0.0.18",
   "version_short": "0.0-alpha2-dev",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.18",
-  "version_short": "0.0-alpha2-dev",
+  "version": "0.0.19-alpha1",
+  "version_short": "0.0",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {
     "start": "npm-run-all --parallel watch docs-serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.2",
+  "version": "0.0.21",
   "version_short": "0.0",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "version_short": "0.0",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.2",
+  "version": "0.0.20",
   "version_short": "0.0",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "js-minify-docs": "cross-env-shell terser --mangle --comments \\\"/^!/\\\" --output site/docs/$npm_package_version_short/assets/js/docs.min.js site/docs/$npm_package_version_short/assets/js/vendor/anchor.min.js site/docs/$npm_package_version_short/assets/js/vendor/clipboard.min.js site/docs/$npm_package_version_short/assets/js/vendor/bs-custom-file-input.min.js \"site/docs/$npm_package_version_short/assets/js/src/*.js\"",
     "lint": "npm-run-all --parallel css-lint-*",
     "test": "npm-run-all lint dist docs-compile docs-lint",
+    "version": "npm run build && git add -A dist",
     "watch": "npm-run-all --parallel watch-*",
     "watch-css-main": "nodemon --watch scss/ --ext scss --exec \"npm run css-main\"",
     "watch-css-docs": "nodemon --watch \"site/docs/**/assets/scss/\" --ext scss --exec \"npm run css-docs\""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.19-alpha1-dev",
+  "version": "0.0.2",
   "version_short": "0.0",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "version_short": "0.0",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.14-dev",
-  "version_short": "0.0-dev-dev",
+  "version": "0.0.14-dev-dev",
+  "version_short": "0.0-dev-dev-dev",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {
     "start": "npm-run-all --parallel watch docs-serve",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.18-alpha2",
-  "version_short": "0.0-alpha2",
+  "version": "0.0.18-alpha2-dev",
+  "version_short": "0.0-alpha2-dev",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {
     "start": "npm-run-all --parallel watch docs-serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.12-dev",
+  "version": "0.0.13-dev",
   "version_short": "0.0-dev",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.10",
-  "version_short": "0.0",
+  "version": "0.0.10-dev",
+  "version_short": "0.0-dev",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {
     "start": "npm-run-all --parallel watch docs-serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.11-dev",
+  "version": "0.0.12-dev",
   "version_short": "0.0-dev",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.24-dev",
+  "version": "0.0.2",
   "version_short": "0.0",
-  "description": "University of Arizona theme for Bootstrap!",
+  "description": "University of Arizona theme for Bootstrap.",
   "scripts": {
     "start": "npm-run-all --parallel watch docs-serve",
     "css": "npm-run-all css-compile css-prefix css-minify css-copy",
@@ -39,7 +39,6 @@
     "js-minify-docs": "cross-env-shell terser --mangle --comments \\\"/^!/\\\" --output site/docs/$npm_package_version_short/assets/js/docs.min.js site/docs/$npm_package_version_short/assets/js/vendor/anchor.min.js site/docs/$npm_package_version_short/assets/js/vendor/clipboard.min.js site/docs/$npm_package_version_short/assets/js/vendor/bs-custom-file-input.min.js \"site/docs/$npm_package_version_short/assets/js/src/*.js\"",
     "lint": "npm-run-all --parallel css-lint-*",
     "test": "npm-run-all lint dist docs-compile docs-lint",
-    "version": "npm run dist && git add -A dist",
     "watch": "npm-run-all --parallel watch-*",
     "watch-css-main": "nodemon --watch scss/ --ext scss --exec \"npm run css-main\"",
     "watch-css-docs": "nodemon --watch \"site/docs/**/assets/scss/\" --ext scss --exec \"npm run css-docs\""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "version_short": "0.0",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arizona-bootstrap",
-  "version": "0.0.18-alpha1-dev",
-  "version_short": "0.0-alpha1-dev",
+  "version": "0.0.18-alpha2",
+  "version_short": "0.0-alpha2",
   "description": "University of Arizona theme for Bootstrap.",
   "scripts": {
     "start": "npm-run-all --parallel watch docs-serve",


### PR DESCRIPTION
This PR adds a github action that facilitates creating a new release of Arizona Bootstrap.

To trigger this action, update the version within package.json and package-lock.json by running `npm version 0.0.3` and opening a PR with the updates. Once the PR is merged to master, a new release will be generated based on the version number specified in package.json.

Open questions:

- [ ] Do we still want to go "back to dev" after a release and append `-dev` to the version numbers

- [ ] Which release types do we want to be "pre-release"? (alpha, beta, etc)