### PR TITLE
Fixes #1855: Update focus visible styles to be more consistent in AZ Navbar

### DIFF
--- a/scss/custom/_navbar.scss
+++ b/scss/custom/_navbar.scss
@@ -93,7 +93,7 @@
     &:focus-visible {
       @include border-radius(2px);
       outline: 0;
-      box-shadow: 0 0 0 .25rem rgba(171, 5, 32, .5);
+      box-shadow: 0 0 0 .25rem rgba($red, .5);
     }
   }
 
@@ -228,7 +228,7 @@
       &:focus-visible {
         @include border-radius(2px);
         outline: 0;
-        box-shadow: inset 0 0 0 .25rem rgba(171, 5, 32, .5);
+        box-shadow: inset 0 0 0 .25rem rgba($red, .5);
       }
 
       &:focus::after {
@@ -318,7 +318,7 @@
     &:focus-visible {
       @include border-radius(2px);
       outline: 0;
-      box-shadow: inset 0 0 0 .25rem rgba(171, 5, 32, .5);
+      box-shadow: inset 0 0 0 .25rem rgba($red, .5);
     }
 
     &:hover {
@@ -382,7 +382,7 @@
       &:focus-visible {
         @include border-radius(2px);
         outline: 0;
-        box-shadow: inset 0 0 0 .25rem rgba(171, 5, 32, .5);
+        box-shadow: inset 0 0 0 .25rem rgba($red, .5);
       }
       /* stylelint-enable selector-no-qualifying-type */
     }


### PR DESCRIPTION
Implements focus visible styles suggested in #1855.

### How to test
1. Navigate to the [AZ Navbar Example](https://review.digital.arizona.edu/arizona-bootstrap/bug/1855/docs/5.0/examples/navbar-az/) page.
2. Keyboard navigate through the navbar to see more consistent focus-visible styles. Compare with [LIVE](https://digital.arizona.edu/arizona-bootstrap/v5/docs/5.0/examples/navbar-az/) if needed.

Review site: https://review.digital.arizona.edu/arizona-bootstrap/bug/1855/