### PR TITLE
#1665: Add ignore line for hash placeholder values back to vnu_jar.mjs script.

### DIFF
--- a/build/vnu-jar.mjs
+++ b/build/vnu-jar.mjs
@@ -23,6 +23,7 @@ execFile('java', ['-version'], (error, stdout, stderr) => {
   // vnu-jar accepts multiple ignores joined with a `|`.
   // Also note that the ignores are string regular expressions.
   const ignores = [
+    '.*our_.*_hash_here.*',
     // "autocomplete" is included in <button> and checkboxes and radio <input>s due to
     // Firefox's non-standard autocomplete behavior - see https://bugzilla.mozilla.org/show_bug.cgi?id=654072
     'Attribute “autocomplete” is only allowed when the input type is.*',


### PR DESCRIPTION
I believe this should resolve the lint errors in the PR checks for #1666:
```
Running vnu-jar validation...
command used: java -jar "/arizona-bootstrap-source/node_modules/vnu-jar/build/dist/vnu.jar" --asciiquotes --skip-non-html --Werror --filterpattern "Attribute “autocomplete” is only allowed when the input type is.*|Attribute “autocomplete” not allowed on element “button” at this point.|An “aria-disabled” attribute whose value is “true” should not be specified on an “a” element that has an “href” attribute." _site/ js/tests/
ERROR: "docs-vnu" exited with 1.
ERROR: "docs-lint" exited with 1.
Error: Process completed with exit code 1.
```