### PR TITLE
Closes #1689: Update pagination focus and active colors to blue

### DIFF
--- a/scss/override/_variables.scss
+++ b/scss/override/_variables.scss
@@ -169,6 +169,10 @@ $navbar-light-link-hover-bg: $gray-100;
 // fusv-disable
 $pagination-color: $breadcrumb-color;
 $pagination-hover-color: $midnight;
+$pagination-active-bg: $blue;
+$pagination-active-border-color: $blue;
+$pagination-focus-color: $blue;
+$focus-ring-box-shadow: 0 0 0 .25rem rgba($blue, .25);
 // fusv-enable
 
 // >> Popovers

--- a/scss/override/_variables.scss
+++ b/scss/override/_variables.scss
@@ -172,7 +172,8 @@ $pagination-hover-color: $midnight;
 $pagination-active-bg: $blue;
 $pagination-active-border-color: $blue;
 $pagination-focus-color: $blue;
-$focus-ring-box-shadow: 0 0 0 .25rem rgba($blue, .25);
+$pagination-focus-ring-box-shadow: 0 0 0 .25rem rgba($blue, .25);
+$pagination-focus-box-shadow: $pagination-focus-ring-box-shadow;
 // fusv-enable
 
 // >> Popovers


### PR DESCRIPTION
Closes #1689

Updates pagination's focus and active colors to blue

## How to test

https://review.digital.arizona.edu/arizona-bootstrap/issue/1689/docs/5.0/components/pagination/

1. Ensure active and focus colors are now blue
2. Ensure other components are not negatively effected