### PR TITLE
Closes #652: Add dependabot support for Github actions & Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,10 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    reviewers:
+      - "az-digital/developers"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,15 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 10
+  - package-ecosystem: "docker"
+      directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "az-digital/developers"
+    open-pull-requests-limit: 10
+    labels:
+      - "ci"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
       interval: "weekly"
     reviewers:
       - "az-digital/developers"
+    labels:
+      - "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 10
   - package-ecosystem: "docker"
-      directory: "/"
+    directory: "/"
     schedule:
       interval: "weekly"
     reviewers:


### PR DESCRIPTION
Enable dependabot alerts for Github actions. Closes #652 