### PR TITLE
#1791 Add `lh-az-normal` utility class

### DIFF
--- a/scss/arizona-bootstrap.scss
+++ b/scss/arizona-bootstrap.scss
@@ -52,6 +52,7 @@
 
 // Include utilities API last to generate classes based on the Sass map in `_utilities.scss`
 @import "override/utilities";
+@import "custom/utilities";
 @import "../node_modules/bootstrap/scss/utilities/api";
 
 // Arizona Bootstrap imports.

--- a/scss/custom/_utilities.scss
+++ b/scss/custom/_utilities.scss
@@ -1,0 +1,21 @@
+/*
+* > Utilities API Customizations
+*/
+
+// add "lh-az-normal" line-height utility
+$utilities: map-merge(
+  $utilities,
+  (
+    "line-height": map-merge(
+      map-get($utilities, "line-height"),
+      (
+        values: map-merge(
+          map-get(map-get($utilities, "line-height"), "values"),
+          (
+            az-normal: normal
+          ),
+        ),
+      ),
+    ),
+  )
+);

--- a/scss/override/_utilities.scss
+++ b/scss/override/_utilities.scss
@@ -100,21 +100,3 @@ $utilities: map-merge(
     ),
   )
 );
-
-// add "lh-normal" line-height utility
-$utilities: map-merge(
-  $utilities,
-  (
-    "line-height": map-merge(
-      map-get($utilities, "line-height"),
-      (
-        values: map-merge(
-          map-get(map-get($utilities, "line-height"), "values"),
-          (
-            normal: normal
-          ),
-        ),
-      ),
-    ),
-  )
-);

--- a/site/content/docs/5.0/utilities/text.md
+++ b/site/content/docs/5.0/utilities/text.md
@@ -117,12 +117,16 @@ Quickly change the `font-weight` or `font-style` of text with these utilities. `
 
 Change the line height with `.lh-*` utilities.
 
+<span class="badge badge-az-custom">Custom Arizona Bootstrap Class</span>
+
+Arizona Bootstrap includes an additional `.lh-*` variant called `.lh-az-normal`. Use it to easily reset line-height to the browser default.
+
 {{< example >}}
 <p class="lh-1">This is a long paragraph written to show how the line-height of an element is affected by our utilities. Classes are applied to the element itself or sometimes the parent element. These classes can be customized as needed with our utility API.</p>
 <p class="lh-sm">This is a long paragraph written to show how the line-height of an element is affected by our utilities. Classes are applied to the element itself or sometimes the parent element. These classes can be customized as needed with our utility API.</p>
 <p class="lh-base">This is a long paragraph written to show how the line-height of an element is affected by our utilities. Classes are applied to the element itself or sometimes the parent element. These classes can be customized as needed with our utility API.</p>
 <p class="lh-lg">This is a long paragraph written to show how the line-height of an element is affected by our utilities. Classes are applied to the element itself or sometimes the parent element. These classes can be customized as needed with our utility API.</p>
-<p class="lh-normal">This is a long paragraph written to show how the line-height of an element is affected by our utilities. Classes are applied to the element itself or sometimes the parent element. These classes can be customized as needed with our utility API.</p>
+<p class="lh-az-normal">This is a long paragraph written to show how the line-height of an element is affected by our utilities. Classes are applied to the element itself or sometimes the parent element. These classes can be customized as needed with our utility API.</p>
 {{< /example >}}
 
 ## Monospace


### PR DESCRIPTION
Note that this PR does not include the changes in the dist folder and will need to be built before the style will take effect.
<img width="3334" height="1424" alt="image" src="https://github.com/user-attachments/assets/9c79ceda-a45e-48ad-a382-e2fc45046d5f" />



See https://review.digital.arizona.edu/arizona-bootstrap/1791-add-lh-normal-utility-class/docs/5.0/utilities/text/#line-height