### PR TITLE
Closes #580: Change the Hugo shortcode delimiter in headings that end up in the ToC.

### DIFF
--- a/site/content/docs/2.0/getting-started/contents.md
+++ b/site/content/docs/2.0/getting-started/contents.md
@@ -6,7 +6,7 @@ group: getting-started
 toc: true
 ---
 
-## Precompiled {{< ourname >}}
+## Precompiled {{% ourname %}}
 
 Once downloaded, unzip the compressed folder and you'll see something like this:
 
@@ -92,7 +92,7 @@ Similarly, we have options for including some or all of our compiled JavaScript.
   </tbody>
 </table>
 
-## {{< ourname >}} Source Code
+## {{% ourname %}} Source Code
 
 The {{< ourname >}} source code download includes the precompiled CSS and JavaScript assets, along with source Sass, JavaScript, and documentation. More specifically, it includes the following and more:
 

--- a/site/content/docs/2.0/getting-started/webpack.md
+++ b/site/content/docs/2.0/getting-started/webpack.md
@@ -6,7 +6,7 @@ group: getting-started
 toc: true
 ---
 
-## Installing {{< ourname >}}
+## Installing {{% ourname %}}
 
 [Install arizona-bootstrap]({{< docsref "/getting-started/download#npm" >}}) as a Node.js module using npm.
 


### PR DESCRIPTION
The Hugo issue has extensive discussion, but a trivial fix seems applicable in this case.
https://github.com/gohugoio/hugo/issues/6081#issuecomment-633147234
This is needed before the next Arizona Bootstrap release, although only the documentation is affected.