### PR TITLE
Update Link description

### DIFF
--- a/site/docs/2.0/content/typography.md
+++ b/site/docs/2.0/content/typography.md
@@ -165,7 +165,7 @@ While not shown above, feel free to use `<b>` and `<i>` in HTML5. `<b>` is meant
 
 ## Links
 
-Default links include a red text color and an underline on hover. You can change a link's default styling by adding additional classes to it (e.g., `.btn`, `.btn-red`, etc.). Links inside navbars, breadcrumbs, and other components receive their own default styling. 
+Default links include a red text color and an underline. You can change a link's default styling by adding additional classes to it (e.g., `.btn`, `.btn-red`, etc.). Links inside navbars, breadcrumbs, and other components receive their own default styling. 
 
 {% capture example %}
 <a href="#">Default Link</a>


### PR DESCRIPTION
Removed "on hover" to more clearly indicate that the default state of links should be underlined.

For reference:
https://webaim.org/techniques/hypertext/link_text#text
"The link text must have a 3:1 contrast ratio from the surrounding non-link text." - WCAG 2.0 Level A
Current contrast ratio between text and link color is 1.17:1, so removing default underlines from links would not be sufficient differentiation.