### PR TITLE
Fixes #1851: Remove needless CSS linting disables that were introduced in #1833

### DIFF
--- a/site/assets/scss/_variables.scss
+++ b/site/assets/scss/_variables.scss
@@ -4,6 +4,11 @@ $bd-violet:        lighten(saturate($bd-purple, 5%), 15%); // stylelint-disable-
 $bd-purple-light:  lighten(saturate($bd-purple, 5%), 45%); // stylelint-disable-line function-disallowed-list
 $bd-accent:        #ffe484;
 
+$bd-violet-rgb: to-rgb($bd-violet);
+$bd-accent-rgb: to-rgb($bd-accent);
+$bd-violet-dark: mix($bd-violet, $white, 75%);
+$bd-sidebar-link-bg-dark: rgba(mix($bd-violet, $black, 75%), .5);
+
 $bd-gutter-x: 3rem;
 $bd-callout-variants: info, warning, danger !default;
 
@@ -12,8 +17,8 @@ $bd-callout-variants: info, warning, danger !default;
   --bd-purple: #{$bd-purple};
   --bd-violet: #{$bd-violet};
   --bd-accent: #{$bd-accent};
-  --bd-violet-rgb: #{to-rgb($bd-violet)};
-  --bd-accent-rgb: #{to-rgb($bd-accent)};
+  --bd-violet-rgb: #{$bd-violet-rgb};
+  --bd-accent-rgb: #{$bd-accent-rgb};
   --bd-pink-rgb: #{to-rgb($pink-500)};
   --bd-teal-rgb: #{to-rgb($teal-500)};
   --bd-violet-bg: var(--bd-violet);
@@ -25,10 +30,10 @@ $bd-callout-variants: info, warning, danger !default;
 }
 
 @include color-mode(dark, true) {
-  --bd-violet: #{mix($bd-violet, $white, 75%)};
+  --bd-violet: #{$bd-violet-dark};
   --bd-violet-bg: #{$bd-violet};
   --bd-toc-color: var(--#{$prefix}emphasis-color);
-  --bd-sidebar-link-bg: rgba(#{to-rgb(mix($bd-violet, $black, 75%))}, .5);
+  --bd-sidebar-link-bg: #{$bd-sidebar-link-bg-dark};
   --bd-callout-link: #{to-rgb($blue-300)};
   --bd-callout-code-color: #{$pink-300};
   --bd-pre-bg: #{adjust-color($gray-900, $lightness: -2.5%)}; // stylelint-disable-line scss/at-function-named-arguments


### PR DESCRIPTION
See #1851. Rewrites offending lines to avoid the `scss/dollar-variable-no-missing-interpolation` linting rule that was discovered in #1832 and then patched via disable statements in #1833. With these rewrites, the initial linting issues do not appear and the added disables are no longer necessary.

### How to test
1. Clone locally and run `npm run css-lint`.
2. Verify that no linting errors appear (again).

Review site: https://review.digital.arizona.edu/arizona-bootstrap/bug/1851/