### PR TITLE
Closes #1876: Disallow 300 weight Material Symbols Rounded icons

### DIFF
--- a/site/layouts/partials/stylesheet.html
+++ b/site/layouts/partials/stylesheet.html
@@ -1,4 +1,4 @@
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,300..400,0..1,0" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,1,0" rel="stylesheet">
 <link href="https://cdn.digital.arizona.edu/lib/az-icons/main/az-icons-styles.css" rel="stylesheet">
 <link href="https://use.typekit.net/emv3zbo.css" rel="stylesheet" crossorigin="anonymous">
 {{ if hugo.IsProduction -}}


### PR DESCRIPTION
Restores Material Symbols Rounded import statement to original settings.

1. Only import 400 weight icon font family (previously allowed 300 and 400).
2. Only import solid fill icons (previously allowed outline and filled).

### How to test
1. Navigate to the [AZ Navbar Example](https://review.digital.arizona.edu/arizona-bootstrap/issue/1876/docs/5.0/examples/navbar-az/) page at `/docs/5.0/examples/navbar-az/`.
2. Verify no visual change with icons used in AZ Navbar. Compare with the [Live environment](https://digital.arizona.edu/arizona-bootstrap/v5/docs/5.0/examples/navbar-az/) if needed.
    1. Primary level icon is an inline SVG so it should not be affected by these changes.
    2. Secondary level "plus" and "minus" icons were already set to 400 weight and solid fill and should not be affected by these changes.