### PR TITLE
Closes #380: Document the changes from UA Bootstrap in hollow buttons.

### DIFF
--- a/site/content/docs/2.0/backwards-compatibility.md
+++ b/site/content/docs/2.0/backwards-compatibility.md
@@ -61,7 +61,7 @@ The classes `.btn-default` and `.btn-primary` available in UA Bootstrap have bee
 
 #### Hollow Buttons
 
-Hollow buttons now use the `.btn-outline-*` class. These buttons are included with backwards compatibility and can be extended using the [available outline classes]({{< docsref "/components/buttons#outline-buttons" >}}).
+Hollow buttons now use the `.btn-outline-*` class. These buttons are included with backwards compatibility and can be extended using the [available outline classes]({{< docsref "/components/buttons#outline-buttons" >}}). The `.btn-hollow` class (in practice identical to `.btn-hollow-default`) is not backwards compatible, needing replacement by `.btn-outline-red`.
 
 The class `.btn-hollow-reverse` is included with backwards compatibility and can be extended using the `.btn-outline-white` class.
 

--- a/site/content/docs/2.0/deprecated.md
+++ b/site/content/docs/2.0/deprecated.md
@@ -61,7 +61,7 @@ The classes `.btn-default` and `.btn-primary` available in UA Bootstrap have bee
 
 #### Hollow Buttons
 
-Hollow buttons now use the `.btn-outline-*` class. These buttons are included with backwards compatibility and can be extended using the [available outline classes]({{< docsref "/components/buttons#outline-buttons" >}}).
+Hollow buttons now use the `.btn-outline-*` class. These buttons are included with backwards compatibility and can be extended using the [available outline classes]({{< docsref "/components/buttons#outline-buttons" >}}). The `.btn-hollow` class (in practice identical to `.btn-hollow-default`) is not backwards compatible, needing replacement by `.btn-outline-red`.
 
 The class `.btn-hollow-reverse` is included with backwards compatibility and can be extended using the `.btn-outline-white` class.
 

--- a/site/content/docs/2.0/migration.md
+++ b/site/content/docs/2.0/migration.md
@@ -98,7 +98,9 @@ New to Bootstrap 4 is the [Reboot]({{< docsref "/content/reboot" >}}), a new sty
 
 ### Buttons
 
-- Renamed `.btn-default` to `.btn-secondary`.
+- Replaced `.btn-default` by `.btn-red`, and `.btn-primary` by `.btn-blue`.
+- Replaced `.btn-hollow-*` by `.btn-outline-*` classes.
+- Dropped the `.btn-hollow` class (substitute `.btn-outline-red`).
 - Dropped the `.btn-xs` class entirely as `.btn-sm` is proportionally much smaller than v3's.
 - The [stateful button](http://uadigital.arizona.edu/ua-bootstrap/javascript#buttons-stateful) feature of the `button.js` jQuery plugin has been dropped. This includes the `$().button(string)` and `$().button('reset')` methods. We advise using a tiny bit of custom JavaScript instead, which will have the benefit of behaving exactly the way you want it to.
   - Note that the other features of the plugin (button checkboxes, button radios, single-toggle buttons) have been retained in v4.


### PR DESCRIPTION
Correcting an omission in the documentation, which didn't make it into the latest release.