### PR TITLE
Add dark mode support for heading colors

### DIFF
--- a/scss/override/_typography.scss
+++ b/scss/override/_typography.scss
@@ -41,4 +41,8 @@ h6,
 .h6 {
   margin: $heading-margins;
   color: $blue;
+
+  @include color-mode(dark) {
+    color: $white;
+  }
 }


### PR DESCRIPTION
## Description
This PR adds dark mode support to heading elements (h1-h6) and their utility classes (.h1-.h6) by implementing conditional color styling based on the current theme.

## Changes Made
- Modified `scss/override/_typography.scss` to include dark mode color support
- Added `@include color-mode(dark)` mixin to heading styles
- Headings now display in white (`$white`) when in dark mode
- Headings maintain Arizona blue (`$blue`) color in light mode

## Technical Details
- Uses Bootstrap's standard `color-mode(dark)` mixin for consistency
- Applies to all heading elements: `h1`, `h2`, `h3`, `h4`, `h5`, `h6`
- Also applies to heading utility classes: `.h1`, `.h2`, `.h3`, `.h4`, `.h5`, `.h6`
- Maintains existing margin styling (`$heading-margins`)

## Testing
- Verify headings display in blue (`#0c234b`) in light mode
- Verify headings display in white (`#fff`) when `data-bs-theme="dark"` is applied
- Test with all heading levels (h1-h6) and utility classes (.h1-.h6)

## Related Issues
- Improves accessibility and readability in dark mode
- Follows existing dark mode patterns used elsewhere in the codebase

Before:
<img width="1361" height="818" alt="Screenshot 2025-07-30 at 5 22 35 PM" src="https://github.com/user-attachments/assets/5dc84c4e-a0b8-4ab8-943e-0cfd2e5f628b" />

After:
<img width="1287" height="794" alt="Screenshot 2025-07-30 at 5 24 08 PM" src="https://github.com/user-attachments/assets/19ade55c-d4fa-4931-b633-e0d64722786d" />

