### PR TITLE
Update links to UA Brand site

### DIFF
--- a/site/content/docs/5.0/examples/navbar/index.html
+++ b/site/content/docs/5.0/examples/navbar/index.html
@@ -36,7 +36,7 @@ title: Navbar template
                     <a href="https://quickstart.arizona.edu/" class="text-muted nav-link nav-link-https--quickstartarizonaedu-">Utility 1</a>
                   </li>
                   <li class="nav-item">
-                    <a href="https://brand.arizona.edu/" class="text-muted nav-link nav-link-https--brandarizonaedu-">Utility 2</a>
+                    <a href="https://marcom.arizona.edu/" class="text-muted nav-link nav-link-https--brandarizonaedu-">Utility 2</a>
                   </li>
                 </ul>
               </nav>

--- a/site/content/docs/5.0/utilities/colors.md
+++ b/site/content/docs/5.0/utilities/colors.md
@@ -8,7 +8,7 @@ toc: true
 
 ## Overview
 
-{{< ourname >}} offers two "types" or colors: Brand colors and contextual (theme) colors. Brand colors are a collection of Arizona Branded colors offered by the <a href="https://brand.arizona.edu/ua-color-palette" target="_blank">Brand website</a>. Contextual colors are a smaller selection of Brand colors that are used to convey meaning and contextual information (e.g., success, warning, dager).
+{{< ourname >}} offers two "types" or colors: Brand colors and contextual (theme) colors. Brand colors are a collection of Arizona Branded colors offered by the <a href="https://marcom.arizona.edu/brand-guidelines/colors" target="_blank">Brand website</a>. Contextual colors are a smaller selection of Brand colors that are used to convey meaning and contextual information (e.g., success, warning, dager).
 
 When using these colors, it is important to maintain sufficient color contrast between your text color and background color. You can utilize the <a href="https://webaim.org/resources/contrastchecker/" target="_blank">WebAim Color Contrast Checker</a> to verify your color contrast. Or, for your convenience, {{< ourname >}} also provides a [helpful tool]({{< docsref "/getting-started/color-contrast" >}}) to determine which Brand text colors have sufficient color contrast on other Brand background colors.
 


### PR DESCRIPTION
Hello!

You may already be aware, but just in case: 
I was looking that the color information for Arizona bootstrap, and when I clicked the link to go to the UA Brand page, I got a cert error.

It looks like maybe they renamed from brand.arizona.edu to marcom.arizona.edu? I think this should update references on the site from the old domain to the new one.

I'll reach out to them next, and I can update this PR with their response if you'd like.

Thanks!
Zach