### PR TITLE
Closes #1969: Add support for a blue Arizona header

### DIFF
--- a/site/assets/scss/_custom-docs.scss
+++ b/site/assets/scss/_custom-docs.scss
@@ -43,7 +43,7 @@
   --#{$prefix}nav-link-color: var(--#{$prefix}navbar-color);
 
   &::after {
-    background-image: linear-gradient(var(--bs-chili), var(--bs-chili) 95%);
+    background-image: linear-gradient(var(--bs-blue), var(--bs-blue) 95%);
   }
 }
 
@@ -51,8 +51,9 @@
   .nav-item {
     &:hover,
     &:has(> .nav-link.active),
-    &:has(> .nav-link:active) {
-      background-color: initial;
+    &:has(> .nav-link:active),
+    &:has(> .nav-link.show) {
+      background-color: transparent;
     }
   }
 
@@ -61,7 +62,7 @@
     &:hover,
     &:active,
     &.active {
-      background-color: initial;
+      background-color: transparent;
     }
   }
 }

--- a/site/content/docs/5.1/components/arizona-header.md
+++ b/site/content/docs/5.1/components/arizona-header.md
@@ -53,7 +53,7 @@ The blue Arizona Header is to be used on marketing-approved subdomains of arizon
 </div>
 
 ```html
-<div class="arizona-header bg-blue">
+<div class="arizona-header az-fixed-header-on-mobile bg-blue">
   <div class="container">
     <div class="row">
       <a class="arizona-logo col-auto" href="https://www.arizona.edu" title="The University of Arizona homepage">

--- a/site/content/docs/5.1/components/arizona-header.md
+++ b/site/content/docs/5.1/components/arizona-header.md
@@ -53,7 +53,7 @@ The blue Arizona Header is to be used on marketing-approved subdomains of arizon
 </div>
 
 ```html
-<div class="arizona-header az-fixed-header-on-mobile bg-blue" id="header_arizona">
+<div class="arizona-header bg-blue">
   <div class="container">
     <div class="row">
       <a class="arizona-logo col-auto" href="https://www.arizona.edu" title="The University of Arizona homepage">

--- a/site/content/docs/5.1/components/arizona-header.md
+++ b/site/content/docs/5.1/components/arizona-header.md
@@ -53,7 +53,7 @@ The blue Arizona Header is to be used on marketing-approved subdomains of arizon
 </div>
 
 ```html
-<div class="arizona-header az-fixed-header-on-mobile bg-blue">
+<div class="arizona-header az-fixed-header-on-mobile bg-blue" id="header_arizona_2">
   <div class="container">
     <div class="row">
       <a class="arizona-logo col-auto" href="https://www.arizona.edu" title="The University of Arizona homepage">

--- a/site/content/docs/5.1/components/arizona-header.md
+++ b/site/content/docs/5.1/components/arizona-header.md
@@ -39,6 +39,30 @@ The Arizona Header is to be used on all subdomains of arizona.edu.
 </div>
 ```
 
+### Blue header
+
+<div class="arizona-header bg-blue">
+  <div class="container">
+    <div class="row">
+      <a class="arizona-logo col-auto" href="https://www.arizona.edu" title="The University of Arizona homepage">
+        <img class="arizona-line-logo" alt="The University of Arizona Wordmark Line Logo White" src="https://cdn.digital.arizona.edu/logos/v1.0.0/ua_wordmark_line_logo_white_rgb.min.svg" fetchpriority="high">
+      </a>
+    </div>
+  </div>
+</div>
+<p></p>
+
+```html
+<div class="arizona-header az-fixed-header-on-mobile bg-blue" id="header_arizona">
+  <div class="container">
+    <div class="row">
+      <a class="arizona-logo col-auto" href="https://www.arizona.edu" title="The University of Arizona homepage">
+        <img class="arizona-line-logo" alt="The University of Arizona Wordmark Line Logo White" src="https://cdn.digital.arizona.edu/logos/v1.0.0/ua_wordmark_line_logo_white_rgb.min.svg" fetchpriority="high">
+      </a>
+    </div>
+  </div>
+</div>
+```
 
 ## Extending the header
 

--- a/site/content/docs/5.1/components/arizona-header.md
+++ b/site/content/docs/5.1/components/arizona-header.md
@@ -25,7 +25,6 @@ The Arizona Header is to be used on all subdomains of arizona.edu.
     </div>
   </div>
 </div>
-<p></p>
 
 ```html
 <div class="arizona-header az-fixed-header-on-mobile bg-red" id="header_arizona">
@@ -41,6 +40,8 @@ The Arizona Header is to be used on all subdomains of arizona.edu.
 
 ### Blue header
 
+The blue Arizona Header is to be used on marketing-approved subdomains of arizona.edu. This functionality should not be used until the flagship arizona.edu website is using a blue header.
+
 <div class="arizona-header bg-blue">
   <div class="container">
     <div class="row">
@@ -50,7 +51,6 @@ The Arizona Header is to be used on all subdomains of arizona.edu.
     </div>
   </div>
 </div>
-<p></p>
 
 ```html
 <div class="arizona-header az-fixed-header-on-mobile bg-blue" id="header_arizona">

--- a/site/layouts/partials/docs-navbar.html
+++ b/site/layouts/partials/docs-navbar.html
@@ -45,7 +45,7 @@
 
         <hr class="d-lg-none text-white-50">
 
-        <ul class="navbar-nav flex-row flex-wrap ms-md-auto">
+        <ul class="navbar-nav flex-row flex-wrap ms-md-auto bd-navbar-nav">
           <li class="nav-item col-6 col-lg-auto">
             <a class="nav-link py-2 px-0 px-lg-2" href="{{ .Site.Params.github_org }}" target="_blank" rel="noopener">
               {{ partial "icons/github.svg" (dict "class" "navbar-nav-svg" "width" "16" "height" "16") }}


### PR DESCRIPTION
See #1969 

Adds a subsection for the blue header with example and source code. The only change needed is `.bg-red` to `.bg-blue` and, in the case of the **Extending the header** section, `.text-bg-red` to `.text-bg-blue`.

Review site: https://review.digital.arizona.edu/arizona-bootstrap/issue/1969/docs/5.1/components/arizona-header/