### PR TITLE
Remove unnecessary(?) git restore package-lock.json step.

### DIFF
--- a/.github/workflows/review-site.yml
+++ b/.github/workflows/review-site.yml
@@ -123,9 +123,6 @@ jobs:
         run: |
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global user.name "${GITHUB_ACTOR}"
-          if [ -n "$(git status --porcelain package-lock.json)" ] ; then
-            git restore package-lock.json
-          fi
           if [ -n "$(git status --porcelain dist)" ] ; then
             git add dist
             git commit -m "Save updated CSS and JS files before deployment to ${AZ_SITE_HOST}${AZ_REVIEW_BASEURL}"


### PR DESCRIPTION
This PR is targeting @mmunro-ltrr's PR branch (#565). 

@mmunro-ltrr I might be missing something obvious but it seems to me that the `git restore package-lock.json` step that is failing in the review site actions workflow on your new PR might not be necessary at all (?).