### PR TITLE
Closes #1732: Remove SRI hashes on JS assets that do not come from a CDN

### DIFF
--- a/site/layouts/_default/examples.html
+++ b/site/layouts/_default/examples.html
@@ -121,13 +121,13 @@
     {{ .Content }}
 
     {{- if hugo.IsProduction -}}
-      <script defer src="{{- (printf `docs/%s%s` $.Site.Params.docs_version `/dist/js/arizona-bootstrap.bundle.min.js` ) | relURL -}}" {{ printf "integrity=%q" .Site.Params.cdn.js_bundle_hash | safeHTMLAttr }}></script>
+      <script defer src="{{- (printf `docs/%s%s` $.Site.Params.docs_version `/dist/js/arizona-bootstrap.bundle.min.js` ) | relURL -}}"></script>
     {{- else -}}
       <script defer src="{{- (printf `docs/%s%s` $.Site.Params.docs_version `/dist/js/arizona-bootstrap.bundle.js` ) | relURL -}}"></script>
     {{- end }}
 
     {{ range .Page.Params.extra_js -}}
-      <script{{ with .async }} async{{ end }}{{ with .defer }} defer{{ end }} src="{{ .src | relURL }}"{{ with .integrity }} {{ printf "integrity=%q" . | safeHTMLAttr }} crossorigin="anonymous"{{ end }}></script>
+      <script{{ with .async }} async{{ end }}{{ with .defer }} defer{{ end }} src="{{ .src | relURL -}}"></script>
     {{- end -}}
   </body>
 </html>

--- a/site/layouts/partials/scripts.html
+++ b/site/layouts/partials/scripts.html
@@ -1,5 +1,5 @@
 {{ if hugo.IsProduction -}}
-  <script defer src="{{- (printf `docs/%s%s` $.Site.Params.docs_version `/dist/js/arizona-bootstrap.bundle.min.js` ) | relURL -}}" {{ printf "integrity=%q" .Site.Params.cdn.js_bundle_hash | safeHTMLAttr }}></script>
+  <script defer src="{{- (printf `docs/%s%s` $.Site.Params.docs_version `/dist/js/arizona-bootstrap.bundle.min.js` ) | relURL -}}"></script>
 {{ else -}}
   <script defer src="{{- (printf `docs/%s%s` $.Site.Params.docs_version `/dist/js/arizona-bootstrap.bundle.js` ) | relURL -}}"></script>
 {{- end }}


### PR DESCRIPTION
Confusingly, the docs pages that incorrectly referenced SRI hashes (`integrity=...`) were breaking some review sites for GitHub PRs, but not showing similar problems in local dev environments. Slight differences in how GitHub Actions & local dev environments invoked the Hugo static site builder meant that it was running in production mode on GitHub (causing errors), but in development mode locally (without errors); however there was nothing to explicitly set the `hugo.IsProduction` flag that the documentation site templates were referencing.