### PR TITLE
az-digital/az_quickstart#2331 Change slack channel names from azdigital-general to azdigital-support

### DIFF
--- a/site/data/slack-channels.yml
+++ b/site/data/slack-channels.yml
@@ -51,6 +51,6 @@
   description:
     - purpose: "For topics concerning documentation for Arizona Digital and its products"
 
-- channel: "#azdigital-general"
+- channel: "#azdigital-support"
   description:
-    - purpose: "For general discussion and side conversations"
+    - purpose: "For Arizona Digital product support"


### PR DESCRIPTION
Parent issue az-digital/az_quickstart#2331