### PR TITLE
Closes #1805: Add js-yaml as an explicit dependency to address CVE-2025-64718

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "globby": "^15.0.0",
     "hugo-bin": "^0.149.2",
     "jquery": "3.7.1",
+    "js-yaml": "^4.1.1",
     "linkinator": "6.1.2",
     "nodemon": "^3.1.10",
     "npm-run-all2": "^8.0.4",


### PR DESCRIPTION
Declares js-yaml 4.1.1 as an explicit devDependcy.

This declaration exists [upstream](https://github.com/twbs/bootstrap/blob/61b0bab5c29415938038a71592b30b05eb96e452/package.json#L151) already and corresponds with the version bump in #1799.

Review site: https://review.digital.arizona.edu/arizona-bootstrap/issue/1805/