### PR TITLE
Start btn-arizona-header focus styling

### DIFF
--- a/scss/custom/_arizona-header.scss
+++ b/scss/custom/_arizona-header.scss
@@ -81,4 +81,12 @@
     font-size: 10px;
     line-height: 10px;
   }
+
+  &:focus-visible {
+    @include border-radius(2px);
+    outline: 0;
+    box-shadow: inset 0 0 $focus-ring-blur 3px $white;
+  }
 }
+
+

--- a/scss/custom/_arizona-header.scss
+++ b/scss/custom/_arizona-header.scss
@@ -88,5 +88,3 @@
     box-shadow: inset 0 0 $focus-ring-blur 3px $white;
   }
 }
-
-


### PR DESCRIPTION
Attempting to address focus styling on `btn-arizona-header`:

<img width="978" height="939" alt="Screenshot 2025-09-18 at 5 15 06 PM" src="https://github.com/user-attachments/assets/9dc0bfba-0158-4ad2-8e2e-8f6ce577026a" />

https://review.digital.arizona.edu/arizona-bootstrap/issue/1720-djcelaya2/docs/5.0/components/arizona-header/#extending-the-header
