### PR TITLE
Closes #1602: Blocked aria-hidden error when closing a modal

### DIFF
--- a/js/index.esm.js
+++ b/js/index.esm.js
@@ -17,4 +17,12 @@ export { default as ScrollSpy } from '../node_modules/bootstrap/js/src/scrollspy
 export { default as Tab } from '../node_modules/bootstrap/js/src/tab.js'
 export { default as Toast } from '../node_modules/bootstrap/js/src/toast.js'
 export { default as Tooltip } from '../node_modules/bootstrap/js/src/tooltip.js'
+export { default as fixModalAriaHidden } from './src/modal.js'
 export { default as Offcanvasmenu } from './src/offcanvasmenu.js'
+
+/**
+ * Temporary fix for blocked aria-hidden attribute on modals.
+ * See https://github.com/az-digital/arizona-bootstrap/issues/1602.
+ */
+/* global fixModalAriaHidden */
+fixModalAriaHidden()

--- a/js/index.umd.js
+++ b/js/index.umd.js
@@ -17,6 +17,7 @@ import ScrollSpy from '../node_modules/bootstrap/js/src/scrollspy.js'
 import Tab from '../node_modules/bootstrap/js/src/tab.js'
 import Toast from '../node_modules/bootstrap/js/src/toast.js'
 import Tooltip from '../node_modules/bootstrap/js/src/tooltip.js'
+import fixModalAriaHidden from './src/modal.js'
 import Offcanvasmenu from './src/offcanvasmenu.js'
 
 export default {
@@ -32,5 +33,12 @@ export default {
   Tab,
   Toast,
   Tooltip,
+  fixModalAriaHidden,
   Offcanvasmenu
 }
+
+/**
+ * Temporary fix for blocked aria-hidden attribute on modals.
+ * See https://github.com/az-digital/arizona-bootstrap/issues/1602.
+ */
+fixModalAriaHidden()

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -1,0 +1,23 @@
+/**
+ * --------------------------------------------------------------------------
+ * Arizona Bootstrap: modal.js
+ * Licensed under MIT (https://github.com/az-digital/arizona-bootstrap/blob/main/LICENSE)
+ * --------------------------------------------------------------------------
+ */
+
+/**
+ * Temporary fix for blocked aria-hidden attribute on modals.
+ * See https://github.com/az-digital/arizona-bootstrap/issues/1602.
+ */
+function fixModalAriaHidden() {
+  const modals = document.querySelectorAll('.modal')
+  for (const modal of modals) {
+    modal.addEventListener('hide.bs.modal', () => {
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur()
+      }
+    })
+  }
+}
+
+export { fixModalAriaHidden as default }

--- a/js/src/offcanvasmenu.js
+++ b/js/src/offcanvasmenu.js
@@ -1,7 +1,7 @@
 /**
  * --------------------------------------------------------------------------
  * Arizona Bootstrap: offcanvasmenu.js
- * Licensed under MIT (https://github.com/az-digital/arizona-bootstrap/blob/master/LICENSE)
+ * Licensed under MIT (https://github.com/az-digital/arizona-bootstrap/blob/main/LICENSE)
  * --------------------------------------------------------------------------
  */
 


### PR DESCRIPTION
### Changes in this PR
 - Adds a JavaScript function to temporarily resolve an accessibility issue with the aria-hidden attribute not being applied to modals upon closing. This issue is expected to be fixed in upstream Bootstrap with version 5.4.0.
 - Corrects the GitHub MIT license link in offcanvasmenu.js.

### How to test

1. Go to https://review.digital.arizona.edu/arizona-bootstrap/main/docs/5.0/components/modal/#live-demo
2. Click the Launch demo modal button
3. Click the Close button at the bottom of the modal
4. View the browser console and confirm that no errors or warnings are shown
5. Confirm that the modal element has a hide.bs.modal event listener added


