### PR TITLE
Fixes #1734: Update light badge link hover color

### DIFF
--- a/scss/custom/_badge.scss
+++ b/scss/custom/_badge.scss
@@ -17,7 +17,7 @@
     background-color: $azurite !important;
   }
   &.text-bg-light {
-    background-color: $gray-200 !important;
+    background-color: #c1c9d0 !important;
   }
 }
 /* stylelint-enable declaration-no-important */


### PR DESCRIPTION
Updates the "light" badge hover color to `#c1c9d0`.

### How to test

1. Navigate to the Badge links docs section at [/docs/5.0/components/badge/#badge-links](https://review.digital.arizona.edu/arizona-bootstrap/issue/1734/docs/5.0/components/badge/#badge-links).
2. Hover over the Light Badge link and verify that the background color on hover has been updated from `#e9ecef` (gray-200) to `#c1c9d0`.

Review site: https://review.digital.arizona.edu/arizona-bootstrap/issue/1734/