### PR TITLE
Fixes #1905: Remove underline on hover for Single Dropdowns in AZ Navbar

### DIFF
--- a/scss/custom/_navbar.scss
+++ b/scss/custom/_navbar.scss
@@ -94,7 +94,8 @@
     &.active,
     &.is-active,
     &:active,
-    &:hover {
+    // Single Dropdown only: remove hover underline at the primary level.
+    &:not(.dropdown-toggle):hover {
       @extend %text-decoration-properties;
       background-color: unset;
     }
@@ -117,11 +118,6 @@
       outline: 0;
       box-shadow: var(--az-navbar-focus-ring);
     }
-  }
-
-  // Single Dropdown only: remove hover underline at the primary level.
-  .dropdown:not(.btn-group) > .nav-link.dropdown-toggle:hover {
-    text-decoration: none;
   }
 
   // For Split Dropdown only.


### PR DESCRIPTION
See #1905.

## How to test
1. Navigate to the [AZ Navbar Example](https://review.digital.arizona.edu/arizona-bootstrap/bug/1905/docs/5.0/examples/navbar-az/) page at `/docs/5.0/examples/navbar-az/`.
2. Hover over the "Single Dropdown" text at the primary level.
3. Verify the text of Single Dropdown is not underlined.

Review site: https://review.digital.arizona.edu/arizona-bootstrap/bug/1905