### PR TITLE
Closes #5377 (quickstart): Footer link accessibility

### DIFF
--- a/scss/custom/_nav.scss
+++ b/scss/custom/_nav.scss
@@ -6,7 +6,10 @@
     padding: 0 .6rem;
   }
   .nav-link {
-    padding: 0;
+    padding: 4px 0px 4px 0px;
+    min-height: 24px;
+    display: flex;
+    align-items: center;
     font-weight: 500;
     color: $dark-silver;
     border-bottom: 2px solid transparent;


### PR DESCRIPTION
(Quickstart issue)
Closes #5377
https://github.com/az-digital/az_quickstart/issues/5377

Adds suggested accessiblity issues to scss>custom>_nav
This change is meant to target the Global Footer in Quickstart, particularly the links and icons in the footer menu.