### PR TITLE
Closes #1593: Fix hover styling for demo buttons on the Background Wrappers page

### DIFF
--- a/site/assets/scss/_custom-docs.scss
+++ b/site/assets/scss/_custom-docs.scss
@@ -172,12 +172,11 @@
   }
 }
 
-
 //
 // > COMPONENTS
 //
 
-// >> Background Wrapper Demo
+// >> Background Wrappers
 .btn-background-wrapper-demo,
 .btn-triangle-background-demo {
   position: relative;
@@ -190,30 +189,6 @@
   }
 }
 
-
-.btn-background-wrapper-demo {
-  &:hover {
-    color: $white;
-  }
-
-  &.bg-sky,
-  &.bg-oasis,
-  &.bg-cool-gray,
-  &.bg-warm-gray,
-  &.bg-leaf,
-  &.bg-silver {
-    &:hover {
-      color: $midnight;
-    }
-  }
-  &.bg-bloom,
-  &.bg-white {
-    &:hover {
-      color: $black;
-    }
-  }
-}
-
 .btn-triangle-background-demo {
   background-color: $white;
 
@@ -223,6 +198,31 @@
   }
 }
 
+.btn-background-wrapper-demo:hover {
+  @each $color, $value in $colors {
+    &.text-bg-#{$color} {
+      @if $color == "midnight" or $color == "ash" or $color == "black" {
+        /* stylelint-disable-next-line declaration-no-important */
+        background-color: tint-color($value, 15%) !important;
+      }
+      @else {
+        /* stylelint-disable-next-line declaration-no-important */
+        background-color: shade-color($value, 10%) !important;
+      }
+    }
+  }
+}
+
+// >> Navs & Tabs
+.bd-example > .nav-utility {
+  margin-bottom: revert;
+}
+
+//
+// > CONTENT
+//
+
+// >> Font
 .proxima-nova-bold {
   font-family: proxima-nova, sans-serif;
   font-style: normal;
@@ -365,9 +365,4 @@
 
 .pn strong {
   font-weight: 700;
-}
-
-// >> Utility Links
-.bd-example > .nav-utility {
-  margin-bottom: revert;
 }

--- a/site/content/docs/5.0/components/background-wrappers.md
+++ b/site/content/docs/5.0/components/background-wrappers.md
@@ -19,7 +19,7 @@ Click on the background color options below to see a live preview of what the ba
   {{< wrapperdemo.inline >}}
   {{ range (index $.Site.Data "colors") }}
   <div class="col-6 col-md-4 col-lg-3 col-xl-2 mt-3">
-    <button id="background-wrapper-btn-{{ .name }}" data-bgcolor="{{ .name }}" class="btn d-block w-100 px-2 btn-background-wrapper-demo text-bg-{{ .name }}">{{ .name | title }}</button>
+    <button id="background-wrapper-btn-{{ .name }}" data-bgcolor="{{ .name }}" class="btn d-block w-100 px-2 btn-background-wrapper-demo {{ if eq .name "chili" }}btn-red{{ else if eq .name "blue" }}btn-blue{{ else }}text-bg-{{ .name }}{{ end }}">{{ .name | title }}</button>
   </div>
   {{ end }}
   {{< /wrapperdemo.inline >}}


### PR DESCRIPTION
### Changes in this PR
 - Updates hover styling for color option buttons on the Background Wrappers docs page
 - Changes "Chili" button to use `.btn-red` and "Blue" button to use `.btn-blue`
 - Minor reorganization of `_custom-docs.scss`

### How to test
Review site: https://review.digital.arizona.edu/arizona-bootstrap/issue/1593/docs/5.0/components/background-wrappers/