### PR TITLE
Closes #1742: Update Arizona Header buttons to have sharp corners

### DIFF
--- a/scss/custom/_arizona-header.scss
+++ b/scss/custom/_arizona-header.scss
@@ -67,6 +67,7 @@
   justify-content: center;
   min-width: 60px;
   padding: 4px 0;
+  @include border-radius(0);
   @extend .text-white;
 
   > .icon-text {


### PR DESCRIPTION
### Changes in this PR
 - Sets the border radius to 0 for the `.btn-arizona-header` class (overriding the default border radius for buttons)

### How to test

1. Go to https://review.digital.arizona.edu/arizona-bootstrap/issue/1742/docs/5.0/components/arizona-header/#extending-the-header
2. Resize your browser window until the mobile header buttons are visible
3. Hold the mouse down over the buttons to confirm that the white border for the active state has sharp corners rather than rounded corners
