### PR TITLE
Closes #1179: Added groups to dependabot config.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
     labels:
       - "ci"
       - "2.0.x only"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -25,6 +30,11 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "ci"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
Copied from https://github.com/twbs/examples/blob/main/.github/dependabot.yml

I believe this would mean that only 2 dependabot PRs would be created for each of our release branches each week.  One for production dependencies and one for dev dependencies.