### PR TITLE
#275 Add col-split utility classes

### DIFF
--- a/scss/_custom-styles.scss
+++ b/scss/_custom-styles.scss
@@ -192,3 +192,15 @@
     box-shadow: none;
   }
 }
+
+// >> Column split utility.
+
+.2-col-split {
+  column-count: 2;
+}
+.3-col-split {
+  column-count: 3;
+}
+.4-col-split {
+  column-count: 4;
+}

--- a/scss/_custom-styles.scss
+++ b/scss/_custom-styles.scss
@@ -197,10 +197,13 @@
 
 .split-2-col {
   column-count: 2;
+  display: block;
 }
 .split-3-col {
   column-count: 3;
+  display: block;
 }
 .split-4-col {
   column-count: 4;
+  display: block;
 }

--- a/scss/_custom-styles.scss
+++ b/scss/_custom-styles.scss
@@ -196,14 +196,14 @@
 // >> Column split utility.
 
 .split-2-col {
-  column-count: 2;
   display: block;
+  column-count: 2;
 }
 .split-3-col {
-  column-count: 3;
   display: block;
+  column-count: 3;
 }
 .split-4-col {
-  column-count: 4;
   display: block;
+  column-count: 4;
 }

--- a/scss/_custom-styles.scss
+++ b/scss/_custom-styles.scss
@@ -195,14 +195,12 @@
 
 // >> Column split utility.
 
-/* stylelint-disable selector-class-pattern */
-.2-col-split {
+.split-2-col {
   column-count: 2;
 }
-.3-col-split {
+.split-3-col {
   column-count: 3;
 }
-.4-col-split {
+.split-4-col {
   column-count: 4;
 }
-/* stylelint-enable selector-class-pattern */

--- a/scss/_custom-styles.scss
+++ b/scss/_custom-styles.scss
@@ -195,6 +195,7 @@
 
 // >> Column split utility.
 
+/* stylelint-disable selector-class-pattern */
 .2-col-split {
   column-count: 2;
 }
@@ -204,3 +205,4 @@
 .4-col-split {
   column-count: 4;
 }
+/* stylelint-enable selector-class-pattern */

--- a/site/content/docs/2.0/migration.md
+++ b/site/content/docs/2.0/migration.md
@@ -213,6 +213,10 @@ Dropped entirely for the new card component.
 - Removed support for styled nested tables. All table styles are now inherited in v4 for simpler selectors.
 - Added inverse table variant.
 
+### Footer Menu
+
+The "Topics" menu in the footer originally had the `two-col-menu` class applied to it to split the menu into two equal columns. This has been replaced with the `2-col-split` utility class.
+
 ### Utilities
 
 - **Display, hidden, and more:**

--- a/site/content/docs/2.0/migration.md
+++ b/site/content/docs/2.0/migration.md
@@ -215,7 +215,7 @@ Dropped entirely for the new card component.
 
 ### Footer Menu
 
-The "Topics" menu in the footer originally had the `two-col-menu` class applied to it to split the menu into two equal columns. This has been replaced with the `2-col-split` utility class.
+The "Topics" menu in the footer originally had the `two-col-menu` class applied to it to split the menu into two equal columns. This has been replaced with the `split-2-col` utility class.
 
 ### Utilities
 

--- a/site/content/docs/2.0/utilities/column-split.md
+++ b/site/content/docs/2.0/utilities/column-split.md
@@ -7,30 +7,30 @@ group: utilities
 
 ## Text content
 
-These classes can be applied to regular text content. Here's an example of `2-col-split` on a container with text.
+These classes can be applied to regular text content. Here's an example of `split-2-col` on a container with text.
 
 {{< example >}}
-<div class="2-col-split">I'm container with content split into 2 columns. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div>
+<div class="split-2-col">I'm container with content split into 2 columns. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div>
 {{< /example >}}
 
-Here's an example of `3-col-split` on a container with text.
+Here's an example of `split-3-col` on a container with text.
 
 {{< example >}}
-<div class="3-col-split">I'm container with content split into 3 columns. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div>
+<div class="split-3-col">I'm container with content split into 3 columns. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div>
 {{< /example >}}
 
-Here's an example of `4-col-split` on a container with text.
+Here's an example of `split-4-col` on a container with text.
 
 {{< example >}}
-<div class="4-col-split">I'm container with content split into 4 columns. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div>
+<div class="split-4-col">I'm container with content split into 4 columns. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div>
 {{< /example >}}
 
 ## Menu content
 
-These classes can be applied to menus as well. Here's an example of `2-col-split` on a menu.
+These classes can be applied to menus as well. Here's an example of `split-2-col` on a menu.
 
 {{< example >}}
-<ul class="nav flex-column 2-col-split">
+<ul class="nav flex-column split-2-col">
   <li class="nav-item">
     <a class="nav-link active" href="#">Active</a>
   </li>
@@ -52,10 +52,10 @@ These classes can be applied to menus as well. Here's an example of `2-col-split
 </ul>
 {{< /example >}}
 
-Here's an example of `3-col-split` on a menu.
+Here's an example of `split-3-col` on a menu.
 
 {{< example >}}
-<ul class="nav flex-column 3-col-split">
+<ul class="nav flex-column split-3-col">
   <li class="nav-item">
     <a class="nav-link active" href="#">Active</a>
   </li>

--- a/site/content/docs/2.0/utilities/column-split.md
+++ b/site/content/docs/2.0/utilities/column-split.md
@@ -3,6 +3,7 @@ layout: docs
 title: Column split
 description: Allow content to be split evenly between 2, 3, or 4 columns within one single column of a grid.
 group: utilities
+toc: true
 ---
 
 ## Text content

--- a/site/content/docs/2.0/utilities/column-split.md
+++ b/site/content/docs/2.0/utilities/column-split.md
@@ -1,0 +1,81 @@
+---
+layout: docs
+title: Column split
+description: Allow content to be split evenly between 2, 3, or 4 columns withhin one single column of a grid.
+group: utilities
+---
+
+## Text content
+
+These classes can be applied to regular text content. Here's an example of `2-col-split` on a container with text.
+
+{{< example >}}
+<div class="2-col-split">I'm container with content split into 2 columns. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div>
+{{< /example >}}
+
+Here's an example of `3-col-split` on a container with text.
+
+{{< example >}}
+<div class="3-col-split">I'm container with content split into 3 columns. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div>
+{{< /example >}}
+
+Here's an example of `4-col-split` on a container with text.
+
+{{< example >}}
+<div class="4-col-split">I'm container with content split into 4 columns. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div>
+{{< /example >}}
+
+## Menu content
+
+These classes can be applied to menus as well. Here's an example of `2-col-split` on a menu.
+
+{{< example >}}
+<ul class="nav flex-column 2-col-split">
+  <li class="nav-item">
+    <a class="nav-link active" href="#">Active</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#">Link</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#">Link</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#">Link</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#">Link</a>
+  </li>
+</ul>
+{{< /example >}}
+
+Here's an example of `3-col-split` on a menu.
+
+{{< example >}}
+<ul class="nav flex-column 3-col-split">
+  <li class="nav-item">
+    <a class="nav-link active" href="#">Active</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#">Link</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#">Link</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#">Link</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#">Link</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#">Link</a>
+  </li>
+</ul>
+{{< /example >}}

--- a/site/content/docs/2.0/utilities/column-split.md
+++ b/site/content/docs/2.0/utilities/column-split.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Column split
-description: Allow content to be split evenly between 2, 3, or 4 columns withhin one single column of a grid.
+description: Allow content to be split evenly between 2, 3, or 4 columns within one single column of a grid.
 group: utilities
 ---
 

--- a/site/data/nav.yml
+++ b/site/data/nav.yml
@@ -67,6 +67,7 @@
     - title: Clearfix
     - title: Close Icon
     - title: Colors
+    - title: Column Split
     - title: Display
     - title: Embed
     - title: Flex


### PR DESCRIPTION
## Related tickets
Closes #275 

## Motivation
Shoshana's work on the Topics footer menu block is reliant on the two-col-menu class to split the menu into 2 columns. Adding a more generic class (and similar classes) to Arizona Bootstrap will allow this feature to be used in more than just the footer menu block.

## Solution

- [x]  Add these classes to bootstrap
   - 2-col-split
   - 3-col-split
   - 4-col-split
- [x]  Each class will have corresponding CSS
   - column-count: 2
   - column-count: 3
   - column-count: 4
- [x]  Ensure migration page on Arizona Bootstrap is updated
   - https://review.digital.arizona.edu/arizona-bootstrap/issue/275/docs/2.0/migration/#footer-menu
- [x] Add new documentation page to Arizona Bootstrap
   - https://review.digital.arizona.edu/arizona-bootstrap/issue/275/docs/2.0/utilities/column-split/