### PR TITLE
Fix remaining Uncaught ReferenceError: bootstrap is not defined errors (targeting issue/1496)

### DIFF
--- a/build/rollup.config.mjs
+++ b/build/rollup.config.mjs
@@ -61,7 +61,7 @@ const rollupConfig = {
 }
 
 if (!ESM) {
-  rollupConfig.output.name = 'arizona-bootstrap'
+  rollupConfig.output.name = 'arizonaBootstrap'
 }
 
 export default rollupConfig

--- a/site/assets/js/partials/snippets.js
+++ b/site/assets/js/partials/snippets.js
@@ -20,7 +20,7 @@ export default () => {
   // Instantiate all tooltips in a docs
   document.querySelectorAll('[data-bs-toggle="tooltip"]')
     .forEach(tooltip => {
-      new arizona-bootstrap.Tooltip(tooltip)
+      new arizonaBootstrap.Tooltip(tooltip)
     })
 
   // --------
@@ -29,7 +29,7 @@ export default () => {
   // Instantiate all popovers in docs
   document.querySelectorAll('[data-bs-toggle="popover"]')
     .forEach(popover => {
-      new arizona-bootstrap.Popover(popover)
+      new arizonaBootstrap.Popover(popover)
     })
 
   // -------------------------------
@@ -50,7 +50,7 @@ export default () => {
   // Instantiate all toasts in docs pages only
   document.querySelectorAll('.bd-example .toast')
     .forEach(toastNode => {
-      const toast = new arizona-bootstrap.Toast(toastNode, {
+      const toast = new arizonaBootstrap.Toast(toastNode, {
         autohide: false
       })
 
@@ -63,9 +63,9 @@ export default () => {
   const toastLiveExample = document.getElementById('liveToast')
 
   if (toastTrigger) {
-    const toastBootstrap = arizona-bootstrap.Toast.getOrCreateInstance(toastLiveExample)
+    const toastArizonaBootstrap = arizonaBootstrap.Toast.getOrCreateInstance(toastLiveExample)
     toastTrigger.addEventListener('click', () => {
-      toastarizona-bootstrap.show()
+      toastArizonaBootstrap.show()
     })
   }
   // js-docs-end live-toast
@@ -103,7 +103,7 @@ export default () => {
   // Instantiate all non-autoplaying carousels in docs
   document.querySelectorAll('.carousel:not([data-bs-ride="carousel"])')
     .forEach(carousel => {
-      arizona-bootstrap.Carousel.getOrCreateInstance(carousel)
+      arizonaBootstrap.Carousel.getOrCreateInstance(carousel)
     })
 
   // -------------------------------

--- a/site/assets/js/partials/snippets.js
+++ b/site/assets/js/partials/snippets.js
@@ -20,7 +20,7 @@ export default () => {
   // Instantiate all tooltips in a docs
   document.querySelectorAll('[data-bs-toggle="tooltip"]')
     .forEach(tooltip => {
-      new bootstrap.Tooltip(tooltip)
+      new arizona-bootstrap.Tooltip(tooltip)
     })
 
   // --------
@@ -29,7 +29,7 @@ export default () => {
   // Instantiate all popovers in docs
   document.querySelectorAll('[data-bs-toggle="popover"]')
     .forEach(popover => {
-      new bootstrap.Popover(popover)
+      new arizona-bootstrap.Popover(popover)
     })
 
   // -------------------------------
@@ -50,7 +50,7 @@ export default () => {
   // Instantiate all toasts in docs pages only
   document.querySelectorAll('.bd-example .toast')
     .forEach(toastNode => {
-      const toast = new bootstrap.Toast(toastNode, {
+      const toast = new arizona-bootstrap.Toast(toastNode, {
         autohide: false
       })
 
@@ -63,9 +63,9 @@ export default () => {
   const toastLiveExample = document.getElementById('liveToast')
 
   if (toastTrigger) {
-    const toastBootstrap = bootstrap.Toast.getOrCreateInstance(toastLiveExample)
+    const toastBootstrap = arizona-bootstrap.Toast.getOrCreateInstance(toastLiveExample)
     toastTrigger.addEventListener('click', () => {
-      toastBootstrap.show()
+      toastarizona-bootstrap.show()
     })
   }
   // js-docs-end live-toast
@@ -103,7 +103,7 @@ export default () => {
   // Instantiate all non-autoplaying carousels in docs
   document.querySelectorAll('.carousel:not([data-bs-ride="carousel"])')
     .forEach(carousel => {
-      bootstrap.Carousel.getOrCreateInstance(carousel)
+      arizona-bootstrap.Carousel.getOrCreateInstance(carousel)
     })
 
   // -------------------------------


### PR DESCRIPTION
Still noticing `Uncaught ReferenceError: bootstrap is not defined` console errors when reviewing #1547 (specifically on https://review.digital.arizona.edu/arizona-bootstrap/issue/1496/docs/5.0/components/modal/).

We should be referencing our global `arizona-bootstrap` but `arizona-bootstrap` is not a valid name for an object reference (variable name) in JS so this updates the rollup config that controls that and some remaining references in the docs JS files.