### PR TITLE
Closes #1866: Prevent all Dependabot dev dependency pull requests from failing.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
       - dependency-name: "eslint-plugin-unicorn"
       - dependency-name: "jquery"
       - dependency-name: "sass"
+      - dependency-name: "stylelint"
       - dependency-name: "vnu-jar"
     open-pull-requests-limit: 10
     labels:
@@ -35,6 +36,7 @@ updates:
       - dependency-name: "eslint-plugin-unicorn"
       - dependency-name: "jquery"
       - dependency-name: "sass"
+      - dependency-name: "stylelint"
       - dependency-name: "vnu-jar"
     open-pull-requests-limit: 10
     labels:


### PR DESCRIPTION
Dependabot is including the major version bump for Stylelint in the dev dependency update pull requests, but this isn't compatible even with upstream Bootstrap. There, rather than pinning Stylelint to the v16 major version, they're putting all dev dependency PRs on hold until a v6 Bootstrap release. We should get Dependabot to ignore Stylelint for now, but then sort out the best long-term approach for Arizona Bootstrap.