### PR TITLE
Navbar style updates to match QS1 - uppercase, padding, borders (Closes #281)

### DIFF
--- a/scss/_custom-variables.scss
+++ b/scss/_custom-variables.scss
@@ -263,7 +263,7 @@ $nav-utility-link-border-hover-color: $dark-silver;
 $navbar-padding-y: 0;
 $navbar-nav-link-padding-y: 1.25rem;
 $navbar-nav-link-padding-x: 1rem;
-$navbar-nav-link-font-weight: 700;
+$navbar-nav-link-font-weight: 600;
 
 $navbar-light-border-color: $gray-200;
 $navbar-light-border-width: 1px 0;

--- a/scss/_custom-variables.scss
+++ b/scss/_custom-variables.scss
@@ -262,7 +262,7 @@ $nav-utility-link-border-hover-color: $dark-silver;
 // >> Navbar
 $navbar-padding-y: 0;
 $navbar-nav-link-padding-y: 1.25rem;
-$navbar-nav-link-padding-x: 1.5rem;
+$navbar-nav-link-padding-x: 1rem;
 $navbar-nav-link-font-weight: 700;
 
 $navbar-light-border-color: $gray-200;

--- a/scss/_navbar-offcanvas.scss
+++ b/scss/_navbar-offcanvas.scss
@@ -280,7 +280,7 @@
 
     .nav-item {
       .nav-link {
-        padding: 1.25rem 1.5rem;
+        padding: 1.25rem 1rem;
         color: $navbar-light-link-color;
         &:hover {
           color: $navbar-light-link-active-color;

--- a/scss/_navbar-offcanvas.scss
+++ b/scss/_navbar-offcanvas.scss
@@ -287,15 +287,14 @@
           background-color: $navbar-light-link-hover-bg;
         }
       }
-
-      &:hover {
-        color: $navbar-light-link-active-color;
-        background-color: $navbar-light-link-hover-bg;
-      }
       &.active,
       &:active {
         color: $navbar-light-link-active-color;
         background-color: $navbar-light-link-active-bg;
+      }
+      &:hover {
+        color: $navbar-light-link-active-color;
+        background-color: $navbar-light-link-hover-bg;
       }
       &.show {
         .dropdown-toggle,

--- a/scss/_navbar-offcanvas.scss
+++ b/scss/_navbar-offcanvas.scss
@@ -105,9 +105,8 @@
   .nav-item {
 
     &.active {
-        color: $navbar-offcanvas-link-color;
-        background-color: $navbar-offcanvas-link-active-bg;
-      }
+      color: $navbar-offcanvas-link-color;
+      background-color: $navbar-offcanvas-link-active-bg;
     }
 
     &.show {

--- a/scss/_navbar-offcanvas.scss
+++ b/scss/_navbar-offcanvas.scss
@@ -294,10 +294,8 @@
       }
       &.active,
       &:active {
-        .nav-link {
-          color: $navbar-light-link-active-color;
-          background-color: $navbar-light-link-active-bg;
-        }
+        color: $navbar-light-link-active-color;
+        background-color: $navbar-light-link-active-bg;
       }
       &.show {
         .dropdown-toggle,

--- a/scss/_navbar-offcanvas.scss
+++ b/scss/_navbar-offcanvas.scss
@@ -87,9 +87,6 @@
   .navbar-nav {
     width: 100%;
     overflow-y: auto;
-    .nav-link {
-      font-weight: 500;
-    }
     .show > .nav-link {
       color: $navbar-offcanvas-link-color;
       background-color: $navbar-offcanvas-bg-expanded;
@@ -269,7 +266,6 @@
       .nav-link {
         padding: $nav-link-padding-y $nav-link-padding-x;
         text-decoration: if($link-decoration == none, null, none);
-        font-weight: 700;
 
         @include hover-focus() {
           text-decoration: none;

--- a/scss/_navbar-offcanvas.scss
+++ b/scss/_navbar-offcanvas.scss
@@ -232,7 +232,8 @@
     padding: initial;
     overflow-y: initial;
     background-color: initial;
-    border: initial;
+    border-top: 1px solid $navbar-light-border-color;
+    border-bottom: 1px solid $navbar-light-border-color;
     -webkit-transform: initial;
     transform: initial;
     top: initial;
@@ -281,12 +282,6 @@
           pointer-events: none;
           cursor: default;
         }
-      }
-    }
-
-    .nav-item-parent {
-      .nav-link {
-        text-transform: initial;
       }
     }
 

--- a/scss/_navbar-offcanvas.scss
+++ b/scss/_navbar-offcanvas.scss
@@ -104,8 +104,7 @@
 
   .nav-item {
 
-    &.active, {
-      .nav-link {
+    &.active {
         color: $navbar-offcanvas-link-color;
         background-color: $navbar-offcanvas-link-active-bg;
       }
@@ -336,13 +335,14 @@
       justify-content: space-between;
 
       &::after {
-        font-size: 1.1em;
+        font-size: inherit;
         content: "";
         border-top: 0.3em solid;
         border-right: 0.3em solid transparent;
         border-bottom: 0;
         border-left: 0.3em solid transparent;
-        margin-left: 0.225em
+        margin-left: 0.225em;
+        display: inline-table;
       }
     }
   }

--- a/scss/_navbar-offcanvas.scss
+++ b/scss/_navbar-offcanvas.scss
@@ -267,7 +267,6 @@
       overflow-y: initial;
 
       .nav-link {
-        display: block;
         padding: $nav-link-padding-y $nav-link-padding-x;
         text-decoration: if($link-decoration == none, null, none);
         font-weight: 700;
@@ -341,8 +340,7 @@
       justify-content: space-between;
 
       &::after {
-        font-size: inherit;
-        vertical-align: 0.255em;
+        font-size: 1.1em;
         content: "";
         border-top: 0.3em solid;
         border-right: 0.3em solid transparent;

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -10,6 +10,7 @@
   font-weight: $navbar-nav-link-font-weight;
   background-color: inherit;
   border: none;
+  text-transform: uppercase;
 }
 
 .navbar-nav .nav-link,

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -8,8 +8,8 @@
 // >> .navbar-nav
 .navbar-nav .nav-link {
   font-weight: $navbar-nav-link-font-weight;
-  background-color: inherit;
   text-transform: uppercase;
+  background-color: inherit;
   border: none;
 }
 

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -9,8 +9,8 @@
 .navbar-nav .nav-link {
   font-weight: $navbar-nav-link-font-weight;
   background-color: inherit;
-  border: none;
   text-transform: uppercase;
+  border: none;
 }
 
 .navbar-nav .nav-link,


### PR DESCRIPTION
Closes #281

Changes to more closely match QS1 include
- Updating main nav to be all uppercase
- Adding top and bottom borders
- Reduced x axis padding
- Updated active background color to span full height
- Updated dropdown arrow to stay on right regardless of word wrap

Review site: https://review.digital.arizona.edu/arizona-bootstrap/issue/281/docs/2.0/components/navbar-off-canvas/