### PR TITLE
Closes #1604: Update text-muted to text-body-secondary

### DIFF
--- a/site/content/docs/5.0/backwards-compatibility.md
+++ b/site/content/docs/5.0/backwards-compatibility.md
@@ -54,6 +54,11 @@ These custom Arizona Bootstrap classes are now deprecated:
 The `.nav-tabs-lg` custom Arizona Bootstrap class is now deprecated.
 
 
+### Text Muted
+
+The `.text-muted` class has been replaced by the `.text-body-secondary` class.
+
+
 ## Removed Utilities
 
 The following utilities have been removed in Arizona Bootstrap 5.

--- a/site/content/docs/5.0/examples/jumbotrons/index.html
+++ b/site/content/docs/5.0/examples/jumbotrons/index.html
@@ -24,7 +24,7 @@ body_class: ""
   <div class="p-5 text-center bg-body-tertiary rounded-3">
     <svg class="bi mt-4 mb-3" style="color: var(--bs-indigo);" width="100" height="100" aria-hidden="true"><use xlink:href="#bootstrap"/></svg>
     <h1 class="text-body-emphasis">Jumbotron with icon</h1>
-    <p class="col-lg-8 mx-auto fs-5 text-muted">
+    <p class="col-lg-8 mx-auto fs-5 text-body-secondary">
       This is a custom jumbotron featuring an SVG image at the top, some longer text that wraps early thanks to a responsive <code>.col-*</code> class, and a customized call to action.
     </p>
     <div class="d-inline-flex gap-2 mb-5">
@@ -42,7 +42,7 @@ body_class: ""
 <div class="b-example-divider"></div>
 
 <div class="container my-5">
-  <div class="position-relative p-5 text-center text-muted bg-body border border-dashed rounded-5">
+  <div class="position-relative p-5 text-center text-body-secondary bg-body border border-dashed rounded-5">
     <button type="button" class="position-absolute top-0 end-0 p-3 m-3 btn-close bg-secondary bg-opacity-10 rounded-pill" aria-label="Close"></button>
     <svg class="bi mt-5 mb-3" width="48" height="48" aria-hidden="true"><use xlink:href="#check2-circle"/></svg>
     <h1 class="text-body-emphasis">Placeholder jumbotron</h1>

--- a/site/content/docs/5.0/examples/navbar/index.html
+++ b/site/content/docs/5.0/examples/navbar/index.html
@@ -33,10 +33,10 @@ title: Navbar template
                 <h2 class="sr-only" id="block-az-utility-links-menu">Utility Links</h2>
                 <ul class="clearfix nav nav-utility ms-auto justify-content-end">
                   <li class="nav-item">
-                    <a href="https://quickstart.arizona.edu/" class="text-muted nav-link nav-link-https--quickstartarizonaedu-">Utility 1</a>
+                    <a href="https://quickstart.arizona.edu/" class="text-body-secondary nav-link nav-link-https--quickstartarizonaedu-">Utility 1</a>
                   </li>
                   <li class="nav-item">
-                    <a href="https://marcom.arizona.edu/" class="text-muted nav-link nav-link-https--brandarizonaedu-">Utility 2</a>
+                    <a href="https://marcom.arizona.edu/" class="text-body-secondary nav-link nav-link-https--brandarizonaedu-">Utility 2</a>
                   </li>
                 </ul>
               </nav>
@@ -231,7 +231,7 @@ title: Navbar template
 
 		 <div class="row featurette">
 			 <div class="col-md-7">
-				 <h2 class="featurette-heading">First featurette heading. <span class="text-muted">It’ll blow your mind.</span></h2>
+				 <h2 class="featurette-heading">First featurette heading. <span class="text-body-secondary">It’ll blow your mind.</span></h2>
 				 <p class="lead">From the highest spire of contentment My fortune is thrown; And fear and grief and pain for my deserts, for my deserts Are my hopes, since hope is gone.</p>
 			 </div>
 			 <div class="col-md-5">
@@ -243,7 +243,7 @@ title: Navbar template
 
 		 <div class="row featurette">
 			 <div class="col-md-7 order-md-2">
-				 <h2 class="featurette-heading">Oh yeah, it’s that good. <span class="text-muted">See for yourself.</span></h2>
+				 <h2 class="featurette-heading">Oh yeah, it’s that good. <span class="text-body-secondary">See for yourself.</span></h2>
 				 <p class="lead">Hark! you shadows that in darkness dwell, Learn to contemn light Happy, happy they that in hell Feel not the world's despite.</p>
 			 </div>
 			 <div class="col-md-5 order-md-1">
@@ -255,7 +255,7 @@ title: Navbar template
 
 		 <div class="row featurette">
 			 <div class="col-md-7">
-				 <h2 class="featurette-heading">And lastly, this one. <span class="text-muted">Checkmate.</span></h2>
+				 <h2 class="featurette-heading">And lastly, this one. <span class="text-body-secondary">Checkmate.</span></h2>
 				 <p class="lead">Hark! you shadows that in darkness dwell, Learn to contemn light Happy, happy they that in hell Feel not the world's despite.</p>
 			 </div>
 			 <div class="col-md-5">

--- a/site/content/docs/5.0/examples/product/index.html
+++ b/site/content/docs/5.0/examples/product/index.html
@@ -56,7 +56,7 @@ extra_css:
   <div class="position-relative overflow-hidden p-3 p-md-5 m-md-3 text-center bg-body-tertiary">
     <div class="col-md-6 p-lg-5 mx-auto my-5">
       <h1 class="display-3 fw-bold">Designed for engineers</h1>
-      <h3 class="fw-normal text-muted mb-3">Build anything you want with Aperture</h3>
+      <h3 class="fw-normal text-body-secondary mb-3">Build anything you want with Aperture</h3>
       <div class="d-flex gap-3 justify-content-center lead fw-normal">
         <a class="icon-link" href="#">
           Learn more

--- a/site/content/docs/5.0/utilities/colors.md
+++ b/site/content/docs/5.0/utilities/colors.md
@@ -27,6 +27,18 @@ When using these colors, it is important to maintain sufficient color contrast b
 <p class="text-dark-silver">.text-dark-silver</p>
 {{< /example >}}
 
+### Contextual
+
+When using these colors, it is important to maintain sufficient color contrast between your text color and background color. You can utilize the <a href="https://webaim.org/resources/contrastchecker/" target="_blank">WebAim Color Contrast Checker</a> to verify your color contrast.
+
+{{< example >}}
+<p class="text-body">.text-body</p>
+<p class="text-body-emphasis">.text-body-emphasis</p>
+<p class="text-body-secondary">.text-body-secondary</p>
+<p class="text-body-tertiary">.text-body-tertiary</p>
+{{< /example >}}
+
+
 ## Further information from upstream Bootstrap
 
 ### Opacity


### PR DESCRIPTION
Closes #1604 

## Changes

- Adds `text-muted` to backwards compatibility page
- Updates examples to use `text-body-secondary`
- Adds contextual colors section to the page