### PR TITLE
Closes #1613: Put back primary and secondary color definitions

### DIFF
--- a/scss/override/_maps.scss
+++ b/scss/override/_maps.scss
@@ -1,2 +1,0 @@
-// Remove primary and secondary colors from the $theme-colors map.
-$theme-colors: map-remove($theme-colors, "primary", "secondary");

--- a/scss/override/_variables.scss
+++ b/scss/override/_variables.scss
@@ -3,6 +3,8 @@
 */
 
 // >> Theme Colors
+$primary: $red;
+$secondary: $blue;
 $success: $leaf;
 $info: $sky;
 $warning: #f19e1f; // to be used for warnings only


### PR DESCRIPTION
## Description
Puts back primary and secondary color definitions

## Related Issue
- Closes #1613 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
