### PR TITLE
Closes #1712: Right-justify content in the Arizona Header except for the wordmark logo

### DIFF
--- a/scss/custom/_arizona-header.scss
+++ b/scss/custom/_arizona-header.scss
@@ -4,7 +4,7 @@
 
 .arizona-header > .container > .row {
   align-items: center;
-  justify-content: space-between;
+  justify-content: end;
   min-height: 50px;
 }
 
@@ -34,6 +34,7 @@
   align-items: center;
   min-height: 50px;
   padding-right: 0;
+  margin-right: auto;
 }
 .arizona-line-logo {
   width: 100%;


### PR DESCRIPTION
### Changes in this PR
 - Updates Arizona Header styling to set all content to `justify-content: end`, to align all items to the right.
 - Updates the `.arizona-logo` class to keep the university wordmark logo aligned to the left. The wordmark logo is the ONLY item that should be aligned to the left.

### Review site
https://review.digital.arizona.edu/arizona-bootstrap/issue/1712/docs/5.0/components/arizona-header/

1. Confirm that the Arizona Header examples look the same as before.
2. Inspect the page and try deleting the `d-lg-none` class for the buttons to confirm that content would be right-aligned on desktop as well.
3. Try deleting the wordmark logo to ensure that the buttons remain aligned to the right.