### PR TITLE
Fixes #1828: Replace expand_circle_down icon at the primary level of navbar-az with keyboard_arrow_down and a round border

### DIFF
--- a/scss/custom/_navbar.scss
+++ b/scss/custom/_navbar.scss
@@ -99,17 +99,19 @@
   .dropdown-toggle {
     @include border-radius(0);
     &::after {
-      display: inline-block; // This prevents the parent's underline from drawing through the icon
+      display: inline-flex; // Prevents underline bleed and creates a centering context
+      align-items: center; // Vertically center the icon glyph
+      justify-content: center; // Horizontally center the icon glyph
       margin-bottom: 0; // Remove Bootstrap's default bottom margin on the single dropdown's icon
       font-family: "Material Symbols Rounded", sans-serif;
       // font-size: 1.55rem; // Increased slightly from 1.5 so that top of icon is not clipped on hover
       font-size: 22px;
-      font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 16;
-      //font-weight: 300; // Needed to prevent inheritance of parent's font weight - otherwise redundant
+      font-variation-settings: "FILL" 0, "wght" 600, "GRAD" 0, "opsz" 24;
+      font-weight: 600; // Needed to prevent inheritance of parent's font weight - otherwise redundant
       line-height: 1;
       color: var(--az-navbar-font-color);
-      vertical-align: 0;
-      content: "\e313";
+      vertical-align: middle; // Align the pseudo-element box itself with surrounding text
+      content: "\e313";    // /e7cd
       border: 1px solid var(--az-navbar-font-color);
       @include border-radius(50%);
     }

--- a/site/layouts/partials/stylesheet.html
+++ b/site/layouts/partials/stylesheet.html
@@ -1,4 +1,4 @@
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,300..400,0..1,0" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,300..600,0..1,0" rel="stylesheet">
 <link href="https://cdn.digital.arizona.edu/lib/az-icons/main/az-icons-styles.css" rel="stylesheet">
 <link href="https://use.typekit.net/emv3zbo.css" rel="stylesheet" crossorigin="anonymous">
 {{ if hugo.IsProduction -}}


### PR DESCRIPTION
expand_circle_down has been replace by [keyboard_arrow_down](https://fonts.google.com/icons?icon.style=Rounded&icon.set=Material+Symbols&icon.size=24&icon.color=%23e3e3e3&selected=Material+Symbols+Rounded:keyboard_arrow_down:FILL@0;wght@400;GRAD@0;opsz@24&icon.query=chevron+down) and a round border.

Review site: https://review.digital.arizona.edu/arizona-bootstrap/issue/1828/docs/5.0/examples/navbar-az/