### PR TITLE
Relates to #689

### DIFF
--- a/scss/_navbar-offcanvas.scss
+++ b/scss/_navbar-offcanvas.scss
@@ -36,8 +36,10 @@
   z-index: 2000;
   display: flex;
   flex-direction: column;
+  flex-basis: 0;
+  flex-grow: 1;
   width: 325px;
-  max-width: 90%;
+  max-width: 100%;
   height: 100vh;
   max-height: 100vh;
   overflow-y: hidden;
@@ -48,6 +50,7 @@
   transition: transform .3s ease-in-out;
   transition: transform .3s ease-in-out, -webkit-transform .3s ease-in-out;
   transform: translateX(100vw);
+
   &.open {
     transform: translateX(0); /* Account for horizontal padding on navbar */
   }


### PR DESCRIPTION
In order make the navigation region span the whole column, we need some addition bootstrap settings.