### PR TITLE
Closes #601: Force Docker containers to use amd64 for now.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.18.0-bullseye-slim
+FROM --platform=linux/amd64 node:16.18.0-bullseye-slim
 
 ENV LANG C.UTF-8
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -160,9 +160,9 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.20.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.3.tgz",
-      "integrity": "sha512-Wl5ilw2UD1+ZYprHVprxHZJCFeBWlzZYOovE4SDYLZnqCOD11j+0QzNeEWKLLTWM7nixrZEh7vNIyb76MyJg3A==",
+      "version": "7.20.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
+      "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.20.2",
@@ -11009,9 +11009,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.20.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.3.tgz",
-      "integrity": "sha512-Wl5ilw2UD1+ZYprHVprxHZJCFeBWlzZYOovE4SDYLZnqCOD11j+0QzNeEWKLLTWM7nixrZEh7vNIyb76MyJg3A==",
+      "version": "7.20.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
+      "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.20.2",


### PR DESCRIPTION
Alternative fix/workaround for local build issues affecting M1 Macs (#601)