### PR TITLE
Closes #1508: Remove hard-coded 2.x reference in release workflow in preparation for creating 5.x releases.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.REPO_DISPATCH_TOKEN }}
-          ref: 2.x
 
       - name: Set variables for Docker images
         run: |


### PR DESCRIPTION
Removes hard-coded reference to 2.x in release workflow that would prevent 5.x releases from working.