### PR TITLE
Closes #1651: Update "Custom Arizona Bootstrap Class" styling on Typography page

### DIFF
--- a/site/content/docs/5.0/content/typography.md
+++ b/site/content/docs/5.0/content/typography.md
@@ -203,7 +203,7 @@ Use text utilities as needed to change the alignment of your blockquote.
 
 ### Triangles
 
-**(Custom Arizona Bootstrap Class)**
+<span class="badge badge-az-custom">Custom Arizona Bootstrap Class</span>
 
 Add the `.ul-triangles` class to your **unordered list** to replace the default bullets with triangles. Triangle list items function the same as an unordered list.
 


### PR DESCRIPTION
### Changes in this PR
 - Updates the Typography docs page to use the custom AZ Bootstrap badge in the section for the custom triangles class

### Review site
 - https://review.digital.arizona.edu/arizona-bootstrap/issue/1651/docs/5.0/content/typography/#triangles

### Questions

1. Should we deprecate/remove `.ul-triangles` and change that class to `.list-triangles` or `.az-list-triangles` to match the upstream Bootstrap list classes?