### PR TITLE
Closes #1771: Text with background patterns need to be aligned

### DIFF
--- a/scss/custom/_background-wrapper.scss
+++ b/scss/custom/_background-wrapper.scss
@@ -60,7 +60,7 @@
   background: {
     image: url("img/triangles-centered.svg");
     repeat: no-repeat;
-    position: center center;
+    position: center bottom;
     size: auto;
     blend-mode: multiply;
   }


### PR DESCRIPTION
Updates the background position of the `.bg-triangles-centered` class from `center center` to `center bottom`.

Looks like this was introduced in #1581.

### How to test
Compare the [Triangles Centered background wrapper live demo on this PR](https://review.digital.arizona.edu/arizona-bootstrap/issue/1771/docs/5.0/components/background-wrappers/) with the one on the [5.0.2 docs site](https://digital.arizona.edu/arizona-bootstrap/v5/docs/5.0/components/background-wrappers/), then compare with the [2.0 branch](https://digital.arizona.edu/arizona-bootstrap/docs/2.0/components/background-wrappers/). 


This PR: https://review.digital.arizona.edu/arizona-bootstrap/issue/1771/docs/5.0/components/background-wrappers/
<img width="799" height="527" alt="Screenshot 2025-10-17 at 4 30 42 PM" src="https://github.com/user-attachments/assets/5e3a5b56-f11a-496a-a339-ae2dad8eaebb" />

v5.0.2: https://digital.arizona.edu/arizona-bootstrap/v5/docs/5.0/components/background-wrappers/
<img width="774" height="523" alt="Screenshot 2025-10-17 at 4 30 58 PM" src="https://github.com/user-attachments/assets/67220fd4-86d6-43f1-8dfe-9b6e115dc128" />

v2.0: https://digital.arizona.edu/arizona-bootstrap/docs/2.0/components/background-wrappers/
<img width="806" height="555" alt="Screenshot 2025-10-17 at 4 31 12 PM" src="https://github.com/user-attachments/assets/9f63fe4f-b1f2-4f77-94f8-6a51655372f2" />
