### PR TITLE
Closes #1701: Fix misaligned Arizona Header buttons in Safari

### DIFF
--- a/scss/custom/_arizona-header.scss
+++ b/scss/custom/_arizona-header.scss
@@ -53,6 +53,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: center;
   min-width: 60px;
   padding: 4px 0;
   @extend .text-white;


### PR DESCRIPTION
Adds an `align-items: center` property to `.btn-arizona-header` to fix the misalignment issue.

### Review site
