### PR TITLE
Closes #562: Update breadcrumb styles

### DIFF
--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -10,10 +10,10 @@
   @include border-radius($breadcrumb-border-radius);
   a {
     padding: 1px 0;
+    font-weight: 500;
     color: $breadcrumb-color;
     &:hover {
-      text-decoration: none;
-      border-bottom: 2px solid $azurite;
+      color: $midnight;
     }
   }
 }


### PR DESCRIPTION
Closes #562 

Motivation is to reduce prominence on breadcrumbs now that the main nav is not uppercase. Removing hover style and lightening the link weight achieves this goal.