### PR TITLE
Closes #1574: Remove unused alerts customization in Arizona Bootstrap 5

### DIFF
--- a/scss/legacy/_mixins.scss
+++ b/scss/legacy/_mixins.scss
@@ -1,22 +1,6 @@
 // Overrides to Mixins
 
 /*
- * > ALERTS
- */
-@mixin alert-variant($background) {
-  @include text-color-contrast($background);
-  background-color: $background;
-  border: 0;
-
-  .alert-link {
-    color: $alert-text-color;
-  }
-  hr {
-    border-top-color: $alert-text-color;
-  }
-}
-
-/*
  * > BACKGROUND COLORS
  */
 


### PR DESCRIPTION
This PR removes the alert-variant() mixin from the legacy mixins. We don't need it in Arizona Bootstrap 5 and it was never used in Arizona Bootstrap 2: the import of the custom alert styling was commented out in the main scss file:

https://github.com/az-digital/arizona-bootstrap/blob/2.x/scss/arizona-bootstrap.scss#L60

Arizona Bootstrap 5 will not contain any customizations specific to the Alerts component.

### How to test
Review site: https://review.digital.arizona.edu/arizona-bootstrap/issue/1574/docs/5.0/components/alerts/
Arizona Bootstrap 2: https://digital.arizona.edu/arizona-bootstrap/docs/2.0/components/alerts/