### PR TITLE
Closes #291 Updating accordion styles

### DIFF
--- a/scss/_collapse.scss
+++ b/scss/_collapse.scss
@@ -31,8 +31,8 @@
         top: 2px;
         right: 20px;
         display: inline-block;
+        font-family: "Material Icons Sharp, sans-serif";
         font-size: 2em;
-        font-family: "Material Icons Sharp";
         content: "\e5cf";
       }
 

--- a/scss/_collapse.scss
+++ b/scss/_collapse.scss
@@ -31,7 +31,7 @@
         top: 2px;
         right: 20px;
         display: inline-block;
-        // stylelint-disable font-family-no-missing-generic-family-keyword
+        // stylelint-disable-next-line
         font-family: "Material Icons Sharp";
         // stylelint-enable font-family-no-missing-generic-family-keyword
         font-size: 2em;

--- a/scss/_collapse.scss
+++ b/scss/_collapse.scss
@@ -33,7 +33,6 @@
         display: inline-block;
         // stylelint-disable-next-line
         font-family: "Material Icons Sharp";
-        // stylelint-enable font-family-no-missing-generic-family-keyword
         font-size: 2em;
         content: "\e5cf";
       }

--- a/scss/_collapse.scss
+++ b/scss/_collapse.scss
@@ -24,6 +24,7 @@
       padding: .75rem 1.25rem;
       color: $dark-silver;
       text-align: left;
+      text-transform: none;
 
       &::after {
         position: absolute;

--- a/scss/_collapse.scss
+++ b/scss/_collapse.scss
@@ -32,8 +32,8 @@
         right: 20px;
         display: inline-block;
         font-size: 2em;
+        font-family: "Material Icons Sharp";
         content: "\e5cf";
-        font-family: 'Material Icons Sharp';
       }
 
     }

--- a/scss/_collapse.scss
+++ b/scss/_collapse.scss
@@ -34,7 +34,7 @@
         // stylelint-disable-next-line
         font-family: "Material Icons Sharp";
         font-size: 2em;
-        content: "\e5cf";
+        content: "expand_more";
       }
 
     }

--- a/scss/_collapse.scss
+++ b/scss/_collapse.scss
@@ -31,7 +31,9 @@
         top: 2px;
         right: 20px;
         display: inline-block;
-        font-family: "Material Icons Sharp, sans-serif";
+        // stylelint-disable font-family-no-missing-generic-family-keyword
+        font-family: "Material Icons Sharp";
+        // stylelint-enable font-family-no-missing-generic-family-keyword
         font-size: 2em;
         content: "\e5cf";
       }

--- a/scss/_collapse.scss
+++ b/scss/_collapse.scss
@@ -40,7 +40,7 @@
     }
     .btn[aria-expanded="true"] {
       &::after {
-        content: "\e5ce";
+        content: "expand_less";
       }
     }
   }

--- a/scss/_collapse.scss
+++ b/scss/_collapse.scss
@@ -28,19 +28,18 @@
 
       &::after {
         position: absolute;
-        top: -4px;
-        right: 25px;
+        top: 2px;
+        right: 20px;
         display: inline-block;
         font-size: 2em;
-        content: "\221F";
-        transform: rotate(-45deg);
+        content: "\e5cf";
+        font-family: 'Material Icons Sharp';
       }
 
     }
     .btn[aria-expanded="true"] {
       &::after {
-        top: 6px;
-        transform: rotate(135deg);
+        content: "\e5ce";
       }
     }
   }


### PR DESCRIPTION
This PR makes two changes to the accordion styles in Bootstrap:
- Adds text-transform: none to the _collapse.scss file to keep the accordion headings regular casing not uppercase
- Adds the arrows on the accordion with the Material Icons Sharp

In testing on the review site, I did not see the reported overlap issue between long headings and the arrows. That may need to be addressed separately in Quickstart.

![image](https://user-images.githubusercontent.com/10873398/121441171-245a8700-c93e-11eb-95ff-892339dc0023.png)

Review site: https://review.digital.arizona.edu/arizona-bootstrap/issue/291/docs/2.0/components/collapse/

Thanks to @danahertzberg for help during the workshop on how to do bootstrap changes and design input.

