### PR TITLE
Closes #1533: Move our deprecated scss to the top of the list of Arizona Bootstrap imports

### DIFF
--- a/scss/arizona-bootstrap.scss
+++ b/scss/arizona-bootstrap.scss
@@ -56,13 +56,14 @@
 @import "../node_modules/bootstrap/scss/utilities/api";
 
 // Arizona Bootstrap imports.
+@import "deprecated/accordion";
+@import "deprecated/nav";
 @import "legacy/mixins";
 @import "override/reboot";
 @import "custom/styles";
 @import "custom/typography";
 @import "override/typography";
 @import "override/accordion";
-@import "deprecated/accordion";
 @import "legacy/badge";
 @import "override/breadcrumb";
 @import "mixins/buttons";
@@ -74,7 +75,6 @@
 @import "custom/card";
 @import "override/dropdown";
 @import "override/nav";
-@import "deprecated/nav";
 @import "override/navbar";
 @import "custom/navbar-offcanvas";
 @import "custom/background-wrapper";


### PR DESCRIPTION
Moves imports of our deprecated scss to the top of the list of Arizona Bootstrap imports.

### Related issues
 - #1533

### How to Test
 - Confirm deprecated accordion styling is maintained: https://review.digital.arizona.edu/arizona-bootstrap/issue/1533/docs/5.0/backwards-compatibility/
 - Confirm deprecated `.nav-tabs-lg` styling is maintained (e.g., using DevTools to add the class): https://review.digital.arizona.edu/arizona-bootstrap/issue/1533/docs/5.0/components/navs-tabs/#tabs