### PR TITLE
Closes #1560: Fix underline behavior using custom hover-text-underline class

### DIFF
--- a/scss/custom/_hover.scss
+++ b/scss/custom/_hover.scss
@@ -1,5 +1,9 @@
 // Hover utility
 
+.hover .hover-text-underline {
+  text-decoration: none;
+}
+
 .hover:hover,
 .hover:focus {
   .hover-text-underline {

--- a/site/content/docs/5.0/utilities/hover.md
+++ b/site/content/docs/5.0/utilities/hover.md
@@ -10,12 +10,14 @@ toc: true
 
 Add a text underline on hover with the `.hover` class on the parent element and the `.hover-text-underline` class on the target child element.
 
+When the element with the `.hover` class does **not** have an active hover state, the `.hover-text-underline` class will remove any existing underline (such as the [underline applied to links]({{< docsref "/content/reboot#links" >}}) by default).
+
 {{< example >}}
 <div class="card hover" style="width: 18rem;">
   <div class="card-body">
     <h2 class="card-title mt-0 h4 hover-text-underline">This is a card title</h2>
-    <p>This card's title should have an underline applied when it receives hover or focus anywhere on the card.</p>
-    <a class="stretched-link" href="#">This is a link</a>
+    <p>This card's title and link should have an underline applied when it receives hover or focus anywhere on the card.</p>
+    <a class="stretched-link hover-text-underline" href="#">This is a link</a>
   </div>
 </div>
 {{< /example >}}


### PR DESCRIPTION
This PR does the following related to the custom Hover text decoration utility:

- Adds `text-decoration: none` styling for the `.hover-text-underline` class when the `.hover` element does **not** have an active hover or focus state.
- Updates the docs page to note this behavior.

### How to Test

Review site: 
Arizona Bootstrap 2: https://digital.arizona.edu/arizona-bootstrap/docs/2.0/utilities/hover/