### PR TITLE
Move dropdown overrides to separate override file

### DIFF
--- a/scss/arizona-bootstrap.scss
+++ b/scss/arizona-bootstrap.scss
@@ -78,6 +78,7 @@
 @import "custom/buttons";
 @import "override/button-group";
 @import "custom/button-group";
+@import "override/dropdown";
 @import "custom/card";
 @import "custom/color-background";
 @import "custom/list-group";

--- a/scss/override/_buttons.scss
+++ b/scss/override/_buttons.scss
@@ -89,14 +89,3 @@
 .btn-outline-light {
   color: $ash;
 }
-.dropdown-item:focus-visible {
-  @include border-radius(2px);
-  outline: 0;
-  box-shadow: inset 0 0 $focus-ring-blur 2px $white;
-}
-.dropdown-menu {
-  input:focus-visible,
-  button:focus-visible {
-    box-shadow: 0 0 $focus-ring-blur $focus-ring-width rgba($white, .75);
-  }
-}

--- a/scss/override/_dropdown.scss
+++ b/scss/override/_dropdown.scss
@@ -1,0 +1,18 @@
+// Overrides for the Dropdown component
+
+//
+// > DROPDOWNS
+//
+
+.dropdown-item:focus-visible {
+  @include border-radius(2px);
+  outline: 0;
+  box-shadow: inset 0 0 $focus-ring-blur 2px $white;
+}
+
+.dropdown-menu {
+  input:focus-visible,
+  button:focus-visible {
+    box-shadow: 0 0 $focus-ring-blur $focus-ring-width rgba($white, .75);
+  }
+}


### PR DESCRIPTION
We could perhaps move these styles to a separate override file. I think this would follow TWBS5 organization a little better: https://github.com/twbs/bootstrap/blob/main/scss/_dropdown.scss