### PR TITLE
Closes #647 Announce deprecation of main and latest CDN buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,65 @@ Arizona Bootstrap is built off of Bootstrap 4, and UA Bootstrap is built off of 
 </a>
 
 This project is tested with BrowserStack.
+
+## Content Delivery Network (CDN)
+Arizona Digital maintains a CDN for easy inclusion of Arizona Bootstrap assets
+in your project.
+
+### How the CDN is updated
+
+The CDN is updated automatically during the following scenarios:
+
+- A pull request is merged into the `main` branch of this repository
+- A pull request is merged into the `2.x` branch of this repository
+- A new release is created on the `main` or `2.x` branch.
+
+The URL structure for the CDN is as follows:
+```
+https://cdn.digital.arizona.edu/lib/arizona-bootstrap/<version bucket>/<asset type>/<filename>
+```
+
+#### The `<version bucket>` parameter can be any of the following
+- `main` Deprecated
+- `2.x` Development version of Arizona Bootstrap 2
+- `5.x` Development version of Arizona Bootstrap 5
+- A release version number, Example: `2.0.19` See [the release
+page](https://github.com/az-digital/arizona-bootstrap/releases) for a full list
+of possible options. Remove the `v` from the version number.
+- `latest-2.x` The latest stable version of Arizona Bootstrap 2
+- `latest-5.x` The latest stable version of Arizona Bootstrap 5
+- `latest` Deprecated
+
+**NOTE: `main` is deprecated and will no longer be updated as of `v2.0.20` - to
+use the latest development version of the `2.x` branch use `2.x`**
+
+**NOTE: `latest` is deprecated and will no longer be updated as of `v2.0.20` -
+to use the latest stable version of the `2.x` branch use `latest-2.x`**
+
+### Release is tagged on the `main` branch
+All tagged releases on the `main` branch will:
+- Update `latest-5.x` bucket
+- Create a new bucket for the version that was released. Example: `5.0.0`
+
+### Release is tagged on the `2.x` branch
+All tagged releases on the `2.x` branch will:
+- Update `latest-2.x` bucket
+- Create a new bucket for the version that was released. Example: `2.0.20`
+
+### Pull request is merged into `main` branch
+All code merged into the `main` branch will update `5.x` bucket.
+
+### Pull request is merged into `2.x` branch
+All code merged into the `2.x` branch will update the `2.x` bucket.
+
+#### The `<asset type>` parameter can be any of the following
+- `css`
+- `js`
+
+#### The `<filename>` parameter is the specific file you are attempting to use.
+**Examples**:
+- `arizona-bootstrap.min.css`
+- `arizona-bootstrap.css`
+
+See the [docs](https://digital.arizona.edu/arizona-bootstrap) for more
+information about the recommended version for your projects.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ of possible options. Remove the `v` from the version number.
 use the latest development version of the `2.x` branch use `2.x`**
 
 **NOTE: `latest` is deprecated and will no longer be updated as of `v2.0.20` -
-to use the latest stable version of the `2.x` branch use `latest-2.x`**
+to use the latest tagged version of the `2.x` branch use `latest-2.x`**
 
 ### Release is tagged on the `main` branch
 All tagged releases on the `main` branch will:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ https://cdn.digital.arizona.edu/lib/arizona-bootstrap/<version bucket>/<asset ty
 ```
 
 #### The `<version bucket>` parameter can be any of the following
-- `main` Deprecated
+- `main` Deprecated as of `2.0.20`
 - `2.x` Development version of Arizona Bootstrap 2
 - `5.x` Development version of Arizona Bootstrap 5
 - A release version number, Example: `2.0.19` See [the release

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ https://cdn.digital.arizona.edu/lib/arizona-bootstrap/<version bucket>/<asset ty
 page](https://github.com/az-digital/arizona-bootstrap/releases) for a full list
 of possible options. Remove the `v` from the version number.
 - `latest-2.x` The latest tagged version of Arizona Bootstrap 2
-- `latest-5.x` The latest stable version of Arizona Bootstrap 5
+- `latest-5.x` The latest tagged version of Arizona Bootstrap 5
 - `latest` Deprecated
 
 **NOTE: `main` is deprecated and will no longer be updated as of `v2.0.20` - to

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ page](https://github.com/az-digital/arizona-bootstrap/releases) for a full list
 of possible options. Remove the `v` from the version number.
 - `latest-2.x` The latest tagged version of Arizona Bootstrap 2
 - `latest-5.x` The latest tagged version of Arizona Bootstrap 5
-- `latest` Deprecated
+- `latest` Deprecated as of `2.0.20`
+
 
 **NOTE: `main` is deprecated and will no longer be updated as of `v2.0.20` - to
 use the latest development version of the `2.x` branch use `2.x`**

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ All tagged releases on the `2.x` branch will:
 - Create a new bucket for the version that was released. Example: `2.0.20`
 
 ### Pull request is merged into `main` branch
-All code merged into the `main` branch will update `5.x` bucket.
+All code merged into the `main` branch will update the `5.x` bucket.
 
 ### Pull request is merged into `2.x` branch
 All code merged into the `2.x` branch will update the `2.x` bucket.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ https://cdn.digital.arizona.edu/lib/arizona-bootstrap/<version bucket>/<asset ty
 - A release version number, Example: `2.0.19` See [the release
 page](https://github.com/az-digital/arizona-bootstrap/releases) for a full list
 of possible options. Remove the `v` from the version number.
-- `latest-2.x` The latest stable version of Arizona Bootstrap 2
+- `latest-2.x` The latest tagged version of Arizona Bootstrap 2
 - `latest-5.x` The latest stable version of Arizona Bootstrap 5
 - `latest` Deprecated
 


### PR DESCRIPTION
Closes #647 

This should be included in the last release to update the "main" bucket `https://cdn.digital.arizona.edu/lib/arizona-bootstrap/main` in our CDN.