### PR TITLE
Closes #1646: Portrait images are not cropped correctly in Photo Galleries with Slider Crop style

### DIFF
--- a/scss/custom/_photo-gallery.scss
+++ b/scss/custom/_photo-gallery.scss
@@ -42,18 +42,16 @@
   }
 }
 
+.az-gallery-image {
+  min-height: 0;
+}
+
 .az-gallery-caption {
   position: static;
   width: 100%;
   padding: .75rem;
   margin-right: auto;
   margin-left: auto;
-}
-
-.az-gallery-grid, .az-gallery-slider-full {
-  .az-gallery-image {
-    min-height: 0;
-  }
 }
 
 .az-gallery-slider-full .az-gallery-caption {
@@ -63,8 +61,8 @@
 
 .az-gallery-slider-crop {
   .az-gallery-image {
-    height: 100%;
     width: 100%;
+    height: 100%;
   }
 
   .az-gallery-caption {

--- a/scss/custom/_photo-gallery.scss
+++ b/scss/custom/_photo-gallery.scss
@@ -42,10 +42,6 @@
   }
 }
 
-.az-gallery-image {
-  min-height: 0;
-}
-
 .az-gallery-caption {
   position: static;
   width: 100%;
@@ -54,16 +50,29 @@
   margin-left: auto;
 }
 
+.az-gallery-grid, .az-gallery-slider-full {
+  .az-gallery-image {
+    min-height: 0;
+  }
+}
+
 .az-gallery-slider-full .az-gallery-caption {
   color: revert;
   background-color: unset;
 }
 
-.az-gallery-slider-crop .az-gallery-caption {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  left: 0;
+.az-gallery-slider-crop {
+  .az-gallery-image {
+    height: 100%;
+    width: 100%;
+  }
+
+  .az-gallery-caption {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
 }
 
 .az-gallery-modal {

--- a/site/content/docs/5.0/components/photo-gallery.md
+++ b/site/content/docs/5.0/components/photo-gallery.md
@@ -89,14 +89,14 @@ With the Grid display, all images in the gallery are presented in a grid layout.
           <div class="modal-body">
             <div id="gridGallery" class="carousel slide az-gallery az-gallery-grid">
               <div class="carousel-inner h-100">
-                <div class="carousel-item az-gallery-item h-100 active">
+                <div class="carousel-item h-100 active">
                   <div class="d-flex flex-column h-100 justify-content-center">
                     <div class="carousel-image az-gallery-image">
                       <img src="{{< docsrefazold `/assets/img/photo-gallery-demo/gallery-img-1.jpg` >}}" class="h-100 w-100 object-fit-contain rounded-0" alt="University of Arizona Spring Fling">
                     </div>
                   </div>
                 </div>
-                <div class="carousel-item az-gallery-item h-100">
+                <div class="carousel-item h-100">
                   <div class="d-flex flex-column h-100 justify-content-center">
                     <div class="carousel-image az-gallery-image">
                       <img src="{{< docsrefazold `/assets/img/photo-gallery-demo/gallery-img-2.jpg` >}}" class="h-100 w-100 object-fit-contain rounded-0" alt="A hand holding a little mirror">
@@ -106,7 +106,7 @@ With the Grid display, all images in the gallery are presented in a grid layout.
                     </div>
                   </div>
                 </div>
-                <div class="carousel-item az-gallery-item h-100">
+                <div class="carousel-item h-100">
                   <div class="d-flex flex-column h-100 justify-content-center">
                     <div class="carousel-image az-gallery-image">
                       <img src="{{< docsrefazold `/assets/img/photo-gallery-demo/gallery-img-3.jpg` >}}" class="h-100 w-100 object-fit-contain rounded-0" alt="University graduate on stage wearing cap and gown">
@@ -116,7 +116,7 @@ With the Grid display, all images in the gallery are presented in a grid layout.
                     </div>
                   </div>
                 </div>
-                <div class="carousel-item az-gallery-item h-100">
+                <div class="carousel-item h-100">
                   <div class="d-flex flex-column h-100 justify-content-center">
                     <div class="carousel-image az-gallery-image">
                       <img src="{{< docsrefazold `/assets/img/photo-gallery-demo/gallery-img-4.jpg` >}}" class="h-100 w-100 object-fit-contain rounded-0" alt="Ceiling tiles">
@@ -127,7 +127,7 @@ With the Grid display, all images in the gallery are presented in a grid layout.
                     </div>
                   </div>
                 </div>
-                <div class="carousel-item az-gallery-item h-100">
+                <div class="carousel-item h-100">
                   <div class="d-flex flex-column h-100 justify-content-center">
                     <div class="carousel-image az-gallery-image">
                       <img src="{{< docsrefazold `/assets/img/photo-gallery-demo/gallery-img-1.jpg` >}}" class="h-100 w-100 object-fit-contain rounded-0" alt="University of Arizona Spring Fling">
@@ -137,7 +137,7 @@ With the Grid display, all images in the gallery are presented in a grid layout.
                     </div>
                   </div>
                 </div>
-                <div class="carousel-item az-gallery-item h-100">
+                <div class="carousel-item h-100">
                   <div class="d-flex flex-column h-100 justify-content-center">
                     <div class="carousel-image az-gallery-image">
                       <img src="{{< docsrefazold `/assets/img/photo-gallery-demo/gallery-img-2.jpg` >}}" class="h-100 w-100 object-fit-contain rounded-0" alt="A hand holding a little mirror">
@@ -147,7 +147,7 @@ With the Grid display, all images in the gallery are presented in a grid layout.
                     </div>
                   </div>
                 </div>
-                <div class="carousel-item az-gallery-item h-100">
+                <div class="carousel-item h-100">
                   <div class="d-flex flex-column h-100 justify-content-center">
                     <div class="carousel-image az-gallery-image">
                       <img src="{{< docsrefazold `/assets/img/photo-gallery-demo/gallery-img-3.jpg` >}}" class="h-100 w-100 object-fit-contain rounded-0" alt="University graduate on stage wearing cap and gown">
@@ -188,14 +188,14 @@ Slider Photo Galleries using the "full image style" make use of the [object fit 
   <div class="ratio ratio-4x3">
     <div id="sliderGallery" class="carousel slide az-gallery az-gallery-slider-full">
       <div class="carousel-inner h-100">
-        <div class="carousel-item az-gallery-item h-100 active">
+        <div class="carousel-item h-100 active">
           <div class="d-flex flex-column h-100 justify-content-center">
             <div class="carousel-image az-gallery-image">
               <img src="{{< docsrefazold `/assets/img/photo-gallery-demo/gallery-img-1.jpg` >}}" class="h-100 w-100 object-fit-contain" alt="University of Arizona Spring Fling">
             </div>
           </div>
         </div>
-        <div class="carousel-item az-gallery-item h-100">
+        <div class="carousel-item h-100">
           <div class="d-flex flex-column h-100 justify-content-center">
             <div class="carousel-image az-gallery-image">
               <img src="{{< docsrefazold `/assets/img/photo-gallery-demo/gallery-img-2.jpg` >}}" class="h-100 w-100 object-fit-contain" alt="A hand holding a little mirror">
@@ -205,7 +205,7 @@ Slider Photo Galleries using the "full image style" make use of the [object fit 
             </div>
           </div>
         </div>
-        <div class="carousel-item az-gallery-item h-100">
+        <div class="carousel-item h-100">
           <div class="d-flex flex-column h-100 justify-content-center">
             <div class="carousel-image az-gallery-image">
               <img src="{{< docsrefazold `/assets/img/photo-gallery-demo/gallery-img-3.jpg` >}}" class="h-100 w-100 object-fit-contain" alt="University graduate on stage wearing cap and gown">
@@ -215,7 +215,7 @@ Slider Photo Galleries using the "full image style" make use of the [object fit 
             </div>
           </div>
         </div>
-        <div class="carousel-item az-gallery-item h-100">
+        <div class="carousel-item h-100">
           <div class="d-flex flex-column h-100 justify-content-center">
             <div class="carousel-image az-gallery-image">
               <img src="{{< docsrefazold `/assets/img/photo-gallery-demo/gallery-img-4.jpg` >}}" class="h-100 w-100 object-fit-contain" alt="University of Arizona Spring Fling">
@@ -247,14 +247,14 @@ The aspect ratio of the Slider Photo Gallery can be changed by simply setting a 
     <div class="ratio ratio-16x9">
       <div id="sliderGallery16x9" class="carousel slide az-gallery az-gallery-slider-full">
         <div class="carousel-inner h-100">
-          <div class="carousel-item az-gallery-item h-100 active">
+          <div class="carousel-item h-100 active">
             <div class="d-flex flex-column h-100 justify-content-center">
               <div class="carousel-image az-gallery-image">
                 <img src="{{< docsrefazold `/assets/img/photo-gallery-demo/gallery-img-1.jpg` >}}" class="h-100 w-100 object-fit-contain" alt="University of Arizona Spring Fling">
               </div>
             </div>
           </div>
-          <div class="carousel-item az-gallery-item h-100">
+          <div class="carousel-item h-100">
             <div class="d-flex flex-column h-100 justify-content-center">
               <div class="carousel-image az-gallery-image">
                 <img src="{{< docsrefazold `/assets/img/photo-gallery-demo/gallery-img-2.jpg` >}}" class="h-100 w-100 object-fit-contain" alt="A hand holding a little mirror">
@@ -264,7 +264,7 @@ The aspect ratio of the Slider Photo Gallery can be changed by simply setting a 
               </div>
             </div>
           </div>
-          <div class="carousel-item az-gallery-item h-100">
+          <div class="carousel-item h-100">
             <div class="d-flex flex-column h-100 justify-content-center">
               <div class="carousel-image az-gallery-image">
                 <img src="{{< docsrefazold `/assets/img/photo-gallery-demo/gallery-img-3.jpg` >}}" class="h-100 w-100 object-fit-contain" alt="University graduate on stage wearing cap and gown">
@@ -274,7 +274,7 @@ The aspect ratio of the Slider Photo Gallery can be changed by simply setting a 
               </div>
             </div>
           </div>
-          <div class="carousel-item az-gallery-item h-100">
+          <div class="carousel-item h-100">
             <div class="d-flex flex-column h-100 justify-content-center">
               <div class="carousel-image az-gallery-image">
                 <img src="{{< docsrefazold `/assets/img/photo-gallery-demo/gallery-img-4.jpg` >}}" class="h-100 w-100 object-fit-contain" alt="University of Arizona Spring Fling">
@@ -308,16 +308,16 @@ As an alternative Slider style, the "crop image style" uses the `object-fit-cove
   <div class="ratio ratio-4x3">
     <div id="sliderGalleryCrop" class="carousel slide az-gallery az-gallery-slider-crop">
       <div class="carousel-inner h-100 rounded">
-        <div class="carousel-item az-gallery-item h-100 active">
+        <div class="carousel-item h-100 active">
           <div class="d-flex flex-column h-100 justify-content-center">
-            <div class="carousel-image az-gallery-image h-100">
+            <div class="carousel-image az-gallery-image">
               <img src="{{< docsrefazold `/assets/img/photo-gallery-demo/gallery-img-1.jpg` >}}" class="h-100 w-100 object-fit-cover" alt="University of Arizona Spring Fling">
             </div>
           </div>
         </div>
-        <div class="carousel-item az-gallery-item h-100">
+        <div class="carousel-item h-100">
           <div class="d-flex flex-column h-100 justify-content-center">
-            <div class="carousel-image az-gallery-image h-100">
+            <div class="carousel-image az-gallery-image">
               <img src="{{< docsrefazold `/assets/img/photo-gallery-demo/gallery-img-2.jpg` >}}" class="h-100 w-100 object-fit-cover" alt="A hand holding a little mirror">
             </div>
             <div class="carousel-caption az-gallery-caption">
@@ -325,9 +325,9 @@ As an alternative Slider style, the "crop image style" uses the `object-fit-cove
             </div>
           </div>
         </div>
-        <div class="carousel-item az-gallery-item h-100">
+        <div class="carousel-item h-100">
           <div class="d-flex flex-column h-100 justify-content-center">
-            <div class="carousel-image az-gallery-image h-100">
+            <div class="carousel-image az-gallery-image">
               <img src="{{< docsrefazold `/assets/img/photo-gallery-demo/gallery-img-3.jpg` >}}" class="h-100 w-100 object-fit-cover" alt="University graduate on stage wearing cap and gown">
             </div>
             <div class="carousel-caption az-gallery-caption">
@@ -335,9 +335,9 @@ As an alternative Slider style, the "crop image style" uses the `object-fit-cove
             </div>
           </div>
         </div>
-        <div class="carousel-item az-gallery-item h-100">
+        <div class="carousel-item h-100">
           <div class="d-flex flex-column h-100 justify-content-center">
-            <div class="carousel-image az-gallery-image h-100">
+            <div class="carousel-image az-gallery-image">
               <img src="{{< docsrefazold `/assets/img/photo-gallery-demo/gallery-img-4.jpg` >}}" class="h-100 w-100 object-fit-cover" alt="University of Arizona Spring Fling">
             </div>
             <div class="carousel-caption az-gallery-caption">


### PR DESCRIPTION
### Changes in this PR

- Updates Photo Gallery custom styling to ensure portrait images are cropped in the Photo Gallery Slider Crop style
- Removes unnecessary `.az-gallery-item` class (which had no CSS associated with it) from Photo Gallery HTML

### Review site

- https://review.digital.arizona.edu/arizona-bootstrap/issue/1646/docs/5.0/components/photo-gallery

Compare with main branch:
 - https://review.digital.arizona.edu/arizona-bootstrap/main/docs/5.0/components/photo-gallery