### PR TITLE
Closes #208: Integrate the Arizona-specific icons into Arizona Bootstrap

### DIFF
--- a/site/content/docs/2.0/extend/icons.md
+++ b/site/content/docs/2.0/extend/icons.md
@@ -17,9 +17,170 @@ Quickstart, and Arizona Bootstrap.
 - [Arizona Icons](https://github.com/az-digital/az-icons) (Arizona branded icons)
 - [Google Material icons (Sharp)](https://material.io/resources/icons/?style=sharp)
 
+## Arizona Icons Implementation
+
+Include a reference to the Arizona Icons' CDN to your project in order to use the font icons: https://cdn.digital.arizona.edu/lib/az-icons/main/az-icons-styles.css
+
+[Refer to Arizona Icons GitHub repository](https://github.com/az-digital/az-icons) for more information and resources.
+
+<div class="row">
+  <div class="col-4 col-md-3 col-sm-1">
+    <div class="well text-center mb-4">
+      <p class="text-size-h2"><i class="az-icon-arizona"></i></p>
+      <div class="small">
+        <p><code class="text-blue">.az-icon-arizona</code></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4 col-md-3 col-sm-1">
+    <div class="well text-center mb-4">
+      <p class="text-size-h2"><i class="az-icon-award"></i></p>
+      <div class="small">
+        <p><code class="text-blue">.az-icon-award</code></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4 col-md-3 col-sm-1">
+    <div class="well text-center mb-4">
+      <p class="text-size-h2"><i class="az-icon-cost"></i></p>
+      <div class="small">
+        <p><code class="text-blue">.az-icon-cost</code></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4 col-md-3 col-sm-1">
+    <div class="well text-center mb-4">
+      <p class="text-size-h2"><i class="az-icon-facebook"></i></p>
+      <div class="small">
+        <p><code class="text-blue">.az-icon-facebook</code></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4 col-md-3 col-sm-1">
+    <div class="well text-center mb-4">
+      <p class="text-size-h2"><i class="az-icon-financial-aid"></i></p>
+      <div class="small">
+        <p><code class="text-blue">.az-icon-financial-aid</code></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4 col-md-3 col-sm-1">
+    <div class="well text-center mb-4">
+      <p class="text-size-h2"><i class="az-icon-grad-cap"></i></p>
+      <div class="small">
+        <p><code class="text-blue">.az-icon-grad-cap</code></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4 col-md-3 col-sm-1">
+    <div class="well text-center mb-4">
+      <p class="text-size-h2"><i class="az-icon-instagram"></i></p>
+      <div class="small">
+        <p><code class="text-blue">.az-icon-instagram</code></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4 col-md-3 col-sm-1">
+    <div class="well text-center mb-4">
+      <p class="text-size-h2"><i class="az-icon-linkedin"></i></p>
+      <div class="small">
+        <p><code class="text-blue">.az-icon-linkedin</code></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4 col-md-3 col-sm-1">
+    <div class="well text-center mb-4">
+      <p class="text-size-h2"><i class="az-icon-majors-and-degrees"></i></p>
+      <div class="small">
+        <p><code class="text-blue">.az-icon-majors-and-degrees</code></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4 col-md-3 col-sm-1">
+    <div class="well text-center mb-4">
+      <p class="text-size-h2"><i class="az-icon-map-marker"></i></p>
+      <div class="small">
+        <p><code class="text-blue">.az-icon-map-marker</code></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4 col-md-3 col-sm-1">
+    <div class="well text-center mb-4">
+      <p class="text-size-h2"><i class="az-icon-pinterest"></i></p>
+      <div class="small">
+        <p><code class="text-blue">.az-icon-pinterest</code></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4 col-md-3 col-sm-1">
+    <div class="well text-center mb-4">
+      <p class="text-size-h2"><i class="az-icon-scholarship"></i></p>
+      <div class="small">
+        <p><code class="text-blue">.az-icon-scholarship</code></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4 col-md-3 col-sm-1">
+    <div class="well text-center mb-4">
+      <p class="text-size-h2"><i class="az-icon-sign-post"></i></p>
+      <div class="small">
+        <p><code class="text-blue">.az-icon-sign-post</code></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4 col-md-3 col-sm-1">
+    <div class="well text-center mb-4">
+      <p class="text-size-h2"><i class="az-icon-spotify"></i></p>
+      <div class="small">
+        <p><code class="text-blue">.az-icon-spotify</code></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4 col-md-3 col-sm-1">
+    <div class="well text-center mb-4">
+      <p class="text-size-h2"><i class="az-icon-spring-fling"></i></p>
+      <div class="small">
+        <p><code class="text-blue">.az-icon-spring-fling</code></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4 col-md-3 col-sm-1">
+    <div class="well text-center mb-4">
+      <p class="text-size-h2"><i class="az-icon-tiktok"></i></p>
+      <div class="small">
+        <p><code class="text-blue">.az-icon-tiktok</code></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4 col-md-3 col-sm-1">
+    <div class="well text-center mb-4">
+      <p class="text-size-h2"><i class="az-icon-twitter"></i></p>
+      <div class="small">
+        <p><code class="text-blue">.az-icon-twitter</code></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4 col-md-3 col-sm-1">
+    <div class="well text-center mb-4">
+      <p class="text-size-h2"><i class="az-icon-wildcat"></i></p>
+      <div class="small">
+        <p><code class="text-blue">.az-icon-wildcat</code></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4 col-md-3 col-sm-1">
+    <div class="well text-center mb-4">
+      <p class="text-size-h2"><i class="az-icon-youtube"></i></p>
+      <div class="small">
+        <p><code class="text-blue">.az-icon-youtube</code></p>
+      </div>
+    </div>
+  </div>
+</div>
+
 ## Material Icons Implementation
 
-Include a the Material Icons' stylesheet to your project in order to use the font icons. [Refer to Material Icons docs](https://google.github.io/material-design-icons#icon-font-for-the-web) for more information.
+Include the Material Icons' stylesheet to your project in order to use the font icons. [Refer to Material Icons docs](https://google.github.io/material-design-icons#icon-font-for-the-web) for more information.
 
 ```html
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons+Sharp" rel="stylesheet">

--- a/site/content/docs/2.0/extend/icons.md
+++ b/site/content/docs/2.0/extend/icons.md
@@ -29,7 +29,7 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
 
 <div class="row">
   <div class="col-4 col-md-3 col-sm-1">
-    <div class="well text-center mb-4">
+    <div class="text-center mb-4">
       <p class="text-size-h2"><i class="az-icon-arizona"></i></p>
       <div class="small">
         <p><code class="text-blue">.az-icon-arizona</code></p>
@@ -37,7 +37,7 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
-    <div class="well text-center mb-4">
+    <div class="text-center mb-4">
       <p class="text-size-h2"><i class="az-icon-award"></i></p>
       <div class="small">
         <p><code class="text-blue">.az-icon-award</code></p>
@@ -45,7 +45,7 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
-    <div class="well text-center mb-4">
+    <div class="text-center mb-4">
       <p class="text-size-h2"><i class="az-icon-cost"></i></p>
       <div class="small">
         <p><code class="text-blue">.az-icon-cost</code></p>
@@ -53,7 +53,7 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
-    <div class="well text-center mb-4">
+    <div class="text-center mb-4">
       <p class="text-size-h2"><i class="az-icon-facebook"></i></p>
       <div class="small">
         <p><code class="text-blue">.az-icon-facebook</code></p>
@@ -61,7 +61,7 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
-    <div class="well text-center mb-4">
+    <div class="text-center mb-4">
       <p class="text-size-h2"><i class="az-icon-financial-aid"></i></p>
       <div class="small">
         <p><code class="text-blue">.az-icon-financial-aid</code></p>
@@ -69,7 +69,7 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
-    <div class="well text-center mb-4">
+    <div class="text-center mb-4">
       <p class="text-size-h2"><i class="az-icon-grad-cap"></i></p>
       <div class="small">
         <p><code class="text-blue">.az-icon-grad-cap</code></p>
@@ -77,7 +77,7 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
-    <div class="well text-center mb-4">
+    <div class="text-center mb-4">
       <p class="text-size-h2"><i class="az-icon-instagram"></i></p>
       <div class="small">
         <p><code class="text-blue">.az-icon-instagram</code></p>
@@ -85,7 +85,7 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
-    <div class="well text-center mb-4">
+    <div class="text-center mb-4">
       <p class="text-size-h2"><i class="az-icon-linkedin"></i></p>
       <div class="small">
         <p><code class="text-blue">.az-icon-linkedin</code></p>
@@ -93,7 +93,7 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
-    <div class="well text-center mb-4">
+    <div class="text-center mb-4">
       <p class="text-size-h2"><i class="az-icon-majors-and-degrees"></i></p>
       <div class="small">
         <p><code class="text-blue">.az-icon-majors-and-degrees</code></p>
@@ -101,7 +101,7 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
-    <div class="well text-center mb-4">
+    <div class="text-center mb-4">
       <p class="text-size-h2"><i class="az-icon-map-marker"></i></p>
       <div class="small">
         <p><code class="text-blue">.az-icon-map-marker</code></p>
@@ -109,7 +109,7 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
-    <div class="well text-center mb-4">
+    <div class="text-center mb-4">
       <p class="text-size-h2"><i class="az-icon-pinterest"></i></p>
       <div class="small">
         <p><code class="text-blue">.az-icon-pinterest</code></p>
@@ -117,7 +117,7 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
-    <div class="well text-center mb-4">
+    <div class="text-center mb-4">
       <p class="text-size-h2"><i class="az-icon-scholarship"></i></p>
       <div class="small">
         <p><code class="text-blue">.az-icon-scholarship</code></p>
@@ -125,7 +125,7 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
-    <div class="well text-center mb-4">
+    <div class="text-center mb-4">
       <p class="text-size-h2"><i class="az-icon-sign-post"></i></p>
       <div class="small">
         <p><code class="text-blue">.az-icon-sign-post</code></p>
@@ -133,7 +133,7 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
-    <div class="well text-center mb-4">
+    <div class="text-center mb-4">
       <p class="text-size-h2"><i class="az-icon-spotify"></i></p>
       <div class="small">
         <p><code class="text-blue">.az-icon-spotify</code></p>
@@ -141,7 +141,7 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
-    <div class="well text-center mb-4">
+    <div class="text-center mb-4">
       <p class="text-size-h2"><i class="az-icon-spring-fling"></i></p>
       <div class="small">
         <p><code class="text-blue">.az-icon-spring-fling</code></p>
@@ -149,7 +149,7 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
-    <div class="well text-center mb-4">
+    <div class="text-center mb-4">
       <p class="text-size-h2"><i class="az-icon-tiktok"></i></p>
       <div class="small">
         <p><code class="text-blue">.az-icon-tiktok</code></p>
@@ -157,7 +157,7 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
-    <div class="well text-center mb-4">
+    <div class="text-center mb-4">
       <p class="text-size-h2"><i class="az-icon-twitter"></i></p>
       <div class="small">
         <p><code class="text-blue">.az-icon-twitter</code></p>
@@ -165,7 +165,7 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
-    <div class="well text-center mb-4">
+    <div class="text-center mb-4">
       <p class="text-size-h2"><i class="az-icon-wildcat"></i></p>
       <div class="small">
         <p><code class="text-blue">.az-icon-wildcat</code></p>
@@ -173,7 +173,7 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
-    <div class="well text-center mb-4">
+    <div class="text-center mb-4">
       <p class="text-size-h2"><i class="az-icon-youtube"></i></p>
       <div class="small">
         <p><code class="text-blue">.az-icon-youtube</code></p>

--- a/site/content/docs/2.0/extend/icons.md
+++ b/site/content/docs/2.0/extend/icons.md
@@ -28,115 +28,115 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
 [Refer to Arizona Icons GitHub repository](https://github.com/az-digital/az-icons) for more information and resources.
 
 <div class="row">
-  <div class="col-4 col-md-3 col-sm-1">
+  <div class="col-6 col-md-3 col-sm-1 col-lg-3">
     <div class="text-center mb-4">
       <p class="text-size-h2 mb-2"><i class="az-icon-arizona"></i></p>
       <p class="small"><code class="text-blue">.az-icon-arizona</code></p>
     </div>
   </div>
-  <div class="col-4 col-md-3 col-sm-1">
+  <div class="col-6 col-md-3 col-sm-1 col-lg-3">
     <div class="text-center mb-4">
       <p class="text-size-h2 mb-2"><i class="az-icon-award"></i></p>
       <p class="small"><code class="text-blue">.az-icon-award</code></p>
     </div>
   </div>
-  <div class="col-4 col-md-3 col-sm-1">
+  <div class="col-6 col-md-3 col-sm-1 col-lg-3">
     <div class="text-center mb-4">
       <p class="text-size-h2 mb-2"><i class="az-icon-cost"></i></p>
       <p class="small"><code class="text-blue">.az-icon-cost</code></p>
     </div>
   </div>
-  <div class="col-4 col-md-3 col-sm-1">
+  <div class="col-6 col-md-3 col-sm-1 col-lg-3">
     <div class="text-center mb-4">
       <p class="text-size-h2 mb-2"><i class="az-icon-facebook"></i></p>
       <p class="small"><code class="text-blue">.az-icon-facebook</code></p>
     </div>
   </div>
-  <div class="col-4 col-md-3 col-sm-1">
+  <div class="col-6 col-md-3 col-sm-1 col-lg-3">
     <div class="text-center mb-4">
       <p class="text-size-h2 mb-2"><i class="az-icon-financial-aid"></i></p>
       <p class="small"><code class="text-blue">.az-icon-financial-aid</code></p>
     </div>
   </div>
-  <div class="col-4 col-md-3 col-sm-1">
+  <div class="col-6 col-md-3 col-sm-1 col-lg-3">
     <div class="text-center mb-4">
       <p class="text-size-h2 mb-2"><i class="az-icon-grad-cap"></i></p>
       <p class="small"><code class="text-blue">.az-icon-grad-cap</code></p>
     </div>
   </div>
-  <div class="col-4 col-md-3 col-sm-1">
+  <div class="col-6 col-md-3 col-sm-1 col-lg-3">
     <div class="text-center mb-4">
       <p class="text-size-h2 mb-2"><i class="az-icon-instagram"></i></p>
       <p class="small"><code class="text-blue">.az-icon-instagram</code></p>
     </div>
   </div>
-  <div class="col-4 col-md-3 col-sm-1">
+  <div class="col-6 col-md-3 col-sm-1 col-lg-3">
     <div class="text-center mb-4">
       <p class="text-size-h2 mb-2"><i class="az-icon-linkedin"></i></p>
       <p class="small"><code class="text-blue">.az-icon-linkedin</code></p>
     </div>
   </div>
-  <div class="col-4 col-md-3 col-sm-1">
+  <div class="col-6 col-md-3 col-sm-1 col-lg-3">
     <div class="text-center mb-4">
       <p class="text-size-h2 mb-2"><i class="az-icon-majors-and-degrees"></i></p>
       <p class="small"><code class="text-blue">.az-icon-majors-and-degrees</code></p>
     </div>
   </div>
-  <div class="col-4 col-md-3 col-sm-1">
+  <div class="col-6 col-md-3 col-sm-1 col-lg-3">
     <div class="text-center mb-4">
       <p class="text-size-h2 mb-2"><i class="az-icon-map-marker"></i></p>
       <p class="small"><code class="text-blue">.az-icon-map-marker</code></p>
     </div>
   </div>
-  <div class="col-4 col-md-3 col-sm-1">
+  <div class="col-6 col-md-3 col-sm-1 col-lg-3">
     <div class="text-center mb-4">
       <p class="text-size-h2 mb-2"><i class="az-icon-pinterest"></i></p>
       <p class="small"><code class="text-blue">.az-icon-pinterest</code></p>
     </div>
   </div>
-  <div class="col-4 col-md-3 col-sm-1">
+  <div class="col-6 col-md-3 col-sm-1 col-lg-3">
     <div class="text-center mb-4">
       <p class="text-size-h2 mb-2"><i class="az-icon-scholarship"></i></p>
       <p class="small"><code class="text-blue">.az-icon-scholarship</code></p>
     </div>
   </div>
-  <div class="col-4 col-md-3 col-sm-1">
+  <div class="col-6 col-md-3 col-sm-1 col-lg-3">
     <div class="text-center mb-4">
       <p class="text-size-h2 mb-2"><i class="az-icon-sign-post"></i></p>
       <p class="small"><code class="text-blue">.az-icon-sign-post</code></p>
     </div>
   </div>
-  <div class="col-4 col-md-3 col-sm-1">
+  <div class="col-6 col-md-3 col-sm-1 col-lg-3">
     <div class="text-center mb-4">
       <p class="text-size-h2 mb-2"><i class="az-icon-spotify"></i></p>
       <p class="small"><code class="text-blue">.az-icon-spotify</code></p>
     </div>
   </div>
-  <div class="col-4 col-md-3 col-sm-1">
+  <div class="col-6 col-md-3 col-sm-1 col-lg-3">
     <div class="text-center mb-4">
       <p class="text-size-h2 mb-2"><i class="az-icon-spring-fling"></i></p>
       <p class="small"><code class="text-blue">.az-icon-spring-fling</code></p>
     </div>
   </div>
-  <div class="col-4 col-md-3 col-sm-1">
+  <div class="col-6 col-md-3 col-sm-1 col-lg-3">
     <div class="text-center mb-4">
       <p class="text-size-h2 mb-2"><i class="az-icon-tiktok"></i></p>
       <p class="small"><code class="text-blue">.az-icon-tiktok</code></p>
     </div>
   </div>
-  <div class="col-4 col-md-3 col-sm-1">
+  <div class="col-6 col-md-3 col-sm-1 col-lg-3">
     <div class="text-center mb-4">
       <p class="text-size-h2 mb-2"><i class="az-icon-twitter"></i></p>
       <p class="small"><code class="text-blue">.az-icon-twitter</code></p>
     </div>
   </div>
-  <div class="col-4 col-md-3 col-sm-1">
+  <div class="col-6 col-md-3 col-sm-1 col-lg-3">
     <div class="text-center mb-4">
       <p class="text-size-h2 mb-2"><i class="az-icon-wildcat"></i></p>
       <p class="small"><code class="text-blue">.az-icon-wildcat</code></p>
     </div>
   </div>
-  <div class="col-4 col-md-3 col-sm-1">
+  <div class="col-6 col-md-3 col-sm-1 col-lg-3">
     <div class="text-center mb-4">
       <p class="text-size-h2 mb-2"><i class="az-icon-youtube"></i></p>
       <p class="small"><code class="text-blue">.az-icon-youtube</code></p>

--- a/site/content/docs/2.0/extend/icons.md
+++ b/site/content/docs/2.0/extend/icons.md
@@ -19,7 +19,11 @@ Quickstart, and Arizona Bootstrap.
 
 ## Arizona Icons Implementation
 
-Include a reference to the Arizona Icons' CDN to your project in order to use the font icons: https://cdn.digital.arizona.edu/lib/az-icons/main/az-icons-styles.css
+Include a reference to the Arizona Icons' CDN to your project in order to use the font icons:
+
+```html
+<link href="https://cdn.digital.arizona.edu/lib/az-icons/main/az-icons-styles.css rel="stylesheet">
+```
 
 [Refer to Arizona Icons GitHub repository](https://github.com/az-digital/az-icons) for more information and resources.
 

--- a/site/content/docs/2.0/extend/icons.md
+++ b/site/content/docs/2.0/extend/icons.md
@@ -7,7 +7,7 @@ group: extend
 
 <div class="alert alert-warning" role="alert">
   <p class="h4 alert-heading">Heads Up!</p>
-  If you're using Arizona Bootstrap, Material Design Sharp icons will still need
+  If you're using Arizona Bootstrap, Arizona Icons and/or Material Design Sharp icons will still need
   to be added to your project if you would like to use them.
 </div>
 

--- a/site/content/docs/2.0/extend/icons.md
+++ b/site/content/docs/2.0/extend/icons.md
@@ -30,154 +30,116 @@ Include a reference to the Arizona Icons' CDN to your project in order to use th
 <div class="row">
   <div class="col-4 col-md-3 col-sm-1">
     <div class="text-center mb-4">
-      <p class="text-size-h2"><i class="az-icon-arizona"></i></p>
-      <div class="small">
-        <p><code class="text-blue">.az-icon-arizona</code></p>
-      </div>
+      <p class="text-size-h2 mb-2"><i class="az-icon-arizona"></i></p>
+      <p class="small"><code class="text-blue">.az-icon-arizona</code></p>
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
     <div class="text-center mb-4">
-      <p class="text-size-h2"><i class="az-icon-award"></i></p>
-      <div class="small">
-        <p><code class="text-blue">.az-icon-award</code></p>
-      </div>
+      <p class="text-size-h2 mb-2"><i class="az-icon-award"></i></p>
+      <p class="small"><code class="text-blue">.az-icon-award</code></p>
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
     <div class="text-center mb-4">
-      <p class="text-size-h2"><i class="az-icon-cost"></i></p>
-      <div class="small">
-        <p><code class="text-blue">.az-icon-cost</code></p>
-      </div>
+      <p class="text-size-h2 mb-2"><i class="az-icon-cost"></i></p>
+      <p class="small"><code class="text-blue">.az-icon-cost</code></p>
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
     <div class="text-center mb-4">
-      <p class="text-size-h2"><i class="az-icon-facebook"></i></p>
-      <div class="small">
-        <p><code class="text-blue">.az-icon-facebook</code></p>
-      </div>
+      <p class="text-size-h2 mb-2"><i class="az-icon-facebook"></i></p>
+      <p class="small"><code class="text-blue">.az-icon-facebook</code></p>
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
     <div class="text-center mb-4">
-      <p class="text-size-h2"><i class="az-icon-financial-aid"></i></p>
-      <div class="small">
-        <p><code class="text-blue">.az-icon-financial-aid</code></p>
-      </div>
+      <p class="text-size-h2 mb-2"><i class="az-icon-financial-aid"></i></p>
+      <p class="small"><code class="text-blue">.az-icon-financial-aid</code></p>
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
     <div class="text-center mb-4">
-      <p class="text-size-h2"><i class="az-icon-grad-cap"></i></p>
-      <div class="small">
-        <p><code class="text-blue">.az-icon-grad-cap</code></p>
-      </div>
+      <p class="text-size-h2 mb-2"><i class="az-icon-grad-cap"></i></p>
+      <p class="small"><code class="text-blue">.az-icon-grad-cap</code></p>
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
     <div class="text-center mb-4">
-      <p class="text-size-h2"><i class="az-icon-instagram"></i></p>
-      <div class="small">
-        <p><code class="text-blue">.az-icon-instagram</code></p>
-      </div>
+      <p class="text-size-h2 mb-2"><i class="az-icon-instagram"></i></p>
+      <p class="small"><code class="text-blue">.az-icon-instagram</code></p>
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
     <div class="text-center mb-4">
-      <p class="text-size-h2"><i class="az-icon-linkedin"></i></p>
-      <div class="small">
-        <p><code class="text-blue">.az-icon-linkedin</code></p>
-      </div>
+      <p class="text-size-h2 mb-2"><i class="az-icon-linkedin"></i></p>
+      <p class="small"><code class="text-blue">.az-icon-linkedin</code></p>
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
     <div class="text-center mb-4">
-      <p class="text-size-h2"><i class="az-icon-majors-and-degrees"></i></p>
-      <div class="small">
-        <p><code class="text-blue">.az-icon-majors-and-degrees</code></p>
-      </div>
+      <p class="text-size-h2 mb-2"><i class="az-icon-majors-and-degrees"></i></p>
+      <p class="small"><code class="text-blue">.az-icon-majors-and-degrees</code></p>
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
     <div class="text-center mb-4">
-      <p class="text-size-h2"><i class="az-icon-map-marker"></i></p>
-      <div class="small">
-        <p><code class="text-blue">.az-icon-map-marker</code></p>
-      </div>
+      <p class="text-size-h2 mb-2"><i class="az-icon-map-marker"></i></p>
+      <p class="small"><code class="text-blue">.az-icon-map-marker</code></p>
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
     <div class="text-center mb-4">
-      <p class="text-size-h2"><i class="az-icon-pinterest"></i></p>
-      <div class="small">
-        <p><code class="text-blue">.az-icon-pinterest</code></p>
-      </div>
+      <p class="text-size-h2 mb-2"><i class="az-icon-pinterest"></i></p>
+      <p class="small"><code class="text-blue">.az-icon-pinterest</code></p>
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
     <div class="text-center mb-4">
-      <p class="text-size-h2"><i class="az-icon-scholarship"></i></p>
-      <div class="small">
-        <p><code class="text-blue">.az-icon-scholarship</code></p>
-      </div>
+      <p class="text-size-h2 mb-2"><i class="az-icon-scholarship"></i></p>
+      <p class="small"><code class="text-blue">.az-icon-scholarship</code></p>
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
     <div class="text-center mb-4">
-      <p class="text-size-h2"><i class="az-icon-sign-post"></i></p>
-      <div class="small">
-        <p><code class="text-blue">.az-icon-sign-post</code></p>
-      </div>
+      <p class="text-size-h2 mb-2"><i class="az-icon-sign-post"></i></p>
+      <p class="small"><code class="text-blue">.az-icon-sign-post</code></p>
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
     <div class="text-center mb-4">
-      <p class="text-size-h2"><i class="az-icon-spotify"></i></p>
-      <div class="small">
-        <p><code class="text-blue">.az-icon-spotify</code></p>
-      </div>
+      <p class="text-size-h2 mb-2"><i class="az-icon-spotify"></i></p>
+      <p class="small"><code class="text-blue">.az-icon-spotify</code></p>
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
     <div class="text-center mb-4">
-      <p class="text-size-h2"><i class="az-icon-spring-fling"></i></p>
-      <div class="small">
-        <p><code class="text-blue">.az-icon-spring-fling</code></p>
-      </div>
+      <p class="text-size-h2 mb-2"><i class="az-icon-spring-fling"></i></p>
+      <p class="small"><code class="text-blue">.az-icon-spring-fling</code></p>
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
     <div class="text-center mb-4">
-      <p class="text-size-h2"><i class="az-icon-tiktok"></i></p>
-      <div class="small">
-        <p><code class="text-blue">.az-icon-tiktok</code></p>
-      </div>
+      <p class="text-size-h2 mb-2"><i class="az-icon-tiktok"></i></p>
+      <p class="small"><code class="text-blue">.az-icon-tiktok</code></p>
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
     <div class="text-center mb-4">
-      <p class="text-size-h2"><i class="az-icon-twitter"></i></p>
-      <div class="small">
-        <p><code class="text-blue">.az-icon-twitter</code></p>
-      </div>
+      <p class="text-size-h2 mb-2"><i class="az-icon-twitter"></i></p>
+      <p class="small"><code class="text-blue">.az-icon-twitter</code></p>
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
     <div class="text-center mb-4">
-      <p class="text-size-h2"><i class="az-icon-wildcat"></i></p>
-      <div class="small">
-        <p><code class="text-blue">.az-icon-wildcat</code></p>
-      </div>
+      <p class="text-size-h2 mb-2"><i class="az-icon-wildcat"></i></p>
+      <p class="small"><code class="text-blue">.az-icon-wildcat</code></p>
     </div>
   </div>
   <div class="col-4 col-md-3 col-sm-1">
     <div class="text-center mb-4">
-      <p class="text-size-h2"><i class="az-icon-youtube"></i></p>
-      <div class="small">
-        <p><code class="text-blue">.az-icon-youtube</code></p>
-      </div>
+      <p class="text-size-h2 mb-2"><i class="az-icon-youtube"></i></p>
+      <p class="small"><code class="text-blue">.az-icon-youtube</code></p>
     </div>
   </div>
 </div>

--- a/site/content/docs/2.0/getting-started/introduction.md
+++ b/site/content/docs/2.0/getting-started/introduction.md
@@ -68,6 +68,8 @@ Be sure to have your pages set up with the latest design and development standar
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <!-- Proxima Nova font. -->
     <link href="https://use.typekit.net/emv3zbo.css" rel="stylesheet" crossorigin="anonymous">
+    <!-- Arizona Icons CSS -->
+    <link rel="stylesheet" href="https://cdn.digital.arizona.edu/lib/az-icons/main/az-icons-styles.css">
     <!-- Arizona Bootstrap CSS -->
     <link rel="stylesheet" href="https://cdn.digital.arizona.edu/lib/arizona-bootstrap/main/css/arizona-bootstrap.min.css">
     <title>Arizona Bootstrap Starter Template</title>
@@ -127,6 +129,8 @@ If you want your footer to remain at the bottom of the page even when you don't 
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <!-- Proxima Nova font. -->
     <link href="https://use.typekit.net/emv3zbo.css" rel="stylesheet" crossorigin="anonymous">
+    <!-- Arizona Icons CSS -->
+    <link rel="stylesheet" href="https://cdn.digital.arizona.edu/lib/az-icons/main/az-icons-styles.css">
     <!-- Arizona Bootstrap CSS -->
     <link rel="stylesheet" href="https://cdn.digital.arizona.edu/lib/arizona-bootstrap/main/css/arizona-bootstrap.min.css">
 

--- a/site/layouts/partials/stylesheet.html
+++ b/site/layouts/partials/stylesheet.html
@@ -1,4 +1,5 @@
 <link href="https://fonts.googleapis.com/css?family=Material+Icons+Sharp" rel="stylesheet">
+<link href="https://cdn.digital.arizona.edu/lib/az-icons/main/az-icons-styles.css" rel="stylesheet">
 {{ printf "<!-- %s core CSS -->" .Site.Title | safeHTML }}
 <link href="https://use.typekit.net/emv3zbo.css" rel="stylesheet" crossorigin="anonymous">
 {{ if eq hugo.Environment "production" -}}


### PR DESCRIPTION
The list of Arizona-specific icons and their corresponding classes are now viewable on the Arizona Bootstrap documentation site under Extend -> Icons.

- [x] Add reference  on starter template https://digital.arizona.edu/arizona-bootstrap/docs/2.0/getting-started/introduction/#starter-template
- [x] Add reference  on sticky footer template https://digital.arizona.edu/arizona-bootstrap/docs/2.0/getting-started/introduction/#sticky-footer-template 
- [x] clean up display of icons a bit, change bg color maybe use card class. (whatever looks best)
- [ ] possibly add link example with icon. — FOLLOW-UP