### PR TITLE
az-digital/az_quickstart#741 Remove rebase option from css-minify command.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "css-lint": "npm-run-all --continue-on-error --parallel css-lint-*",
     "css-lint-stylelint": "stylelint \"**/*.{css,scss}\" --cache --cache-location .cache/.stylelintcache --rd",
     "css-lint-vars": "fusv scss/ site/assets/scss/",
-    "css-minify": "cleancss -O1 --format breakWith=lf --with-rebase --source-map --source-map-inline-sources --output dist/css/ --batch --batch-suffix \".min\" \"dist/css/*.css\" \"!dist/css/*.min.css\"",
+    "css-minify": "cleancss -O1 --format breakWith=lf --source-map --source-map-inline-sources --output dist/css/ --batch --batch-suffix \".min\" \"dist/css/*.css\" \"!dist/css/*.min.css\"",
     "css-prefix": "postcss --config build/postcss.config.js --replace \"dist/css/*.css\" \"!dist/css/*.min.css\"",
     "dist": "npm-run-all --parallel css js",
     "docs": "npm-run-all docs-build docs-lint",


### PR DESCRIPTION
For az-digital/az_quickstart#741

It looks like the image paths in the minified Arizona Bootstrap CSS files have been wrong since version 2.0.7.

Example before 2.0.7
(see https://cdn.digital.arizona.edu/lib/arizona-bootstrap/2.0.6/css/arizona-bootstrap.min.css):
```
.bg-red.bg-triangles-top-left{background-image:url(img/triangles-top-left-red.svg);background-blend-mode:initial}
```

Example after 2.0.7
(see https://cdn.digital.arizona.edu/lib/arizona-bootstrap/2.0.7/css/arizona-bootstrap.min.css):
```
.bg-red.bg-triangles-top-left{background-image:url("css/img/triangles-top-left-red.svg");background-blend-mode:initial}
```
