### PR TITLE
Closes #1528: Only update CDN assets if /dist was updated.

### DIFF
--- a/.github/workflows/cdn-deploy-head.yml
+++ b/.github/workflows/cdn-deploy-head.yml
@@ -2,6 +2,8 @@ name: Build & deploy CDN assets (HEAD)
 run-name: Build & deploy CDN assets for `${{ github.ref_name }}` branch update.
 on:
   push:
+    paths:
+      - 'dist/**'
     branches:
       - main
       - 2.x


### PR DESCRIPTION
We should only be triggering the workflow to update CDN assets for main/2.0.x if there are changes to dist files.