### PR TITLE
Closes #1497: only update the `dist` directory subtree on releases, not after checking or merging PRs.

### DIFF
--- a/.github/workflows/review-site.yml
+++ b/.github/workflows/review-site.yml
@@ -133,15 +133,6 @@ jobs:
           sudo find . -path "./.git" -prune -o -exec chown 1000:1000 {} \;
           sudo chown 1000:1000 .
           docker run --rm -e "AZ_SITE_BASE_URL=${AZ_REVIEW_BASEURL}" -e "AZ_SITE_HOST=${AZ_SITE_HOST}" -v $(pwd):"${AZ_BOOTSTRAP_SOURCE_DIR}" "$AZ_EPHEMERAL_IMAGE" expose-review-site
-      - name: Push back the updated deployable files to the repository (CSS, JS, and so on)
-        run: |
-          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git config --global user.name "${GITHUB_ACTOR}"
-          if [ -n "$(git status --porcelain dist)" ] ; then
-            git add dist
-            git commit -m "Save updated CSS and JS files before deployment to ${AZ_SITE_HOST}${AZ_REVIEW_BASEURL}"
-            git push --force origin "HEAD:${AZ_TRIMMED_REF}"
-          fi
         shell: sh
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
The documentation part of the original Issue isn't handled here. This pull request has not been tested on the replica of the Arizona Bootstrap repository, and will directly affect all subsequent pull requests inn the main repository, but is a very simple change (deletion of part of the GitHub Actions configuration) which can be rolled back if it proves problematic. The `.gitignore` file still does not prevent commits changing the `dist/` subtree, following the practice in upstream Bootstrap, where the derived CSS and JS files are updated on each release.