### PR TITLE
Closes #1694: Remove custom styling for navbar dropdown carets

### DIFF
--- a/scss/override/_navbar.scss
+++ b/scss/override/_navbar.scss
@@ -30,10 +30,6 @@
       background-color: $nav-tabs-link-bg;
     }
   }
-
-  .dropdown-toggle::after {
-    margin-left: .125rem;
-  }
 }
 
 .navbar-toggler {


### PR DESCRIPTION
This PR adjusted the left margin of dropdown carets in navbars:
 - #1680

This change looked like a slight improvement in the Arizona Bootstrap docs, but in Quickstart the left margin is too small. It is not clear exactly what styling is causing this difference, so it makes sense to simply undo this styling and keep the caret margins as they were before.

### Review site
https://review.digital.arizona.edu/arizona-bootstrap/issue/1694/docs/5.0/components/navbar/
