### PR TITLE
Fixes #1902: Dead space in new navbar causes dropdown to close for slower moving cursors

### DIFF
--- a/scss/custom/_navbar.scss
+++ b/scss/custom/_navbar.scss
@@ -27,6 +27,7 @@
   --az-navbar-dropdown-padding-x: 12px;
   --az-navbar-dropdown-toggle-icon-gap: 6px;
   --az-navbar-dropdown-toggle-icon-size: 24px;
+  --az-navbar-hover-bridge-height: 20px;
   --az-navbar-dropdown-max-width: 50%; // Dynamically updated via JS to half the navbar width in px
   --az-navbar-secondary-dropdown-item-padding-x: 20px;
   --az-navbar-secondary-dropdown-item-padding-y: 12px;
@@ -130,6 +131,36 @@
   // Override Bootstrap's margin-left on adjacent buttons in split dropdown btn-groups
   .dropdown.btn-group > .dropdown-toggle-split {
     margin-left: 0;
+  }
+
+  // Desktop hover bridge between top-level toggle and menu to keep hover open while crossing the vertical gap.
+  // Applies to both single-dropdown toggles and split-dropdown toggle buttons without requiring HTML changes.
+  @media (hover: hover) and (pointer: fine) {
+    .nav-item.dropdown > .dropdown-toggle:is(:hover, :focus, [aria-expanded="true"]) {
+      position: relative;
+
+      &::before {
+        position: absolute;
+        top: 100%;
+        right: 0;
+        left: 0;
+        display: block;
+        height: var(--az-navbar-hover-bridge-height);
+        content: "";
+      }
+    }
+
+    .nav-item.dropdown > .dropdown-menu {
+      &::before {
+        position: absolute;
+        right: 0;
+        bottom: 100%;
+        left: 0;
+        display: block;
+        height: var(--az-navbar-hover-bridge-height);
+        content: "";
+      }
+    }
   }
 
   // Primary dropdown toggle (single dropdown and split dropdown toggle).


### PR DESCRIPTION
See #1902.

Extends the downward hover area of `.dropdown-toggle` so that slow hovers reach the `.dropdown-menu` without prematurely dismissing. This was previously handled with a .3s delay.

## How to test
1. Navigate to [AZ Navbar Example](https://review.digital.arizona.edu/arizona-bootstrap/bug/1902/docs/5.0/examples/navbar-az/) page at `5.0/examples/navbar-az/`.
2. Hover-open either a Single or Split Dropdown.
3. Slowly move your cursor (hover) down to the corresponding dropdown menu. The dropdown menu should not dismiss as long as you remain within the vertical bounds of the `.dropdown-toggle` or within the `.dropdown-menu`. Note that `.dropdown-toggle` is positioned differently in [Single](https://digital.arizona.edu/arizona-bootstrap/v5/docs/5.0/components/dropdowns/#single-button) vs [Split](https://digital.arizona.edu/arizona-bootstrap/v5/docs/5.0/components/dropdowns/#split-button) Dropdowns.

Review site: https://review.digital.arizona.edu/arizona-bootstrap/bug/1902/