### PR TITLE
Closes #263: Adjust the Hugo whitespace handling in .Site.Title references.

### DIFF
--- a/site/layouts/partials/home/masthead-followup.html
+++ b/site/layouts/partials/home/masthead-followup.html
@@ -2,7 +2,7 @@
   <div class="col-md-4 p-3 p-md-5 bg-light border border-white">
     <span class="material-icons-sharp text-blue display-4">cloud_download</span>
     <h3 class="bd-content-title">Installation</h3>
-    <p>Include {{- .Site.Title -}}’s source Sass and JavaScript files via npm, Composer or Meteor. Package managed installs don’t include documentation, but do include our build system and readme.</p>
+    <p>Include {{ .Site.Title -}}’s source Sass and JavaScript files via npm, Composer or Meteor. Package managed installs don’t include documentation, but do include our build system and readme.</p>
 
     {{ highlight (printf ("npm install %s") .Site.Params.repo) "sh" "" }}
 
@@ -13,7 +13,7 @@
   <div class="col-md-4 p-3 p-md-5 bg-light border border-white">
     <span class="material-icons-sharp text-blue display-4">extension</span>
     <h3 class="bd-content-title">Arizona Digital CDN</h3>
-    <p>When you only need to include {{- .Site.Title -}}’s compiled CSS or JS, you can use the Arizona Digital CDN.</p>
+    <p>When you only need to include {{ .Site.Title -}}’s compiled CSS or JS, you can use the Arizona Digital CDN.</p>
 
 <h5 class="bd-content-title">CSS only</h5>
 {{ highlight (printf (`<link rel="stylesheet" href="%s" crossorigin="anonymous">`) .Site.Params.cdn.css ) "html" "" }}
@@ -31,7 +31,7 @@
    <i class="fab fa-drupal fa-4x mb-3 text-blue"></i>
     <h3 class="bd-content-title">Arizona Quickstart</h3>
     <p>
-      {{- .Site.Title -}} is included in the Arizona Quickstart web content management system.
+      {{ .Site.Title }} is included in the Arizona Quickstart web content management system.
     </p>
     <hr class="half-rule">
     <a href="{{ .Site.Params.az_quickstart }}" class="btn btn-outline-blue">Try Arizona Quickstart</a>

--- a/site/layouts/partials/home/masthead.html
+++ b/site/layouts/partials/home/masthead.html
@@ -9,7 +9,7 @@
         <p class="lead mb-4">
           Bootstrap is an open source toolkit for developing with HTML, CSS, and JS. Quickly prototype your ideas or build your entire app with our Sass variables and mixins, responsive grid system, extensive prebuilt components, and powerful plugins built on jQuery.
         </p>
-        <p class="lead mb-4">A team of web-focused volunteers known as Arizona Digital meets weekly to build and test products like Arizona Bootstrap and Arizona Quickstart. Contributions are what keep {{- .Site.Title -}} moving and improving, and are in everyone's best interest.</p>
+        <p class="lead mb-4">A team of web-focused volunteers known as Arizona Digital meets weekly to build and test products like Arizona Bootstrap and Arizona Quickstart. Contributions are what keep {{ .Site.Title }} moving and improving, and are in everyone's best interest.</p>
         <div class="row mx-n2">
           <div class="col-md px-2">
             <a href="{{- (printf `docs/%s%s` $.Site.Params.docs_version `/getting-started/introduction`) | relURL -}}" class="btn btn-lg btn-red w-100 mb-3" onclick="ga('send', 'event', 'Jumbotron actions', 'Get started', 'Get started');">Get started</a>


### PR DESCRIPTION
This doubles as the trivial change that can test issues with the manually triggered Arizona Bootstrap release process.

Closes #263 