### PR TITLE
Closes #1497: Add /dist to gitignore, don't update /dist assets in PR branches automatically.

### DIFF
--- a/.github/workflows/review-site.yml
+++ b/.github/workflows/review-site.yml
@@ -134,11 +134,12 @@ jobs:
           sudo chown 1000:1000 .
           docker run --rm -e "AZ_SITE_BASE_URL=${AZ_REVIEW_BASEURL}" -e "AZ_SITE_HOST=${AZ_SITE_HOST}" -v $(pwd):"${AZ_BOOTSTRAP_SOURCE_DIR}" "$AZ_EPHEMERAL_IMAGE" expose-review-site
       - name: Push back the updated deployable files to the repository (CSS, JS, and so on)
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global user.name "${GITHUB_ACTOR}"
           if [ -n "$(git status --porcelain dist)" ] ; then
-            git add dist
+            git add -f dist
             git commit -m "Save updated CSS and JS files before deployment to ${AZ_SITE_HOST}${AZ_REVIEW_BASEURL}"
             git push --force origin "HEAD:${AZ_TRIMMED_REF}"
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore dist files
+/dist/
+
 # Ignore docs files
 /_site/
 # Hugo folders


### PR DESCRIPTION
Alternate PR for #1497 

- Adds `/dist` to .gitignore
- Updates review site workflow to skip updating /dist assets in PR branches
- Adds `-f` argument to `git add` command in review site workflow step to override gitignore in main/2.x branches