### PR TITLE
Backport the upgrade to Node.js 22 from the main branch.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,13 @@ updates:
     target-branch: "2.x"
     ignore:
       - dependency-name: "bootstrap"
-        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint"
+      - dependency-name: "eslint-config-xo"
+      - dependency-name: "eslint-plugin-unicorn"
+      - dependency-name: "jquery"
+      - dependency-name: "linkinator"
+      - dependency-name: "sass"
+      - dependency-name: "vnu-jar"
     open-pull-requests-limit: 10
     labels:
       - "ci"
@@ -23,6 +29,15 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "main"
+    ignore:
+      - dependency-name: "bootstrap"
+      - dependency-name: "eslint"
+      - dependency-name: "eslint-config-xo"
+      - dependency-name: "eslint-plugin-unicorn"
+      - dependency-name: "jquery"
+      - dependency-name: "linkinator"
+      - dependency-name: "sass"
+      - dependency-name: "vnu-jar"
     open-pull-requests-limit: 10
     labels:
       - "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,6 @@ updates:
       - dependency-name: "eslint-plugin-unicorn"
       - dependency-name: "jquery"
       - dependency-name: "linkinator"
-      - dependency-name: "sass"
       - dependency-name: "vnu-jar"
     open-pull-requests-limit: 10
     labels:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:20.19.2-bookworm-slim
+FROM node:22.17.1-bookworm-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 COPY scripts/build-cdn-assets.sh /usr/local/bin/build-cdn-assets
 COPY scripts/build-review-site.sh /usr/local/bin/build-review-site
@@ -13,12 +13,12 @@ COPY scripts/serve-review-site.sh /usr/local/bin/serve-review-site
 
 # Build args don't normally persist as environment variables.
 ARG AZ_BOOTSTRAP_FROZEN_DIR
-ENV AZ_BOOTSTRAP_FROZEN_DIR ${AZ_BOOTSTRAP_FROZEN_DIR:-/azbuild/arizona-bootstrap}
+ENV AZ_BOOTSTRAP_FROZEN_DIR=${AZ_BOOTSTRAP_FROZEN_DIR:-/azbuild/arizona-bootstrap}
 ARG AZ_BOOTSTRAP_SOURCE_DIR
-ENV AZ_BOOTSTRAP_SOURCE_DIR ${AZ_BOOTSTRAP_SOURCE_DIR:-/arizona-bootstrap-source}
+ENV AZ_BOOTSTRAP_SOURCE_DIR=${AZ_BOOTSTRAP_SOURCE_DIR:-/arizona-bootstrap-source}
 
 # Silence warnings from the update-notifier npm package.
-ENV NO_UPDATE_NOTIFIER 1
+ENV NO_UPDATE_NOTIFIER=1
 
 WORKDIR $AZ_BOOTSTRAP_SOURCE_DIR
 
@@ -37,7 +37,7 @@ RUN apt-get update \
   && chmod 755 /root \
   && touch /root/.npmrc \
   && chmod 644 /root/.npmrc \
-  && npm install --location=global npm-check-updates@17.1.3 \
+  && npm install --location=global npm-check-updates@18.0.2 \
   && curl 'https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip' -o /tmp/awscliv2.zip \
   && unzip -d /tmp /tmp/awscliv2.zip \
   && /tmp/aws/install \


### PR DESCRIPTION
This includes a cosmetic re-synchronization of the Dependabot configuration file with the main branch.