### PR TITLE
Fixes #1877: Closing a primary dropdown-toggle should reset the state of its dropdown menu

### DIFF
--- a/js/src/navbar.js
+++ b/js/src/navbar.js
@@ -410,6 +410,19 @@ class NavbarHoverDropdown extends Dropdown {
       return
     }
 
+    const menu = this._menu || this._dropdownElement?.querySelector('.dropdown-menu')
+    const togglesByTarget = new Map()
+
+    if (menu) {
+      const toggles = menu.querySelectorAll('[data-bs-target]')
+      for (const toggle of toggles) {
+        const target = toggle.getAttribute('data-bs-target')
+        if (target) {
+          togglesByTarget.set(target, toggle)
+        }
+      }
+    }
+
     for (const [collapse, wasShown] of this._initialCollapseStates) {
       const isShown = collapse.classList.contains('show')
 
@@ -427,8 +440,7 @@ class NavbarHoverDropdown extends Dropdown {
 
       // Sync the toggle button's aria-expanded attribute.
       if (collapse.id) {
-        const menu = this._menu || this._dropdownElement?.querySelector('.dropdown-menu')
-        const toggle = menu?.querySelector(`[data-bs-target="#${collapse.id}"]`)
+        const toggle = togglesByTarget.get(`#${collapse.id}`)
         if (toggle) {
           toggle.setAttribute('aria-expanded', String(wasShown))
         }


### PR DESCRIPTION
See #1877.

## How to test
1. Navigate to the [AZ Navbar Example](https://review.digital.arizona.edu/arizona-bootstrap/bug/1877-1/docs/5.0/examples/navbar-az/) page at `/docs/5.0/examples/navbar-az/`.
2. Open a dropdown menu and observe the default expansion states of the collapsible submenus (if present). The expansion states are determined by the currently active navigation element. See #1877 for expected behavior.
3. Open a collapsible submenu that is not shown by default.
4. Close the dropdown menu you just interacted with.
5. Re-open the dropdown menu you just closed.
6. Observe that the collapsible submenu expansion states have been reset to their default values.

Review site: https://review.digital.arizona.edu/arizona-bootstrap/bug/1877-1/