### PR TITLE
Closes #1528: Only update CDN assets if /dist was updated. (2.x)

### DIFF
--- a/.github/workflows/cdn-deploy-head.yml
+++ b/.github/workflows/cdn-deploy-head.yml
@@ -2,6 +2,8 @@ name: Build & deploy CDN assets (HEAD)
 run-name: Build & deploy CDN assets for `${{ github.ref_name }}` branch update.
 on:
   push:
+    paths:
+      - 'dist/**'
     branches:
       - main
       - 2.x


### PR DESCRIPTION
2.x backport of #1529 