### PR TITLE
Closes #1552: Add callout-info back to callouts page

### DIFF
--- a/scss/custom/_callouts.scss
+++ b/scss/custom/_callouts.scss
@@ -36,7 +36,7 @@
 }
 
 // Do not create callouts for the "light" and "dark" theme colors.
-@each $color, $value in map-remove($theme-colors, "info", "light", "dark") {
+@each $color, $value in map-remove($theme-colors, "light", "dark") {
   .callout-#{$color} {
     @include callout-variant($color, $value);
   }

--- a/site/content/docs/5.0/backwards-compatibility.md
+++ b/site/content/docs/5.0/backwards-compatibility.md
@@ -116,11 +116,9 @@ For our custom [Callouts component]({{< docsref "/components/callouts/" >}}), th
  - `.callout-river`
  - `.callout-silver`
  - `.callout-mesa`
- - `.callout-info`
  - `.callout-light`
  - `.callout-dark`
 
-Similar callout variants exist for many of those removed: for example, as a replacement for `.callout-info`, you may use `.callout-sky` instead.
 
 ## Removed JavaScript
 

--- a/site/content/docs/5.0/components/callouts.md
+++ b/site/content/docs/5.0/components/callouts.md
@@ -9,9 +9,9 @@ redirect_from:
 toc: true
 ---
 
-## Brand
-
 Callouts call attention to a small portion of content that needs to stand out against the rest of the page. They can be used with [brand colors]({{< docsref "/customize/color#all-colors" >}}) or [theme colors]({{< docsref "/customize/color#theme-colors" >}}).
+
+## Brand
 
 {{< example >}}
 {{< callout.inline >}}
@@ -25,12 +25,17 @@ Callouts call attention to a small portion of content that needs to stand out ag
 {{< /callout.inline >}}
 {{< /example >}}
 
-
 ## Contextual (Theme)
+
+
+<div class="callout callout-azurite">
+  <p><strong>Note:</strong> Although an "info" callout is included below, callouts of any brand color may be used for informational purposes (like this azurite callout).</p>
+</div>
+
 
 {{< example >}}
 {{< callout.inline >}}
-{{ $excluded := slice "info" "light" "dark" }}
+{{ $excluded := slice "light" "dark" }}
 {{ $siteThemeColors := index $.Site.Data "theme-colors" }}
 {{- range $color := where $siteThemeColors "name" "not in" $excluded -}}
   <div class="callout callout-{{ $color.name }}">


### PR DESCRIPTION
This PR does the following:

- Adds callout-info back to the contextual section of the Callouts page
- Keeps the heading the same color as the body, as with the other contextual callouts
- Adds a note to the Contextual (Theme) section that any brand color may be used for informational purposes
- Removes `callout-info` information from the Backwards Compatibility page since it is no longer a removed callout variant

### Review site

https://review.digital.arizona.edu/arizona-bootstrap/issue/1552/docs/5.0/components/callouts/

