### PR TITLE
Closes #243: Adding class to auto hyphenate long words

### DIFF
--- a/scss/_custom-styles.scss
+++ b/scss/_custom-styles.scss
@@ -108,6 +108,12 @@
   font-family: $font-family-sans-serif;
   font-weight: 500;
 }
+
+// >> Text Hyphenation.
+.text-hyphen {
+  hyphens: auto;}
+}
+
 // >> Lists
 .ul-triangles {
   overflow: hidden;

--- a/scss/_text.scss
+++ b/scss/_text.scss
@@ -1,0 +1,8 @@
+// Overrides to text
+
+/*
+* > HYPHENATED TEXT
+*/
+.text-hyphen {
+  hyphens: auto;
+}

--- a/scss/_text.scss
+++ b/scss/_text.scss
@@ -1,8 +1,0 @@
-// Overrides to text
-
-/*
-* > HYPHENATED TEXT
-*/
-.text-hyphen {
-  hyphens: auto;
-}

--- a/site/content/docs/2.0/utilities/text.md
+++ b/site/content/docs/2.0/utilities/text.md
@@ -71,10 +71,10 @@ Prevent long strings of text from breaking your components' layout by using `.te
 
 ## HYPHENATE WORD
 
-Allow long strings of text to break to the next line with a hyphen automatically placed at the break point by using `.text-hyphen` to set `hyphens: auto`.
+Allow long strings of text to break to the next line with a hyphen automatically placed at the break point by using `.text-hyphen` to set `hyphens: auto`. This can be applied as a span on single words that are longer than the column width.
 
 {{< example >}}
-<div class="card col-1">
+<div class="card col-2">
 	<div class="card-body">
 		<p>We should all learn about <span class="text-hyphen">Tranformationaltotality</span></p>
 	</div>

--- a/site/content/docs/2.0/utilities/text.md
+++ b/site/content/docs/2.0/utilities/text.md
@@ -74,7 +74,11 @@ Prevent long strings of text from breaking your components' layout by using `.te
 Allow long strings of text to break to the next line with a hyphen automatically placed at the break point by using `.text-hyphen` to set `hyphens: auto`.
 
 {{< example >}}
-<p class="text-hyphen">mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</p>
+<div class="card col-1">
+	<div class="card-body">
+		<p>We should all learn about <span class="text-hyphen">Tranformationaltotality</span></p>
+	</div>
+</div>
 {{< /example >}}
 
 ## Text Transform

--- a/site/content/docs/2.0/utilities/text.md
+++ b/site/content/docs/2.0/utilities/text.md
@@ -69,6 +69,14 @@ Prevent long strings of text from breaking your components' layout by using `.te
 <p class="text-break">mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</p>
 {{< /example >}}
 
+## HYPHENATE WORD
+
+Allow long strings of text to break to the next line with a hyphen automatically placed at the break point by using `.text-hyphen` to set `hyphens: auto`.
+
+{{< example >}}
+<p class="text-hyphen">mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</p>
+{{< /example >}}
+
 ## Text Transform
 
 Transform text in components with text capitalization classes.

--- a/site/content/docs/2.0/utilities/text.md
+++ b/site/content/docs/2.0/utilities/text.md
@@ -71,7 +71,7 @@ Prevent long strings of text from breaking your components' layout by using `.te
 
 ## HYPHENATE WORD
 
-Allow long strings of text to break to the next line with a hyphen automatically placed at the break point by using `.text-hyphen` to set `hyphens: auto`. This can be applied as a span on single words that are longer than the column width.
+Allow long strings of text to break to the next line with a hyphen automatically placed at the break point by using `.text-hyphen` to set `hyphens: auto`. This should only be applied as a span on a single word that may be longer than the column width at some screen sizes. Do not use on paragraphs or longer spans of text.
 
 {{< example >}}
 <div class="card col-2">

--- a/site/content/docs/2.0/utilities/text.md
+++ b/site/content/docs/2.0/utilities/text.md
@@ -75,9 +75,9 @@ Allow long strings of text to break to the next line with a hyphen automatically
 
 {{< example >}}
 <div class="card col-2">
-	<div class="card-body">
-		<p>We should all learn about <span class="text-hyphen">Tranformationaltotality</span></p>
-	</div>
+  <div class="card-body">
+    <p>We should all learn about <span class="text-hyphen">Tranformationaltotality</span>.</p>
+  </div>
 </div>
 {{< /example >}}
 

--- a/site/content/docs/2.0/utilities/text.md
+++ b/site/content/docs/2.0/utilities/text.md
@@ -69,7 +69,7 @@ Prevent long strings of text from breaking your components' layout by using `.te
 <p class="text-break">mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</p>
 {{< /example >}}
 
-## HYPHENATE WORD
+## Hyphenate Word
 
 Allow long strings of text to break to the next line with a hyphen automatically placed at the break point by using `.text-hyphen` to set `hyphens: auto`. This should only be applied as a span on a single word that may be longer than the column width at some screen sizes. Do not use on paragraphs or longer spans of text.
 


### PR DESCRIPTION
This PR creates a custom of class .text-hyphen to set hyphens: auto. 

SASG reported a problem with words breaking without hyphens in #243. Dana and I were not able to recreate their exact issue, but did not that exceptionally long words can break this way if they are longer than the column size (particularly when there are four cards on a page with sidebar nav).

The .text-hyphen class can be used sparingly in these cases to allow for auto hyphenation of singe words. The documentation for Text Utilities has been updated with an example and also the caution that this class should not be used on paragraphs or longer spans of text.

Review site: https://review.digital.arizona.edu/arizona-bootstrap/issue/243/docs/2.0/utilities/text/