### PR TITLE
Add `.is-active` to `nav-link`'s in our nav.scss override file

### DIFF
--- a/dist/css/arizona-bootstrap.css
+++ b/dist/css/arizona-bootstrap.css
@@ -20772,7 +20772,7 @@ h6,
   color: #fff;
 }
 
-.nav-link.active, .nav-link:active {
+.nav-link.active, .nav-link:active, .nav-link.is-active {
   color: #001c48;
   background-color: #e9ecef;
   border-radius: var(--bs-border-radius);
@@ -20787,14 +20787,14 @@ h6,
 .nav-tabs .nav-link {
   background-color: #e9ecef;
 }
-.nav-tabs .nav-link.active, .nav-tabs .nav-link:active {
+.nav-tabs .nav-link.active, .nav-tabs .nav-link:active, .nav-tabs .nav-link.is-active {
   border-radius: var(--bs-border-radius) var(--bs-border-radius) 0 0;
 }
 .nav-tabs .nav-link.disabled, .nav-tabs .nav-link:disabled {
   background-color: initial;
 }
 
-.nav.nav-underline .nav-link.active, .nav.nav-underline .nav-link:active {
+.nav.nav-underline .nav-link.active, .nav.nav-underline .nav-link:active, .nav.nav-underline .nav-link.is-active {
   background-color: #fff;
   border-radius: revert;
 }

--- a/scss/override/_nav.scss
+++ b/scss/override/_nav.scss
@@ -2,7 +2,8 @@
 
 .nav-link {
   &.active,
-  &:active {
+  &:active,
+  &.is-active {
     color: $nav-tabs-link-active-color;
     background-color: $nav-tabs-link-bg;
     @include border-radius($nav-pills-border-radius);
@@ -22,7 +23,8 @@
     background-color: $nav-tabs-link-bg;
 
     &.active,
-    &:active {
+    &:active,
+    &.is-active {
       @include border-radius($nav-tabs-border-radius $nav-tabs-border-radius 0 0);
     }
 
@@ -35,7 +37,8 @@
 
 .nav.nav-underline .nav-link {
   &.active,
-  &:active {
+  &:active,
+  &.is-active {
     background-color: $nav-tabs-link-active-bg;
     @include border-radius(revert);
   }


### PR DESCRIPTION
Closes [4383 Quickstart Issue](https://github.com/az-digital/az_quickstart/issues/4383)

Drupal core uses the `.is-active` class for nav-links, whereas Bootstrap uses `active` links. This causes all active nav-links on sidebars in quickstart to not be highlighted when active.

Back in Arizona Bootstrap 2.x, we added `.is-active` as part of our nav.scss override file:
https://github.com/az-digital/arizona-bootstrap/blob/005082501a4dd3ebee0e668eb6e2218f15a9f1dc/scss/_nav.scss#L19-L21

We should do the same in Arizona Bootstrap 5

## Conditions of satisfaction
- [ ] All active sidebar menu's in quickstart should now be highlighted with `$nav-tabs-link-bg`

