### PR TITLE
Fixes #1849: Secondary navigation items should have a blue underline on hover in AZ Navbar

### DIFF
--- a/scss/custom/_navbar.scss
+++ b/scss/custom/_navbar.scss
@@ -276,6 +276,13 @@
       text-decoration-color: var(--az-navbar-accent-color);
       text-underline-offset: 4px;
     }
+
+    &:hover {
+      text-decoration: underline;
+      text-decoration-thickness: 2px;
+      text-decoration-color: var(--az-navbar-font-hover-color);
+      text-underline-offset: 4px;
+    }
   }
 
   // Tertiary navigation level


### PR DESCRIPTION
See #1849.

### How to test
1. Navigate to the [AZ Navbar Example](https://review.digital.arizona.edu/arizona-bootstrap/bug/1849/docs/5.0/examples/navbar-az/) page at `/docs/5.0/examples/navbar-az/`.
2. Verify that the "Secondary Navigation" elements under "Single Dropdown" and "Split Dropdown" have a blue underline on hover in addition to the gray background (existing behavior).
