### PR TITLE
Closes #494: Add overrides for shadow classes

### DIFF
--- a/scss/_custom-variables.scss
+++ b/scss/_custom-variables.scss
@@ -304,3 +304,6 @@ $table-hover-bg: rgba($table-head-bg, .5);
 $tooltip-arrow-color: $blue;
 $tooltip-bg: $blue;
 
+// >> Shadows
+$box-shadow:                  0 .25rem 1rem rgba($black, .15) !default;
+$box-shadow-lg:               0 .75rem 3rem rgba($black, .175) !default;


### PR DESCRIPTION
Closes #494

Changing y-axis on shadow class CSS to more closely align with brand guidelines

