### PR TITLE
Closes #1598: Fix duplicate subdirectories in path to docs.css

### DIFF
--- a/site/layouts/partials/stylesheet.html
+++ b/site/layouts/partials/stylesheet.html
@@ -17,7 +17,7 @@
 {{- $sassOptions := dict "outputStyle" "expanded" "precision" 6 -}}
 {{- $postcssOptions := dict "use" "autoprefixer" "noMap" true -}}
 
-{{- $targetDocsCssPath := path.Join "docs" .Site.Params.docs_version "assets/css/docs.css" | relURL -}}
+{{- $targetDocsCssPath := path.Join "docs" .Site.Params.docs_version "assets/css/docs.css" -}}
 
 {{ if hugo.IsProduction -}}
   {{- $sassOptions = merge $sassOptions (dict "outputStyle" "compressed") -}}


### PR DESCRIPTION
### Changes in this PR
 - Remove an extra RelURL function applied to the path to the docs.css file. 
   - Before: /arizona-bootstrap/issue/1598/arizona-bootstrap/issue/1589/docs/5.0/assets/css/docs.css
   - After: /arizona-bootstrap/issue/1598/docs/5.0/assets/css/docs.css

### How to test
Review site: https://review.digital.arizona.edu/arizona-bootstrap/issue/1598/docs/5.0/

Confirm that docs.css is located at the "After" URL above.