### PR TITLE
Closes #1464: An alternative version to updating the .js to toggle inaccessible color combinations in the docs.

### DIFF
--- a/site/assets/js/custom-docs.js
+++ b/site/assets/js/custom-docs.js
@@ -1,17 +1,6 @@
 (function ($) {
   'use strict'
 
-  // COLOR CONTRAST TABLE
-  $('#hide-inaccessible').change(function () {
-    if ($('#hide-inaccessible').is(':checked')) {
-      $('.inaccessible').css('visibility', 'hidden') // checked
-      $('.inaccessible').parent().css('opacity', '0')
-    } else {
-      $('.inaccessible').css('visibility', 'visible') // unchecked
-      $('.inaccessible').parent().css('opacity', '1')
-    }
-  })
-
   var specimenButtons = document.querySelectorAll('.js-specimen-modal-trigger');
   [].forEach.call(specimenButtons, function (specimenButton) {
     specimenButton.addEventListener('click', specimenChangeFont)

--- a/site/content/docs/5.0/getting-started/color-contrast.md
+++ b/site/content/docs/5.0/getting-started/color-contrast.md
@@ -4,6 +4,9 @@ title: Color Contrast
 description: A brief overview of Arizona Bootstrap's brand colors and color contrast.
 group: getting-started
 toc: true
+extra_js:
+  - src: "/docs/5.0/assets/js/toggle-visible.js"
+    async: true
 ---
 
 ## Overview

--- a/site/static/docs/5.0/assets/js/toggle-visible.js
+++ b/site/static/docs/5.0/assets/js/toggle-visible.js
@@ -1,0 +1,30 @@
+// Support the control that toggles visibility of inaccessible color combinations.
+(() => {
+  'use strict'
+
+  const hideBox = document.querySelector('#hide-inaccessible')
+
+  if (!hideBox) {
+    return
+  }
+
+  const flaggedAsInaccessible = document.querySelectorAll('.inaccessible')
+
+  hideBox.addEventListener('change', () => {
+    if (hideBox.checked) {
+      Array.prototype.forEach.call(flaggedAsInaccessible, inaccessible => {
+        const parent = inaccessible.parentElement
+        if (parent) {
+          parent.classList.add('invisible')
+        }
+      })
+    } else {
+      Array.prototype.forEach.call(flaggedAsInaccessible, inaccessible => {
+        const parent = inaccessible.parentElement
+        if (parent) {
+          parent.classList.remove('invisible')
+        }
+      })
+    }
+  })
+})()


### PR DESCRIPTION
There were a few suggested changes to https://github.com/az-digital/arizona-bootstrap/pull/1636, so this PR is a way to gather them together for easy reference, rather than as comments there.

People viewing the table of different text and background colors in the docs should have an interactive toggle, allowing them to turn on or off the display of the inaccessible combinations, but only at that one place. That's best addressed by having a .js file loaded just on the page containing the table, with a close analogy being the sample code for validating forms. The file for that is at `site/static/docs/5.0/assets/js/validate-forms.js`, and is included in the page that needs it by the `extra_js:` mechanism in `validation_md`, so we can make a new `toggle-visible.js` file beside that, then reference it in `color-contrast.md`.