### PR TITLE
Fixes: #1854: Single Dropdown text should not have an underline when its submenu is already open in AZ Navbar

### DIFF
--- a/scss/custom/_navbar.scss
+++ b/scss/custom/_navbar.scss
@@ -69,7 +69,6 @@
     &.active,
     &.is-active,
     &:active,
-    &.show,
     &:hover {
       text-decoration: underline;
       text-decoration-thickness: 2px;
@@ -88,11 +87,6 @@
     // On hover, underline is blue, text remains blue (variable override above on navbar-nav)
     &:hover {
       text-decoration-color: var(--az-navbar-font-hover-color);
-    }
-
-    // Single dropdowns: don't keep underline just because the menu is open
-    &:not(.active):not(.is-active):not(:active).dropdown-toggle.show:not(:hover) {
-      text-decoration: none;
     }
 
     &:focus-visible {


### PR DESCRIPTION
See #1854. Changes the text of the Single Dropdown to only be underlined when the Single Dropdown toggle itself (text or icon) is being hovered directly. The text previously remained underlined when hovering the corresponding dropdown submenu in addition to the dropdown toggle.

### How to test
1. Navigate to the [AZ Navbar Example](https://review.digital.arizona.edu/arizona-bootstrap/bug/1854/docs/5.0/examples/navbar-az/) page at `/docs/5.0/examples/navbar-az/`.
2. Verify Single Dropdown hover behavior. Compare with the [Live environment](https://digital.arizona.edu/arizona-bootstrap/v5/docs/5.0/examples/navbar-az/) if needed.

Review site: https://review.digital.arizona.edu/arizona-bootstrap/bug/1854/