### PR TITLE
Closes #322: Adding .figure-caption styles

### DIFF
--- a/scss/_custom-styles.scss
+++ b/scss/_custom-styles.scss
@@ -260,5 +260,5 @@
 .figure-caption {
   padding-top: .5em;
   padding-bottom: .9375em;
-  border-bottom: 1px solid #eef1f1;
+  border-bottom: 1px solid $gray-200;
 }

--- a/scss/_custom-styles.scss
+++ b/scss/_custom-styles.scss
@@ -254,3 +254,11 @@
   // stylelint-disable-next-line declaration-no-important
   border-width: .25rem !important;
 }
+
+// >> Figure caption.
+
+.figure-caption {
+  border-bottom: 1px solid #eef1f1;
+  padding-bottom: 0.9375em;
+  padding-top: .5em;
+}

--- a/scss/_custom-styles.scss
+++ b/scss/_custom-styles.scss
@@ -258,7 +258,7 @@
 // >> Figure caption.
 
 .figure-caption {
-  border-bottom: 1px solid #eef1f1;
-  padding-bottom: 0.9375em;
   padding-top: .5em;
+  padding-bottom: .9375em;
+  border-bottom: 1px solid #eef1f1;
 }


### PR DESCRIPTION
This PR adds custom padding and a border bottom to the .figure-caption class (matching QS1 styles)

Review site: https://review.digital.arizona.edu/arizona-bootstrap/issue/322/docs/2.0/content/figures/