### PR TITLE
Closes #459 Fixing broken links in arizona bootstrap docs.

### DIFF
--- a/site/content/docs/2.0/components/dropdowns.md
+++ b/site/content/docs/2.0/components/dropdowns.md
@@ -10,7 +10,7 @@ toc: true
 
 Dropdowns are toggleable, contextual overlays for displaying lists of links and more. They're made interactive with the included Bootstrap dropdown JavaScript plugin. They're toggled by clicking, not by hovering; this is [an intentional design decision](https://markdotto.com/2012/02/27/bootstrap-explained-dropdowns/).
 
-Dropdowns are built on a third party library, [Popper](https://popper.js.org/), which provides dynamic positioning and viewport detection. Be sure to include [popper.min.js]({{< param "cdn.popper" >}}) before Bootstrap's JavaScript or use `bootstrap.bundle.min.js` / `bootstrap.bundle.js` which contains Popper. Popper isn't used to position dropdowns in navbars though as dynamic positioning isn't required.
+Dropdowns are built on a third party library, [Popper](https://popper.js.org/), which provides dynamic positioning and viewport detection. Be sure to include [popper.min.js]({{< param "cdn.popper" >}}) before Bootstrap's JavaScript or use `arizona-bootstrap.bundle.min.js` / `arizona-bootstrap.bundle.js` which contains Popper. Popper isn't used to position dropdowns in navbars though as dynamic positioning isn't required.
 
 If you're building our JavaScript from source, it [requires `util.js`]({{< docsref "/getting-started/javascript#util" >}}).
 

--- a/site/content/docs/2.0/components/popovers.md
+++ b/site/content/docs/2.0/components/popovers.md
@@ -10,7 +10,7 @@ toc: true
 
 Things to know when using the popover plugin:
 
-- Popovers rely on the 3rd party library [Popper](https://popper.js.org/) for positioning. You must include [popper.min.js]({{< param "cdn.popper" >}}) before bootstrap.js or use `bootstrap.bundle.min.js` / `bootstrap.bundle.js` which contains Popper in order for popovers to work!
+- Popovers rely on the 3rd party library [Popper](https://popper.js.org/) for positioning. You must include [popper.min.js]({{< param "cdn.popper" >}}) before bootstrap.js or use `arizona-bootstrap.bundle.min.js` / `arizona-bootstrap.bundle.js` which contains Popper in order for popovers to work!
 - Popovers require the [tooltip plugin]({{< docsref "/components/tooltips" >}}) as a dependency.
 - If you're building our JavaScript from source, it [requires `util.js`]({{< docsref "/getting-started/javascript#util" >}}).
 - Popovers are opt-in for performance reasons, so **you must initialize them yourself**.
@@ -232,7 +232,7 @@ Note that for security reasons the `sanitize`, `sanitizeFn` and `whiteList` opti
       <td>selector</td>
       <td>string | false</td>
       <td>false</td>
-      <td>If a selector is provided, popover objects will be delegated to the specified targets. In practice, this is used to enable dynamic HTML content to have popovers added. See <a href="{{< param repo >}}/issues/4215">this</a> and <a href="https://codepen.io/team/bootstrap/pen/qBNGbYK">an informative example</a>.</td>
+      <td>If a selector is provided, popover objects will be delegated to the specified targets. In practice, this is used to enable dynamic HTML content to have popovers added. See <a href="https://github.com/twbs/bootstrap/issues/4215">this</a> and <a href="https://codepen.io/team/bootstrap/pen/qBNGbYK">an informative example</a>.</td>
     </tr>
     <tr>
       <td>template</td>

--- a/site/content/docs/2.0/components/tooltips.md
+++ b/site/content/docs/2.0/components/tooltips.md
@@ -199,7 +199,7 @@ Note that for security reasons the `sanitize`, `sanitizeFn` and `whiteList` opti
       <td>selector</td>
       <td>string | false</td>
       <td>false</td>
-      <td>If a selector is provided, tooltip objects will be delegated to the specified targets. In practice, this is used to also apply tooltips to dynamically added DOM elements (<code>jQuery.on</code> support). See <a href="{{< param repo >}}/issues/4215">this</a> and <a href="https://codepen.io/team/bootstrap/pen/qBNGbYK">an informative example</a>.</td>
+      <td>If a selector is provided, tooltip objects will be delegated to the specified targets. In practice, this is used to also apply tooltips to dynamically added DOM elements (<code>jQuery.on</code> support). See <a href="https://github.com/twbs/bootstrap/issues/4215">this</a> and <a href="https://codepen.io/team/bootstrap/pen/qBNGbYK">an informative example</a>.</td>
     </tr>
     <tr>
       <td>template</td>

--- a/site/content/docs/2.0/components/tooltips.md
+++ b/site/content/docs/2.0/components/tooltips.md
@@ -10,7 +10,7 @@ toc: true
 
 Things to know when using the tooltip plugin:
 
-- Tooltips rely on the 3rd party library [Popper](https://popper.js.org/) for positioning. You must include [popper.min.js]({{< param "cdn.popper" >}}) before bootstrap.js or use `bootstrap.bundle.min.js` / `bootstrap.bundle.js` which contains Popper in order for tooltips to work!
+- Tooltips rely on the 3rd party library [Popper](https://popper.js.org/) for positioning. You must include [popper.min.js]({{< param "cdn.popper" >}}) before bootstrap.js or use `arizona-bootstrap.bundle.min.js` / `arizona-bootstrap.bundle.js` which contains Popper in order for tooltips to work!
 - If you're building our JavaScript from source, it [requires `util.js`]({{< docsref "/getting-started/javascript#util" >}}).
 - Tooltips are opt-in for performance reasons, so **you must initialize them yourself**.
 - Tooltips with zero-length titles are never displayed.

--- a/site/content/docs/2.0/examples/navbar/index.html
+++ b/site/content/docs/2.0/examples/navbar/index.html
@@ -9,7 +9,7 @@ title: Navbar template
      <div class="row">
        <div class="col-10 col-md-3 pr-0">
          <a href="https://www.arizona.edu" title="The University of Arizona homepage">
-           <img alt="The University of Arizona Wordmark Line Logo White" src="https://cdn.uadigital.arizona.edu/logos/v1.0.0/ua_wordmark_line_logo_white_rgb.min.svg" class="pt-4 pb-3 pl-2">
+           <img alt="The University of Arizona Wordmark Line Logo White" src="https://cdn.digital.arizona.edu/logos/v1.0.0/ua_wordmark_line_logo_white_rgb.min.svg" class="pt-4 pb-3 pl-2">
          </a>
        </div>
        <div class="col-2 col-md-9 pr-0 d-lg-none d-flex justify-content-end">

--- a/site/content/docs/2.0/getting-started/browsers-devices.md
+++ b/site/content/docs/2.0/getting-started/browsers-devices.md
@@ -111,7 +111,7 @@ For a list of some of the browser bugs that {{< ourname >}} has to grapple with,
 
 ## Internet Explorer
 
-Internet Explorer 10+ is supported; IE9 and down is not. Please be aware that some CSS3 properties and HTML5 elements are not fully supported in IE10, or require prefixed properties for full functionality. Visit [Can I use...](https://caniuse.com/) for details on browser support of CSS3 and HTML5 features. **If you require IE8-9 support, use [ua-bootstrap](http://uadigital.arizona.edu/ua-bootstrap/).**
+Internet Explorer 10+ is supported; IE9 and down is not. Please be aware that some CSS3 properties and HTML5 elements are not fully supported in IE10, or require prefixed properties for full functionality. Visit [Can I use...](https://caniuse.com/) for details on browser support of CSS3 and HTML5 features. **If you require IE8-9 support, use [ua-bootstrap](https://digital.arizona.edu/ua-bootstrap/).**
 
 ## Modals and Dropdowns on Mobile
 

--- a/site/content/docs/2.0/getting-started/color-contrast.md
+++ b/site/content/docs/2.0/getting-started/color-contrast.md
@@ -14,7 +14,7 @@ toc: true
 
 All University of Arizona websites should **maintain a minimum of WCAG AA color contrast between text color and background color**.
 
-Below we have provided a table that includes all of the Arizona branded colors. Check the "Hide inaccessible color combinations" checkbox to only display the color combinations that meet the minimum of WCAG AA. The accessible color combinations have been determined by use of the [WebAIM Accessibility Tool](http://wave.webaim.org/report#/http://uadigital.arizona.edu/ua-bootstrap/colors.html).
+Below we have provided a table that includes all of the Arizona branded colors. Check the "Hide inaccessible color combinations" checkbox to only display the color combinations that meet the minimum of WCAG AA. The accessible color combinations have been determined by use of the [WebAIM Accessibility Tool](http://wave.webaim.org/report#/https://digital.arizona.edu/ua-bootstrap/colors.html).
 
 <label id="hide-inaccessible-label">
   <input type="checkbox" id="hide-inaccessible"> <strong>Hide inaccessible color combinations.</strong>

--- a/site/content/docs/2.0/migration.md
+++ b/site/content/docs/2.0/migration.md
@@ -102,7 +102,7 @@ New to Bootstrap 4 is the [Reboot]({{< docsref "/content/reboot" >}}), a new sty
 - Replaced `.btn-hollow-*` by `.btn-outline-*` classes.
 - Dropped the `.btn-hollow` class (substitute `.btn-outline-red`).
 - Dropped the `.btn-xs` class entirely as `.btn-sm` is proportionally much smaller than v3's.
-- The [stateful button](http://uadigital.arizona.edu/ua-bootstrap/javascript#buttons-stateful) feature of the `button.js` jQuery plugin has been dropped. This includes the `$().button(string)` and `$().button('reset')` methods. We advise using a tiny bit of custom JavaScript instead, which will have the benefit of behaving exactly the way you want it to.
+- The [stateful button](https://digital.arizona.edu/ua-bootstrap/javascript#buttons-stateful) feature of the `button.js` jQuery plugin has been dropped. This includes the `$().button(string)` and `$().button('reset')` methods. We advise using a tiny bit of custom JavaScript instead, which will have the benefit of behaving exactly the way you want it to.
   - Note that the other features of the plugin (button checkboxes, button radios, single-toggle buttons) have been retained in v4.
 - Change buttons' `[disabled]` to `:disabled` as IE9+ supports `:disabled`. However `fieldset[disabled]` is still necessary because [native disabled fieldsets are still buggy in IE11](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset#Browser_compatibility).
 

--- a/site/data/browser-features.yml
+++ b/site/data/browser-features.yml
@@ -3,8 +3,6 @@
     Edge
   summary: >
     Focusable elements should fire focus event / receive :focus styling when they receive Narrator/accessibility focus
-  upstream_bug: >
-    A11yUserVoice#16717318
   origin: >
     Bootstrap#20732
 
@@ -35,8 +33,6 @@
     Fire a [`transitioncancel` event](https://developer.mozilla.org/en-US/docs/Web/Events/transitioncancel) when a CSS transition is canceled
   upstream_bug: >
     UserVoice#15939898
-  origin: >
-    Bootstrap#20618
 
 -
   browser: >
@@ -115,8 +111,6 @@
     Fire a [`transitioncancel` event](https://developer.mozilla.org/en-US/docs/Web/Events/transitioncancel) when a CSS transition is canceled
   upstream_bug: >
     WebKit#161535
-  origin: >
-    Bootstrap#20618
 
 -
   browser: >

--- a/site/data/slack-channels.yml
+++ b/site/data/slack-channels.yml
@@ -43,14 +43,14 @@
   description:
     - purpose: "For topics and questions concerning the migration of UA Quickstart from Drupal 7 to Drupal 8"
 
-- channel: "#uadigital-ci"
+- channel: "#azdigital-ci"
   description:
     - purpose: "For automated tasks and CI (continuous integration)"
 
-- channel: "#uadigital-docs"
+- channel: "#azdigital-docs"
   description:
     - purpose: "For topics concerning documentation for Arizona Digital and its products"
 
-- channel: "#uadigital-general"
+- channel: "#azdigital-general"
   description:
     - purpose: "For general discussion and side conversations"

--- a/site/layouts/partials/bugify.html
+++ b/site/layouts/partials/bugify.html
@@ -19,8 +19,6 @@
       <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/{{ $bug_id }}/">Edge issue #{{ $bug_id }}</a>
     {{- else if (eq $bug_cat "A11yUserVoice") -}}
       <a href="https://microsoftaccessibility.uservoice.com/forums/307429-microsoft-accessibility-feedback/suggestions/{{ $bug_id }}">Microsoft A11y UserVoice idea #{{ $bug_id }}</a>
-    {{- else if (eq $bug_cat "UserVoice") -}}
-      <a href="https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/{{ $bug_id }}">Edge UserVoice idea #{{ $bug_id }}</a>
     {{- else if (eq $bug_cat "Mozilla") -}}
       <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ $bug_id }}">Mozilla bug #{{ $bug_id }}</a>
     {{- else if (eq $bug_cat "Chromium") -}}


### PR DESCRIPTION
Changed references to `bootstrap.bundle.min.js` and `bootstrap.bundle.js` with `arizona-bootstrap.bundle.min.js` and `arizona-bootstrap.bundle.js` everywhere.

Fixed this issue link https://github.com/twbs/bootstrap/issues/4215 on https://review.digital.arizona.edu/arizona-bootstrap/issues/459-fix-broken-links/docs/2.0/components/popovers/#options
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/1023167/163057054-54c073b2-7f04-49a8-bf54-60c075dfdb9f.png">

Fixed this issue link https://github.com/twbs/bootstrap/issues/4215 on https://review.digital.arizona.edu/arizona-bootstrap/issues/459-fix-broken-links/docs/2.0/components/tooltips/#options
<img width="1092" alt="image" src="https://user-images.githubusercontent.com/1023167/163057285-be265aeb-87c5-4d79-bb4a-d908258820df.png">

Fixed navbar logo here: https://review.digital.arizona.edu/arizona-bootstrap/issues/459-fix-broken-links/docs/2.0/examples/navbar/

Looks like the main logo is still broken.


Removed a bunch of issue links that no longer exist 