### PR TITLE
[Branch of issue/1937] Support mobile display of AZ Navbar Fullscreen

### DIFF
--- a/js/index.esm.js
+++ b/js/index.esm.js
@@ -19,6 +19,7 @@ export { default as Toast } from '../node_modules/bootstrap/js/src/toast.js'
 export { default as Tooltip } from '../node_modules/bootstrap/js/src/tooltip.js'
 export { default as fixModalAriaHidden } from './src/modal.js'
 export { default as AzTab } from './src/az-tab.js'
+export { default as NavbarAzFullscreenMobileNav } from './src/navbar-az-fullscreen-mobile-nav.js'
 export { default as photoGalleryGridSlideToImage } from './src/photogallery.js'
 export { default as enableAzNavbar } from './src/navbar.js'
 

--- a/js/index.umd.js
+++ b/js/index.umd.js
@@ -19,6 +19,7 @@ import Toast from '../node_modules/bootstrap/js/src/toast.js'
 import Tooltip from '../node_modules/bootstrap/js/src/tooltip.js'
 import fixModalAriaHidden from './src/modal.js'
 import AzTab from './src/az-tab.js'
+import NavbarAzFullscreenMobileNav from './src/navbar-az-fullscreen-mobile-nav.js'
 import photoGalleryGridSlideToImage from './src/photogallery.js'
 import enableAzNavbar from './src/navbar.js'
 
@@ -34,6 +35,7 @@ export default {
   ScrollSpy,
   Tab,
   AzTab,
+  NavbarAzFullscreenMobileNav,
   Toast,
   Tooltip,
   fixModalAriaHidden,

--- a/js/src/navbar-az-fullscreen-mobile-nav.js
+++ b/js/src/navbar-az-fullscreen-mobile-nav.js
@@ -21,6 +21,15 @@ class NavbarAzFullscreenMobileNav {
       return
     }
 
+    // Save call-to-action items as a fragment
+    const ctaElement = this.mobileCol.querySelector('.navbar-az-fullscreen-actions')
+    this.ctaFragment = null
+    if (ctaElement) {
+      const fragment = document.createDocumentFragment()
+      fragment.append(ctaElement.cloneNode(true))
+      this.ctaFragment = fragment
+    }
+
     this.navigationStack = [] // Stack to track navigation history
     this.init()
   }
@@ -238,7 +247,19 @@ class NavbarAzFullscreenMobileNav {
   resetToPrimaryNav() {
     const primaryNav = document.querySelector('.navbar-az-fullscreen-nav-primary')
     if (primaryNav) {
-      this.mobileCol.innerHTML = primaryNav.outerHTML
+      // Clear the mobile column
+      this.mobileCol.innerHTML = ''
+
+      // Add call-to-action items
+      if (this.ctaFragment) {
+        const ctaClone = this.ctaFragment.cloneNode(true)
+        this.mobileCol.append(ctaClone)
+      }
+
+      // Add primary navigation
+      const primaryClone = primaryNav.cloneNode(true)
+      this.mobileCol.append(primaryClone)
+
       this.setupPrimaryNavListeners()
     }
   }

--- a/js/src/navbar-az-fullscreen-mobile-nav.js
+++ b/js/src/navbar-az-fullscreen-mobile-nav.js
@@ -7,279 +7,270 @@
 
 /**
  * Arizona Bootstrap Fullscreen Navbar Mobile Navigation
- * Handles paged navigation for mobile view of .navbar-az-fullscreen-nav-mobile-col
+ * Handles paged navigation for mobile view of #navbar-az-fullscreen-nav-mobile-col.
  */
 
-(function () {
-  'use strict';
+class NavbarAzFullscreenMobileNav {
+  constructor() {
+    this.mobileCol = document.querySelector('#navbar-az-fullscreen-nav-mobile-col')
+    this.desktopSecondaryContainer = document.querySelector('.navbar-az-fullscreen-nav-secondary-tertiary-cols')
+    this.primaryNavContainer = document.querySelector('.navbar-az-fullscreen-nav-primary-col')
 
-  class NavbarAzFullscreenMobileNav {
-    constructor() {
-      this.mobileCol = document.querySelector('.navbar-az-fullscreen-nav-mobile-col');
-      this.desktopSecondaryContainer = document.querySelector('.navbar-az-fullscreen-nav-secondary-tertiary-cols');
-      this.primaryNavContainer = document.querySelector('.navbar-az-fullscreen-nav-primary-col');
-
-      if (!this.mobileCol) {
-        console.warn('Mobile navbar column not found');
-        return;
-      }
-
-      this.navigationStack = []; // Stack to track navigation history
-      this.init();
+    if (!this.mobileCol) {
+      // Mobile navbar column not found
+      return
     }
 
-    /**
-     * Initialize the mobile navigation
-     */
-    init() {
-      // Set up event listeners for primary navigation items in mobile view
-      this.setupPrimaryNavListeners();
-    }
+    this.navigationStack = [] // Stack to track navigation history
+    this.init()
+  }
 
-    /**
-     * Set up click listeners on primary navigation items
-     */
-    setupPrimaryNavListeners() {
-      const primaryButtons = this.mobileCol.querySelectorAll('.navbar-az-fullscreen-nav-primary .nav-link');
+  /**
+   * Initialize the mobile navigation
+   */
+  init() {
+    // Set up event listeners for primary navigation items in mobile view
+    this.setupPrimaryNavListeners()
+  }
 
-      primaryButtons.forEach((button) => {
-        button.addEventListener('click', (e) => {
-          e.preventDefault();
-          const targetId = button.getAttribute('data-bs-target');
-          const label = button.textContent.trim();
+  /**
+   * Set up click listeners on primary navigation items
+   */
+  setupPrimaryNavListeners() {
+    const primaryButtons = this.mobileCol.querySelectorAll('.navbar-az-fullscreen-nav-primary .nav-link')
 
-          if (targetId) {
-            this.showSecondaryNav(targetId, label);
-          }
-        });
-      });
-    }
+    for (const button of primaryButtons) {
+      button.addEventListener('click', e => {
+        e.preventDefault()
+        const targetId = button.getAttribute('data-bs-target')
+        const label = button.textContent.trim()
 
-    /**
-     * Display secondary navigation for a primary menu item
-     * @param {string} targetId - The ID of the secondary content to display
-     * @param {string} label - The label of the primary menu item
-     */
-    showSecondaryNav(targetId, label) {
-      // Extract the menu content from desktop view
-      const desktopContent = document.querySelector(targetId);
-      if (!desktopContent) {
-        console.warn(`Secondary content not found for ${targetId}`);
-        return;
-      }
-
-      // Create the secondary menu display
-      const secondaryMenuHtml = this.buildSecondaryMenuHtml(desktopContent, label);
-
-      // Update navigation stack
-      this.navigationStack.push({
-        type: 'primary',
-        label: label,
-      });
-
-      // Update mobile column
-      this.mobileCol.innerHTML = secondaryMenuHtml;
-
-      // Set up listeners for the new secondary menu
-      this.setupSecondaryNavListeners(label);
-    }
-
-    /**
-     * Build HTML for secondary menu display
-     * @param {Element} desktopContent - The desktop secondary content element
-     * @param {string} label - The label of the menu
-     * @returns {string} HTML string for the secondary menu
-     */
-    buildSecondaryMenuHtml(desktopContent, label) {
-      let html = '<div class="navbar-az-fullscreen-nav-secondary-mobile">';
-
-      // Add back button
-      html += this.createBackButton('Main Menu');
-
-      // Extract secondary nav content from desktop
-      const secondaryNav = desktopContent.querySelector('.navbar-az-fullscreen-nav-secondary');
-      if (secondaryNav) {
-        // Clone the secondary nav structure
-        const navContent = secondaryNav.innerHTML;
-        html += `<nav class="nav flex-column navbar-az-fullscreen-nav-secondary">`;
-        html += navContent;
-        html += `</nav>`;
-      }
-
-      html += '</div>';
-      return html;
-    }
-
-    /**
-     * Set up event listeners for secondary navigation items
-     * @param {string} parentLabel - The label of the parent menu
-     */
-    setupSecondaryNavListeners(parentLabel) {
-      // Back button
-      const backButton = this.mobileCol.querySelector('.navbar-az-fullscreen-nav-back-btn');
-      if (backButton) {
-        backButton.addEventListener('click', () => {
-          this.goBack();
-        });
-      }
-
-      // Secondary menu toggle buttons (for tertiary menus)
-      const toggleButtons = this.mobileCol.querySelectorAll('.navbar-az-fullscreen-nav-toggle');
-      toggleButtons.forEach((button) => {
-        button.addEventListener('click', (e) => {
-          e.preventDefault();
-          const tertiaryId = button.getAttribute('data-bs-target');
-          const tertiaryContent = document.querySelector(tertiaryId);
-
-          if (tertiaryContent) {
-            // Extract the tertiary label from the parent link
-            const parentLink = button.previousElementSibling?.textContent?.trim() || parentLabel;
-            this.showTertiaryNav(tertiaryContent, parentLink, parentLabel);
-          }
-        });
-      });
-    }
-
-    /**
-     * Display tertiary navigation
-     * @param {Element} tertiaryContent - The tertiary content element
-     * @param {string} label - The label of the tertiary menu
-     * @param {string} parentLabel - The label of the parent secondary menu
-     */
-    showTertiaryNav(tertiaryContent, label, parentLabel) {
-      const tertiaryMenuHtml = this.buildTertiaryMenuHtml(tertiaryContent, label, parentLabel);
-
-      // Update navigation stack
-      this.navigationStack.push({
-        type: 'secondary',
-        label: label,
-        parentLabel: parentLabel,
-      });
-
-      // Update mobile column
-      this.mobileCol.innerHTML = tertiaryMenuHtml;
-
-      // Set up listeners for back button
-      const backButton = this.mobileCol.querySelector('.navbar-az-fullscreen-nav-back-btn');
-      if (backButton) {
-        backButton.addEventListener('click', () => {
-          this.goBack();
-        });
-      }
-    }
-
-    /**
-     * Build HTML for tertiary menu display
-     * @param {Element} tertiaryContent - The tertiary content element
-     * @param {string} label - The label of the menu
-     * @param {string} parentLabel - The label of the parent menu
-     * @returns {string} HTML string for the tertiary menu
-     */
-    buildTertiaryMenuHtml(tertiaryContent, label, parentLabel) {
-      let html = '<div class="navbar-az-fullscreen-nav-tertiary-mobile">';
-
-      // Add back button
-      html += this.createBackButton(`${parentLabel}`);
-
-      // Extract tertiary nav content
-      const tertiaryNav = tertiaryContent.querySelector('.navbar-az-fullscreen-nav-secondary');
-      if (tertiaryNav) {
-        const navContent = tertiaryNav.innerHTML;
-        html += `<nav class="nav flex-column navbar-az-fullscreen-nav-secondary">`;
-        html += navContent;
-        html += `</nav>`;
-      } else {
-        // Fallback: use the entire content if no nav element found
-        html += tertiaryContent.innerHTML;
-      }
-
-      html += '</div>';
-      return html;
-    }
-
-    /**
-     * Create a back button element
-     * @param {string} label - The label for the back button
-     * @returns {string} HTML string for the back button
-     */
-    createBackButton(label) {
-      return `
-        <div class="navbar-az-fullscreen-nav-back">
-          <button type="button" class="btn navbar-az-fullscreen-nav-back-btn" aria-label="Back to ${label}">
-            Back to ${label}
-          </button>
-          <hr class="border-top border-azurite opacity-100" aria-hidden="true" role="presentation">
-        </div>
-      `;
-    }
-
-    /**
-     * Navigate back to the previous menu
-     */
-    goBack() {
-      // Remove current level from stack
-      this.navigationStack.pop();
-
-      if (this.navigationStack.length === 0) {
-        // Back to primary menu
-        this.resetToPrimaryNav();
-      } else {
-        const previousLevel = this.navigationStack[this.navigationStack.length - 1];
-        if (previousLevel.type === 'primary') {
-          // Back to secondary menu
-          this.navigationStack.pop();
-          this.showSecondaryNav(
-            this.getTargetIdForLabel(previousLevel.label),
-            previousLevel.label
-          );
+        if (targetId) {
+          this.showSecondaryNav(targetId, label)
         }
+      })
+    }
+  }
+
+  /**
+   * Display secondary navigation for a primary menu item
+   * @param {string} targetId - The ID of the secondary content to display
+   * @param {string} label - The label of the primary menu item
+   */
+  showSecondaryNav(targetId, label) {
+    // Extract the menu content from desktop view
+    const desktopContent = document.querySelector(targetId)
+    if (!desktopContent) {
+      // Secondary content not found for ${targetId}
+      return
+    }
+
+    // Create the secondary menu display
+    const secondaryMenuHtml = this.buildSecondaryMenuHtml(desktopContent)
+
+    // Update navigation stack
+    this.navigationStack.push({
+      type: 'primary',
+      label
+    })
+
+    // Update mobile column
+    this.mobileCol.innerHTML = secondaryMenuHtml
+
+    // Set up listeners for the new secondary menu
+    this.setupSecondaryNavListeners(label)
+  }
+
+  /**
+   * Build HTML for secondary menu display
+   * @param {Element} desktopContent - The desktop secondary content element
+   * @returns {string} HTML string for the secondary menu
+   */
+  buildSecondaryMenuHtml(desktopContent) {
+    let html = '<div class="navbar-az-fullscreen-nav-secondary-mobile">'
+
+    // Add back button
+    html += this.createBackButton('Main Menu')
+
+    // Extract secondary nav content from desktop
+    const secondaryNav = desktopContent.querySelector('.navbar-az-fullscreen-nav-secondary')
+    if (secondaryNav) {
+      // Clone the secondary nav structure
+      const navContent = secondaryNav.innerHTML
+      html += '<nav class="nav flex-column navbar-az-fullscreen-nav-secondary">'
+      html += navContent
+      html += '</nav>'
+    }
+
+    html += '</div>'
+    return html
+  }
+
+  /**
+   * Set up event listeners for secondary navigation items
+   * @param {string} parentLabel - The label of the parent menu
+   */
+  setupSecondaryNavListeners(parentLabel) {
+    // Back button
+    const backButton = this.mobileCol.querySelector('.navbar-az-fullscreen-nav-back-btn')
+    if (backButton) {
+      backButton.addEventListener('click', () => {
+        this.goBack()
+      })
+    }
+
+    // Secondary menu toggle buttons (for tertiary menus)
+    const toggleButtons = this.mobileCol.querySelectorAll('.navbar-az-fullscreen-nav-toggle')
+    for (const button of toggleButtons) {
+      button.addEventListener('click', e => {
+        e.preventDefault()
+        const tertiaryId = button.getAttribute('data-bs-target')
+        const tertiaryContent = document.querySelector(tertiaryId)
+
+        if (tertiaryContent) {
+          // Extract the tertiary label from the parent link
+          const parentLink = button.previousElementSibling?.textContent?.trim() || parentLabel
+          this.showTertiaryNav(tertiaryContent, parentLink, parentLabel)
+        }
+      })
+    }
+  }
+
+  /**
+   * Display tertiary navigation
+   * @param {Element} tertiaryContent - The tertiary content element
+   * @param {string} label - The label of the tertiary menu
+   * @param {string} parentLabel - The label of the parent secondary menu
+   */
+  showTertiaryNav(tertiaryContent, label, parentLabel) {
+    const tertiaryMenuHtml = this.buildTertiaryMenuHtml(tertiaryContent, label, parentLabel)
+
+    // Update navigation stack
+    this.navigationStack.push({
+      type: 'secondary',
+      label,
+      parentLabel
+    })
+
+    // Update mobile column
+    this.mobileCol.innerHTML = tertiaryMenuHtml
+
+    // Set up listeners for back button
+    const backButton = this.mobileCol.querySelector('.navbar-az-fullscreen-nav-back-btn')
+    if (backButton) {
+      backButton.addEventListener('click', () => {
+        this.goBack()
+      })
+    }
+  }
+
+  /**
+   * Build HTML for tertiary menu display
+   * @param {Element} tertiaryContent - The tertiary content element
+   * @param {string} label - The label of the menu
+   * @param {string} parentLabel - The label of the parent menu
+   * @returns {string} HTML string for the tertiary menu
+   */
+  buildTertiaryMenuHtml(tertiaryContent, label, parentLabel) {
+    let html = '<div class="navbar-az-fullscreen-nav-tertiary-mobile">'
+
+    // Add back button
+    html += this.createBackButton(`${parentLabel}`)
+
+    // Extract tertiary nav content
+    const tertiaryNav = tertiaryContent.querySelector('.navbar-az-fullscreen-nav-secondary')
+    if (tertiaryNav) {
+      const navContent = tertiaryNav.innerHTML
+      html += '<nav class="nav flex-column navbar-az-fullscreen-nav-secondary">'
+      html += navContent
+      html += '</nav>'
+    } else {
+      // Fallback: use the entire content if no nav element found
+      html += tertiaryContent.innerHTML
+    }
+
+    html += '</div>'
+    return html
+  }
+
+  /**
+   * Create a back button element
+   * @param {string} label - The label for the back button
+   * @returns {string} HTML string for the back button
+   */
+  createBackButton(label) {
+    return `
+      <div class="navbar-az-fullscreen-nav-back">
+        <button type="button" class="btn navbar-az-fullscreen-nav-back-btn" aria-label="Back to ${label}">
+          Back to ${label}
+        </button>
+        <hr class="border-top border-azurite opacity-100" aria-hidden="true" role="presentation">
+      </div>
+    `
+  }
+
+  /**
+   * Navigate back to the previous menu
+   */
+  goBack() {
+    // Remove current level from stack
+    this.navigationStack.pop()
+
+    if (this.navigationStack.length === 0) {
+      // Back to primary menu
+      this.resetToPrimaryNav()
+    } else {
+      const previousLevel = this.navigationStack[this.navigationStack.length - 1]
+      if (previousLevel.type === 'primary') {
+        // Back to secondary menu
+        this.navigationStack.pop()
+        this.showSecondaryNav(
+          this.getTargetIdForLabel(previousLevel.label),
+          previousLevel.label
+        )
       }
     }
+  }
 
-    /**
-     * Reset to primary navigation
-     */
-    resetToPrimaryNav() {
-      const primaryNav = document.querySelector('.navbar-az-fullscreen-nav-primary');
-      if (primaryNav) {
-        this.mobileCol.innerHTML = primaryNav.outerHTML;
-        this.setupPrimaryNavListeners();
-      }
-    }
-
-    /**
-     * Get the target ID for a primary menu label
-     * @param {string} label - The menu label
-     * @returns {string} The target ID
-     */
-    getTargetIdForLabel(label) {
-      const labelMap = {
-        'Admissions': '#az-navbar-az-fullscreen-primary-admissions-content',
-        'Academics': '#az-navbar-az-fullscreen-primary-academics-content',
-        'Research': '#az-navbar-az-fullscreen-primary-research-content',
-        'Campus Life': '#az-navbar-az-fullscreen-primary-campus-life-content',
-        'About': '#az-navbar-az-fullscreen-primary-about-content',
-      };
-      return labelMap[label] || '';
+  /**
+   * Reset to primary navigation
+   */
+  resetToPrimaryNav() {
+    const primaryNav = document.querySelector('.navbar-az-fullscreen-nav-primary')
+    if (primaryNav) {
+      this.mobileCol.innerHTML = primaryNav.outerHTML
+      this.setupPrimaryNavListeners()
     }
   }
 
-  // Initialize when DOM is ready
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => {
-      new NavbarAzFullscreenMobileNav();
-    });
-  } else {
-    new NavbarAzFullscreenMobileNav();
+  /**
+   * Get the target ID for a primary menu label
+   * @param {string} label - The menu label
+   * @returns {string} The target ID
+   */
+  getTargetIdForLabel(label) {
+    const labelMap = {
+      Admissions: '#az-navbar-az-fullscreen-primary-admissions-content',
+      Academics: '#az-navbar-az-fullscreen-primary-academics-content',
+      Research: '#az-navbar-az-fullscreen-primary-research-content',
+      'Campus Life': '#az-navbar-az-fullscreen-primary-campus-life-content',
+      About: '#az-navbar-az-fullscreen-primary-about-content'
+    }
+    return labelMap[label] || ''
   }
+}
 
-  // Export for use as module if needed
-  if (typeof module !== 'undefined' && module.exports) {
-    module.exports = NavbarAzFullscreenMobileNav;
-  }
-  if (typeof window !== 'undefined') {
-    window.NavbarAzFullscreenMobileNav = NavbarAzFullscreenMobileNav;
-  }
-})();
+// Initialize when DOM is ready
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => {
+    const _navbarAzFullscreenMobileNav = new NavbarAzFullscreenMobileNav()
+  })
+} else {
+  const _navbarAzFullscreenMobileNav = new NavbarAzFullscreenMobileNav()
+}
 
-export default NavbarAzFullscreenMobileNav;
+if (typeof window !== 'undefined') {
+  window.NavbarAzFullscreenMobileNav = NavbarAzFullscreenMobileNav
+}
+
+export default NavbarAzFullscreenMobileNav

--- a/js/src/navbar-az-fullscreen-mobile-nav.js
+++ b/js/src/navbar-az-fullscreen-mobile-nav.js
@@ -31,6 +31,7 @@ class NavbarAzFullscreenMobileNav {
     }
 
     this.navigationStack = [] // Stack to track navigation history
+    this.labelToTargetMap = {} // Map to store label-to-targetId mappings from page content
     this.init()
   }
 
@@ -49,10 +50,16 @@ class NavbarAzFullscreenMobileNav {
     const primaryButtons = this.mobileCol.querySelectorAll('.navbar-az-fullscreen-nav-primary .nav-link')
 
     for (const button of primaryButtons) {
+      const targetId = button.getAttribute('data-az-menu-element')
+      const label = button.textContent.trim()
+
+      // Build dynamic mapping from page content
+      if (targetId && label) {
+        this.labelToTargetMap[label] = targetId
+      }
+
       button.addEventListener('click', e => {
         e.preventDefault()
-        const targetId = button.getAttribute('data-bs-target')
-        const label = button.textContent.trim()
 
         if (targetId) {
           this.showSecondaryNav(targetId, label)
@@ -62,87 +69,48 @@ class NavbarAzFullscreenMobileNav {
   }
 
   /**
+   * Display navigation menu (secondary or tertiary)
+   * @param {Element|string} content - The content element or target ID to display
+   * @param {string} label - The label of the menu item
+   * @param {string} navType - Navigation type: 'primary' (secondary menu) or 'secondary' (tertiary menu)
+   * @param {string} backButtonLabel - Label for the back button
+   * @param {string} parentLabel - Parent label (used for tertiary navigation)
+   */
+  showNavMenu(content, label, navType, backButtonLabel, parentLabel = null) {
+    // Handle both targetId (string) and Element
+    let element = content
+    if (typeof content === 'string') {
+      element = document.querySelector(content)
+      if (!element) {
+        return
+      }
+    }
+
+    // Create the menu display
+    const menuHtml = this.buildMenuHtml(element, label, backButtonLabel)
+
+    // Update navigation stack
+    const stackEntry = { type: navType, label }
+    if (parentLabel) {
+      stackEntry.parentLabel = parentLabel
+    }
+
+    this.navigationStack.push(stackEntry)
+
+    // Update mobile column
+    this.mobileCol.innerHTML = menuHtml
+
+    // Set up listeners for the new menu
+    this.setupNavListeners(label, navType)
+  }
+
+  /**
    * Display secondary navigation for a primary menu item
    * @param {string} targetId - The ID of the secondary content to display
    * @param {string} label - The label of the primary menu item
    */
   showSecondaryNav(targetId, label) {
-    // Extract the menu content from desktop view
-    const desktopContent = document.querySelector(targetId)
-    if (!desktopContent) {
-      // Secondary content not found for ${targetId}
-      return
-    }
-
-    // Create the secondary menu display
-    const secondaryMenuHtml = this.buildSecondaryMenuHtml(desktopContent)
-
-    // Update navigation stack
-    this.navigationStack.push({
-      type: 'primary',
-      label
-    })
-
-    // Update mobile column
-    this.mobileCol.innerHTML = secondaryMenuHtml
-
-    // Set up listeners for the new secondary menu
-    this.setupSecondaryNavListeners(label)
-  }
-
-  /**
-   * Build HTML for secondary menu display
-   * @param {Element} desktopContent - The desktop secondary content element
-   * @returns {string} HTML string for the secondary menu
-   */
-  buildSecondaryMenuHtml(desktopContent) {
-    let html = '<div class="navbar-az-fullscreen-nav-secondary-mobile">'
-
-    // Add back button
-    html += this.createBackButton('Main Menu')
-
-    // Extract secondary nav content from desktop
-    const secondaryNav = desktopContent.querySelector('.navbar-az-fullscreen-nav-secondary')
-    if (secondaryNav) {
-      // Clone the secondary nav structure
-      const navContent = secondaryNav.innerHTML
-      html += '<nav class="nav flex-column navbar-az-fullscreen-nav-secondary">'
-      html += navContent
-      html += '</nav>'
-    }
-
-    html += '</div>'
-    return html
-  }
-
-  /**
-   * Set up event listeners for secondary navigation items
-   * @param {string} parentLabel - The label of the parent menu
-   */
-  setupSecondaryNavListeners(parentLabel) {
-    // Back button
-    const backButton = this.mobileCol.querySelector('.navbar-az-fullscreen-nav-back-btn')
-    if (backButton) {
-      backButton.addEventListener('click', () => {
-        this.goBack()
-      })
-    }
-
-    // Secondary menu toggle buttons (for tertiary menus)
-    const toggleButtons = this.mobileCol.querySelectorAll('.navbar-az-fullscreen-nav-toggle')
-    for (const button of toggleButtons) {
-      button.addEventListener('click', e => {
-        e.preventDefault()
-        const tertiaryId = button.getAttribute('data-bs-target')
-        const tertiaryContent = document.querySelector(tertiaryId)
-
-        if (tertiaryContent) {
-          // Extract the tertiary label from the parent link
-          const parentLink = button.previousElementSibling?.textContent?.trim() || parentLabel
-          this.showTertiaryNav(tertiaryContent, parentLink, parentLabel)
-        }
-      })
-    }
+    this.showNavMenu(targetId, label, 'primary', 'Main Menu')
   }
 
   /**
@@ -152,54 +120,104 @@ class NavbarAzFullscreenMobileNav {
    * @param {string} parentLabel - The label of the parent secondary menu
    */
   showTertiaryNav(tertiaryContent, label, parentLabel) {
-    const tertiaryMenuHtml = this.buildTertiaryMenuHtml(tertiaryContent, label, parentLabel)
+    this.showNavMenu(tertiaryContent, label, 'secondary', parentLabel, parentLabel)
+  }
 
-    // Update navigation stack
-    this.navigationStack.push({
-      type: 'secondary',
-      label,
-      parentLabel
-    })
+  /**
+   * Build HTML for menu display
+   * @param {Element} content - The content element to display
+   * @param {string} label - The label of the menu item that was clicked
+   * @param {string} backButtonLabel - Label for the back button
+   * @returns {string} HTML string for the menu
+   */
+  buildMenuHtml(content, label, backButtonLabel) {
+    let html = '<div class="navbar-az-fullscreen-nav-menu-mobile">'
 
-    // Update mobile column
-    this.mobileCol.innerHTML = tertiaryMenuHtml
+    // Add back button
+    html += this.createBackButton(backButtonLabel)
 
-    // Set up listeners for back button
+    // Add menu heading
+    html += `<h2 class="navbar-az-fullscreen-nav-mobile-menu-heading">${label} Menu</h2>`
+
+    // Extract nav content from content
+    const nav = content.querySelector('.navbar-az-fullscreen-nav-secondary')
+    if (nav) {
+      // Clone the nav element to avoid modifying the original
+      const navClone = nav.cloneNode(true)
+      // Remove tertiary panel if it exists
+      const tertiaryPanel = navClone.querySelector('.navbar-az-fullscreen-nav-tertiary-panel')
+      if (tertiaryPanel) {
+        tertiaryPanel.remove()
+      }
+
+      // Process all buttons in the cloned nav
+      let buttonCounter = 0
+      const buttons = navClone.querySelectorAll('button')
+      for (const button of buttons) {
+        // Store data-bs-target value before removing attributes
+        const targetId = button.getAttribute('data-bs-target')
+
+        // Remove Bootstrap attributes
+        button.removeAttribute('data-bs-toggle')
+        button.removeAttribute('data-bs-target')
+        button.removeAttribute('aria-expanded')
+
+        // Create dynamic id
+        buttonCounter++
+        button.id = `az-fullscreen-nav-mobile-${buttonCounter}`
+
+        // Update aria-controls
+        button.setAttribute('aria-controls', 'navbar-az-fullscreen-nav-mobile-col')
+
+        // Add data-az-menu-element attribute with original target value
+        if (targetId) {
+          button.setAttribute('data-az-menu-element', targetId)
+        }
+      }
+
+      const navContent = navClone.innerHTML
+      html += '<nav class="nav flex-column navbar-az-fullscreen-nav-secondary"><hr class="border-top border-azurite opacity-100" aria-hidden="true" role="presentation">'
+      html += navContent
+      html += '<hr class="border-top border-azurite opacity-100" aria-hidden="true" role="presentation"></nav>'
+    } else {
+      // Fallback: use the entire content if no nav element found
+      html += content.innerHTML
+    }
+
+    html += '</div>'
+    return html
+  }
+
+  /**
+   * Set up event listeners for navigation menu
+   * @param {string} parentLabel - The label of the parent/current menu
+   * @param {string} parentNavType - Navigation type: 'primary' (secondary menu) or 'secondary' (tertiary menu)
+   */
+  setupNavListeners(parentLabel, parentNavType) {
+    // Back button
     const backButton = this.mobileCol.querySelector('.navbar-az-fullscreen-nav-back-btn')
     if (backButton) {
       backButton.addEventListener('click', () => {
         this.goBack()
       })
     }
-  }
 
-  /**
-   * Build HTML for tertiary menu display
-   * @param {Element} tertiaryContent - The tertiary content element
-   * @param {string} label - The label of the menu
-   * @param {string} parentLabel - The label of the parent menu
-   * @returns {string} HTML string for the tertiary menu
-   */
-  buildTertiaryMenuHtml(tertiaryContent, label, parentLabel) {
-    let html = '<div class="navbar-az-fullscreen-nav-tertiary-mobile">'
+    // Toggle buttons for secondary menu navigation
+    if (parentNavType === 'primary') {
+      const toggleButtons = this.mobileCol.querySelectorAll('.navbar-az-fullscreen-nav-toggle')
+      for (const button of toggleButtons) {
+        button.addEventListener('click', e => {
+          const tertiaryId = button.getAttribute('data-az-menu-element')
+          const tertiaryContent = document.querySelector(tertiaryId)
 
-    // Add back button
-    html += this.createBackButton(`${parentLabel}`)
-
-    // Extract tertiary nav content
-    const tertiaryNav = tertiaryContent.querySelector('.navbar-az-fullscreen-nav-secondary')
-    if (tertiaryNav) {
-      const navContent = tertiaryNav.innerHTML
-      html += '<nav class="nav flex-column navbar-az-fullscreen-nav-secondary">'
-      html += navContent
-      html += '</nav>'
-    } else {
-      // Fallback: use the entire content if no nav element found
-      html += tertiaryContent.innerHTML
+          if (tertiaryContent) {
+            // Extract the tertiary label from button aria-label text
+            const toggleLabel = e.target.ariaLabel.replace('Toggle ', '').replace(' submenu', '')
+            this.showTertiaryNav(tertiaryContent, toggleLabel, parentLabel)
+          }
+        })
+      }
     }
-
-    html += '</div>'
-    return html
   }
 
   /**
@@ -213,7 +231,6 @@ class NavbarAzFullscreenMobileNav {
         <button type="button" class="btn navbar-az-fullscreen-nav-back-btn" aria-label="Back to ${label}">
           Back to ${label}
         </button>
-        <hr class="border-top border-azurite opacity-100" aria-hidden="true" role="presentation">
       </div>
     `
   }
@@ -258,6 +275,33 @@ class NavbarAzFullscreenMobileNav {
 
       // Add primary navigation
       const primaryClone = primaryNav.cloneNode(true)
+
+      // Update the tablist id for mobile
+      const tablist = primaryClone.querySelector('#az-navbar-az-fullscreen-primary-tablist')
+      if (tablist) {
+        tablist.id = 'az-navbar-az-fullscreen-primary-tablist-mobile'
+      }
+
+      // Process all buttons in the cloned primary nav
+      const buttons = primaryClone.querySelectorAll('button')
+      for (const button of buttons) {
+        // Replace data-bs-target with data-az-menu-element
+        const targetId = button.getAttribute('data-bs-target')
+        if (targetId) {
+          button.setAttribute('data-az-menu-element', targetId)
+          button.removeAttribute('data-bs-target')
+        }
+
+        // Remove specific attributes
+        button.removeAttribute('id')
+        button.removeAttribute('data-bs-toggle')
+        button.removeAttribute('role')
+        button.removeAttribute('aria-selected')
+
+        // Update aria-controls
+        button.setAttribute('aria-controls', 'navbar-az-fullscreen-nav-mobile-col')
+      }
+
       this.mobileCol.append(primaryClone)
 
       this.setupPrimaryNavListeners()
@@ -270,14 +314,7 @@ class NavbarAzFullscreenMobileNav {
    * @returns {string} The target ID
    */
   getTargetIdForLabel(label) {
-    const labelMap = {
-      Admissions: '#az-navbar-az-fullscreen-primary-admissions-content',
-      Academics: '#az-navbar-az-fullscreen-primary-academics-content',
-      Research: '#az-navbar-az-fullscreen-primary-research-content',
-      'Campus Life': '#az-navbar-az-fullscreen-primary-campus-life-content',
-      About: '#az-navbar-az-fullscreen-primary-about-content'
-    }
-    return labelMap[label] || ''
+    return this.labelToTargetMap[label] || ''
   }
 }
 

--- a/js/src/navbar-az-fullscreen-mobile-nav.js
+++ b/js/src/navbar-az-fullscreen-mobile-nav.js
@@ -175,7 +175,8 @@ class NavbarAzFullscreenMobileNav {
         }
       }
 
-      const navContent = navClone.innerHTML
+      let navContent = navClone.innerHTML
+      navContent = navContent.replaceAll('class="vr"', 'class="vr my-2"')
       html += '<nav class="nav flex-column navbar-az-fullscreen-nav-secondary"><hr class="border-top border-azurite opacity-100" aria-hidden="true" role="presentation">'
       html += navContent
       html += '<hr class="border-top border-azurite opacity-100" aria-hidden="true" role="presentation"></nav>'

--- a/js/src/navbar-az-fullscreen-mobile-nav.js
+++ b/js/src/navbar-az-fullscreen-mobile-nav.js
@@ -1,0 +1,285 @@
+/**
+ * --------------------------------------------------------------------------
+ * Arizona Bootstrap: navbar-az-fullscreen.js
+ * Licensed under MIT (https://github.com/az-digital/arizona-bootstrap/blob/main/LICENSE)
+ * --------------------------------------------------------------------------
+ */
+
+/**
+ * Arizona Bootstrap Fullscreen Navbar Mobile Navigation
+ * Handles paged navigation for mobile view of .navbar-az-fullscreen-nav-mobile-col
+ */
+
+(function () {
+  'use strict';
+
+  class NavbarAzFullscreenMobileNav {
+    constructor() {
+      this.mobileCol = document.querySelector('.navbar-az-fullscreen-nav-mobile-col');
+      this.desktopSecondaryContainer = document.querySelector('.navbar-az-fullscreen-nav-secondary-tertiary-cols');
+      this.primaryNavContainer = document.querySelector('.navbar-az-fullscreen-nav-primary-col');
+
+      if (!this.mobileCol) {
+        console.warn('Mobile navbar column not found');
+        return;
+      }
+
+      this.navigationStack = []; // Stack to track navigation history
+      this.init();
+    }
+
+    /**
+     * Initialize the mobile navigation
+     */
+    init() {
+      // Set up event listeners for primary navigation items in mobile view
+      this.setupPrimaryNavListeners();
+    }
+
+    /**
+     * Set up click listeners on primary navigation items
+     */
+    setupPrimaryNavListeners() {
+      const primaryButtons = this.mobileCol.querySelectorAll('.navbar-az-fullscreen-nav-primary .nav-link');
+
+      primaryButtons.forEach((button) => {
+        button.addEventListener('click', (e) => {
+          e.preventDefault();
+          const targetId = button.getAttribute('data-bs-target');
+          const label = button.textContent.trim();
+
+          if (targetId) {
+            this.showSecondaryNav(targetId, label);
+          }
+        });
+      });
+    }
+
+    /**
+     * Display secondary navigation for a primary menu item
+     * @param {string} targetId - The ID of the secondary content to display
+     * @param {string} label - The label of the primary menu item
+     */
+    showSecondaryNav(targetId, label) {
+      // Extract the menu content from desktop view
+      const desktopContent = document.querySelector(targetId);
+      if (!desktopContent) {
+        console.warn(`Secondary content not found for ${targetId}`);
+        return;
+      }
+
+      // Create the secondary menu display
+      const secondaryMenuHtml = this.buildSecondaryMenuHtml(desktopContent, label);
+
+      // Update navigation stack
+      this.navigationStack.push({
+        type: 'primary',
+        label: label,
+      });
+
+      // Update mobile column
+      this.mobileCol.innerHTML = secondaryMenuHtml;
+
+      // Set up listeners for the new secondary menu
+      this.setupSecondaryNavListeners(label);
+    }
+
+    /**
+     * Build HTML for secondary menu display
+     * @param {Element} desktopContent - The desktop secondary content element
+     * @param {string} label - The label of the menu
+     * @returns {string} HTML string for the secondary menu
+     */
+    buildSecondaryMenuHtml(desktopContent, label) {
+      let html = '<div class="navbar-az-fullscreen-nav-secondary-mobile">';
+
+      // Add back button
+      html += this.createBackButton('Main Menu');
+
+      // Extract secondary nav content from desktop
+      const secondaryNav = desktopContent.querySelector('.navbar-az-fullscreen-nav-secondary');
+      if (secondaryNav) {
+        // Clone the secondary nav structure
+        const navContent = secondaryNav.innerHTML;
+        html += `<nav class="nav flex-column navbar-az-fullscreen-nav-secondary">`;
+        html += navContent;
+        html += `</nav>`;
+      }
+
+      html += '</div>';
+      return html;
+    }
+
+    /**
+     * Set up event listeners for secondary navigation items
+     * @param {string} parentLabel - The label of the parent menu
+     */
+    setupSecondaryNavListeners(parentLabel) {
+      // Back button
+      const backButton = this.mobileCol.querySelector('.navbar-az-fullscreen-nav-back-btn');
+      if (backButton) {
+        backButton.addEventListener('click', () => {
+          this.goBack();
+        });
+      }
+
+      // Secondary menu toggle buttons (for tertiary menus)
+      const toggleButtons = this.mobileCol.querySelectorAll('.navbar-az-fullscreen-nav-toggle');
+      toggleButtons.forEach((button) => {
+        button.addEventListener('click', (e) => {
+          e.preventDefault();
+          const tertiaryId = button.getAttribute('data-bs-target');
+          const tertiaryContent = document.querySelector(tertiaryId);
+
+          if (tertiaryContent) {
+            // Extract the tertiary label from the parent link
+            const parentLink = button.previousElementSibling?.textContent?.trim() || parentLabel;
+            this.showTertiaryNav(tertiaryContent, parentLink, parentLabel);
+          }
+        });
+      });
+    }
+
+    /**
+     * Display tertiary navigation
+     * @param {Element} tertiaryContent - The tertiary content element
+     * @param {string} label - The label of the tertiary menu
+     * @param {string} parentLabel - The label of the parent secondary menu
+     */
+    showTertiaryNav(tertiaryContent, label, parentLabel) {
+      const tertiaryMenuHtml = this.buildTertiaryMenuHtml(tertiaryContent, label, parentLabel);
+
+      // Update navigation stack
+      this.navigationStack.push({
+        type: 'secondary',
+        label: label,
+        parentLabel: parentLabel,
+      });
+
+      // Update mobile column
+      this.mobileCol.innerHTML = tertiaryMenuHtml;
+
+      // Set up listeners for back button
+      const backButton = this.mobileCol.querySelector('.navbar-az-fullscreen-nav-back-btn');
+      if (backButton) {
+        backButton.addEventListener('click', () => {
+          this.goBack();
+        });
+      }
+    }
+
+    /**
+     * Build HTML for tertiary menu display
+     * @param {Element} tertiaryContent - The tertiary content element
+     * @param {string} label - The label of the menu
+     * @param {string} parentLabel - The label of the parent menu
+     * @returns {string} HTML string for the tertiary menu
+     */
+    buildTertiaryMenuHtml(tertiaryContent, label, parentLabel) {
+      let html = '<div class="navbar-az-fullscreen-nav-tertiary-mobile">';
+
+      // Add back button
+      html += this.createBackButton(`${parentLabel}`);
+
+      // Extract tertiary nav content
+      const tertiaryNav = tertiaryContent.querySelector('.navbar-az-fullscreen-nav-secondary');
+      if (tertiaryNav) {
+        const navContent = tertiaryNav.innerHTML;
+        html += `<nav class="nav flex-column navbar-az-fullscreen-nav-secondary">`;
+        html += navContent;
+        html += `</nav>`;
+      } else {
+        // Fallback: use the entire content if no nav element found
+        html += tertiaryContent.innerHTML;
+      }
+
+      html += '</div>';
+      return html;
+    }
+
+    /**
+     * Create a back button element
+     * @param {string} label - The label for the back button
+     * @returns {string} HTML string for the back button
+     */
+    createBackButton(label) {
+      return `
+        <div class="navbar-az-fullscreen-nav-back">
+          <button type="button" class="btn navbar-az-fullscreen-nav-back-btn" aria-label="Back to ${label}">
+            Back to ${label}
+          </button>
+          <hr class="border-top border-azurite opacity-100" aria-hidden="true" role="presentation">
+        </div>
+      `;
+    }
+
+    /**
+     * Navigate back to the previous menu
+     */
+    goBack() {
+      // Remove current level from stack
+      this.navigationStack.pop();
+
+      if (this.navigationStack.length === 0) {
+        // Back to primary menu
+        this.resetToPrimaryNav();
+      } else {
+        const previousLevel = this.navigationStack[this.navigationStack.length - 1];
+        if (previousLevel.type === 'primary') {
+          // Back to secondary menu
+          this.navigationStack.pop();
+          this.showSecondaryNav(
+            this.getTargetIdForLabel(previousLevel.label),
+            previousLevel.label
+          );
+        }
+      }
+    }
+
+    /**
+     * Reset to primary navigation
+     */
+    resetToPrimaryNav() {
+      const primaryNav = document.querySelector('.navbar-az-fullscreen-nav-primary');
+      if (primaryNav) {
+        this.mobileCol.innerHTML = primaryNav.outerHTML;
+        this.setupPrimaryNavListeners();
+      }
+    }
+
+    /**
+     * Get the target ID for a primary menu label
+     * @param {string} label - The menu label
+     * @returns {string} The target ID
+     */
+    getTargetIdForLabel(label) {
+      const labelMap = {
+        'Admissions': '#az-navbar-az-fullscreen-primary-admissions-content',
+        'Academics': '#az-navbar-az-fullscreen-primary-academics-content',
+        'Research': '#az-navbar-az-fullscreen-primary-research-content',
+        'Campus Life': '#az-navbar-az-fullscreen-primary-campus-life-content',
+        'About': '#az-navbar-az-fullscreen-primary-about-content',
+      };
+      return labelMap[label] || '';
+    }
+  }
+
+  // Initialize when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      new NavbarAzFullscreenMobileNav();
+    });
+  } else {
+    new NavbarAzFullscreenMobileNav();
+  }
+
+  // Export for use as module if needed
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = NavbarAzFullscreenMobileNav;
+  }
+  if (typeof window !== 'undefined') {
+    window.NavbarAzFullscreenMobileNav = NavbarAzFullscreenMobileNav;
+  }
+})();
+
+export default NavbarAzFullscreenMobileNav;

--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -37,37 +37,6 @@
     min-width: 0;
   }
 
-  .navbar-az-fullscreen-actions {
-    --az-navbar-fullscreen-actions-font-size: 22px;
-    --az-navbar-fullscreen-actions-line-height: 27px;
-    --az-navbar-fullscreen-actions-font: normal normal bold var(--az-navbar-fullscreen-actions-font-size) / var(--az-navbar-fullscreen-actions-line-height) proxima-nova-condensed;
-    --bs-nav-link-padding-x: 15px;
-    --bs-nav-link-padding-y: 36.5px;
-    --bs-nav-link-color: var(--bs-white);
-    --bs-nav-link-hover-color: var(--bs-sky);
-
-    .nav-item {
-      &:hover,
-      &:has(> .nav-link.active) {
-        background-color: transparent;
-      }
-    }
-
-    .nav-link {
-      padding-top: var(--bs-nav-link-padding-y);
-      padding-bottom: var(--bs-nav-link-padding-y);
-      font: var(--az-navbar-fullscreen-actions-font);
-      letter-spacing: .66px;
-
-      &:active,
-      &.active,
-      &.is-active {
-        color: var(--bs-navbar-active-color);
-        background-color: transparent;
-      }
-    }
-  }
-
   .navbar-toggler {
     display: inline-flex;
     flex: 0 0 auto;
@@ -86,6 +55,36 @@
   }
 }
 
+.navbar-az-fullscreen-actions {
+  --az-navbar-fullscreen-actions-font-size: 22px;
+  --az-navbar-fullscreen-actions-line-height: 27px;
+  --az-navbar-fullscreen-actions-font: normal normal bold var(--az-navbar-fullscreen-actions-font-size) / var(--az-navbar-fullscreen-actions-line-height) proxima-nova-condensed;
+  --bs-nav-link-padding-x: 15px;
+  --bs-nav-link-padding-y: 36.5px;
+  --bs-nav-link-color: var(--bs-white);
+  --bs-nav-link-hover-color: var(--bs-sky);
+
+  .nav-item {
+    &:hover,
+    &:has(> .nav-link.active) {
+      background-color: transparent;
+    }
+  }
+
+  .nav-link {
+    padding-top: var(--bs-nav-link-padding-y);
+    padding-bottom: var(--bs-nav-link-padding-y);
+    font: var(--az-navbar-fullscreen-actions-font);
+    letter-spacing: .66px;
+
+    &:active,
+    &.active,
+    &.is-active {
+      color: var(--bs-navbar-active-color);
+      background-color: transparent;
+    }
+  }
+}
 
 .navbar-az-fullscreen-search {
   --az-navbar-fullscreen-search-height: 60px;
@@ -564,10 +563,10 @@
     --bs-navbar-brand-padding-y: 12px;
 
     .navbar-toggler {
-      padding: 0px;
+      padding: 0;
       margin-top: 0;
       margin-bottom: 0;
-      border-radius: 4px;
+      @include border-radius(4px);
     }
 
   }
@@ -583,23 +582,26 @@
       padding: 0;
     }
 
+    /* stylelint-disable selector-max-id */
     #navbar-az-fullscreen-modal-search + .btn {
-      min-height: unset;
-      min-width: unset;
       width: 40px;
+      min-width: unset;
+      min-height: unset;
       padding: 0;
       margin-right: 4px;
     }
+    /* stylelint-enable selector-max-id */
   }
 
   header .navbar-toggler-icon {
     width: 2.75rem;
     height: 2.75rem;
-    transform: scaleX(0.8) scaleY(1.25);
+    transform: scaleX(.8) scaleY(1.25);
   }
 }
 
-.navbar-az-fullscreen-nav-mobile-col {
+/* stylelint-disable selector-max-id */
+#navbar-az-fullscreen-nav-mobile-col {
   // https://fonts.google.com/icons?icon.style=Rounded&icon.set=Material+Symbols&icon.size=24&icon.color=%231e5288&selected=Material+Symbols+Rounded:expand_circle_down:FILL@0;wght@400;GRAD@0;opsz@24&icon.query=expand+ci
   --az-navbar-fullscreen-back-icon: #{escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 -960 960 960' width='24px' fill='#{$sky}'><path d='m480-453-95-95q-11-11-27.5-11T329-548q-12 12-12 28.5t12 28.5l123 123q12 12 28 12t28-12l124-124q12-12 11.5-28T631-548q-12-11-28-11.5T575-548l-95 95Zm0 373q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z'/></svg>"))};
   // https://fonts.google.com/icons?icon.style=Rounded&icon.set=Material+Symbols&icon.size=24&icon.color=%23AB0520&selected=Material+Symbols+Rounded:expand_circle_down:FILL@1;wght@400;GRAD@0;opsz@24&icon.query=expand+ci
@@ -608,6 +610,10 @@
   --az-navbar-fullscreen-back-icon-active-child: #{escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 -960 960 960' width='24px' fill='#{$white}'><path d='m480-453-95-95q-11-11-27.5-11T329-548q-12 12-12 28.5t12 28.5l123 123q12 12 28 12t28-12l124-124q12-12 11.5-28T631-548q-12-11-28-11.5T575-548l-95 95Zm0 373q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z'/></svg>"))};
 
   overflow: auto;
+
+  .navbar-az-fullscreen-actions {
+    --bs-nav-link-padding-y: 12px;
+  }
 
   .navbar-az-fullscreen-nav-primary {
     font-size: 48px;
@@ -618,9 +624,9 @@
   }
 
   .navbar-az-fullscreen-nav-back-btn {
-    color: var(--bs-sky);
     padding: 8px 0;
-  
+    color: var(--bs-sky);
+
     &::before {
       display: inline-block;
       -ms-flex-negative: 0;
@@ -631,15 +637,16 @@
       height: 24px;
       margin-bottom: 0;
       line-height: 1;
+      vertical-align: bottom;
       content: "";
       background-image: var(--az-navbar-fullscreen-back-icon);
       background-repeat: no-repeat;
       background-position: center;
       background-size: 100% 100%;
       border: 0;
-      transform: rotate(90deg);
       fill: var(--bs-sky);
-      vertical-align: bottom;
+      transform: rotate(90deg);
     }
   }
 }
+/* stylelint-enable selector-max-id */

--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -59,6 +59,9 @@
   --az-navbar-fullscreen-actions-font-size: 22px;
   --az-navbar-fullscreen-actions-line-height: 27px;
   --az-navbar-fullscreen-actions-font: normal normal bold var(--az-navbar-fullscreen-actions-font-size) / var(--az-navbar-fullscreen-actions-line-height) proxima-nova-condensed;
+  --az-navbar-fullscreen-actions-separator-width: 1px;
+  --az-navbar-fullscreen-actions-separator-height: 24px;
+  --az-navbar-fullscreen-actions-separator-color: var(--bs-bloom);
   --bs-nav-link-padding-x: 15px;
   --bs-nav-link-padding-y: 36.5px;
   --bs-nav-link-color: var(--bs-white);
@@ -68,6 +71,11 @@
     &:hover,
     &:has(> .nav-link.active) {
       background-color: transparent;
+    }
+
+    &[role="presentation"] {
+      display: flex;
+      align-items: center;
     }
   }
 
@@ -83,6 +91,14 @@
       color: var(--bs-navbar-active-color);
       background-color: transparent;
     }
+  }
+
+  .vr {
+    display: block;
+    width: var(--az-navbar-fullscreen-actions-separator-width);
+    height: var(--az-navbar-fullscreen-actions-separator-height);
+    background-color: var(--az-navbar-fullscreen-actions-separator-color);
+    opacity: 1;
   }
 }
 

--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -153,10 +153,6 @@
     }
 
   }
-
-  @media (max-width: 575.98px) {
-    display: none;
-  }
 }
 
 
@@ -533,5 +529,94 @@
   .collapse,
   .collapsing {
     @include transition(none);
+  }
+}
+
+/* Mobile Nav styling */
+@include media-breakpoint-down(md) {
+  .navbar-az-fullscreen {
+    --az-navbar-fullscreen-height: 69px;
+    --az-navbar-fullscreen-brand-height: 45px;
+    --bs-navbar-brand-padding-x: 12px;
+    --bs-navbar-brand-padding-y: 12px;
+
+    .navbar-toggler {
+      padding: 0px;
+      margin-top: 0;
+      margin-bottom: 0;
+      border-radius: 4px;
+    }
+
+  }
+
+  .navbar-az-fullscreen-search {
+    --az-navbar-fullscreen-search-height: 45px;
+
+    .input-group {
+      height: 51px;
+    }
+
+    .navbar-toggler-search {
+      padding: 0;
+    }
+
+    #navbar-az-fullscreen-modal-search + .btn {
+      min-height: unset;
+      min-width: unset;
+      width: 40px;
+      padding: 0;
+      margin-right: 4px;
+    }
+  }
+
+  header .navbar-toggler-icon {
+    width: 2.75rem;
+    height: 2.75rem;
+    transform: scaleX(0.8) scaleY(1.25);
+  }
+}
+
+.navbar-az-fullscreen-nav-mobile-col {
+  // https://fonts.google.com/icons?icon.style=Rounded&icon.set=Material+Symbols&icon.size=24&icon.color=%231e5288&selected=Material+Symbols+Rounded:expand_circle_down:FILL@0;wght@400;GRAD@0;opsz@24&icon.query=expand+ci
+  --az-navbar-fullscreen-back-icon: #{escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 -960 960 960' width='24px' fill='#{$sky}'><path d='m480-453-95-95q-11-11-27.5-11T329-548q-12 12-12 28.5t12 28.5l123 123q12 12 28 12t28-12l124-124q12-12 11.5-28T631-548q-12-11-28-11.5T575-548l-95 95Zm0 373q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z'/></svg>"))};
+  // https://fonts.google.com/icons?icon.style=Rounded&icon.set=Material+Symbols&icon.size=24&icon.color=%23AB0520&selected=Material+Symbols+Rounded:expand_circle_down:FILL@1;wght@400;GRAD@0;opsz@24&icon.query=expand+ci
+  --az-navbar-fullscreen-back-icon-active: #{escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 -960 960 960' width='24px' fill='#{$white}'><path d='m480-453-95-95q-11-11-27.5-11T329-548q-12 12-12 28.5t12 28.5l123 123q12 12 28 12t28-12l124-124q12-12 11.5-28T631-548q-12-11-28-11.5T575-548l-95 95Zm0 373q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Z'/></svg>"))};
+  // https://fonts.google.com/icons?icon.style=Rounded&icon.set=Material+Symbols&icon.size=24&icon.color=%23AB0520&selected=Material+Symbols+Rounded:expand_circle_down:FILL@0;wght@400;GRAD@0;opsz@24&icon.query=expand+ci
+  --az-navbar-fullscreen-back-icon-active-child: #{escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 -960 960 960' width='24px' fill='#{$white}'><path d='m480-453-95-95q-11-11-27.5-11T329-548q-12 12-12 28.5t12 28.5l123 123q12 12 28 12t28-12l124-124q12-12 11.5-28T631-548q-12-11-28-11.5T575-548l-95 95Zm0 373q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z'/></svg>"))};
+
+  overflow: auto;
+
+  .navbar-az-fullscreen-nav-primary {
+    font-size: 48px;
+  }
+
+  .navbar-az-fullscreen-nav-secondary {
+    width: unset;
+  }
+
+  .navbar-az-fullscreen-nav-back-btn {
+    color: var(--bs-sky);
+    padding: 8px 0;
+  
+    &::before {
+      display: inline-block;
+      -ms-flex-negative: 0;
+      flex-shrink: 0;
+      inline-size: 24px;
+      width: 24px;
+      block-size: 24px;
+      height: 24px;
+      margin-bottom: 0;
+      line-height: 1;
+      content: "";
+      background-image: var(--az-navbar-fullscreen-back-icon);
+      background-repeat: no-repeat;
+      background-position: center;
+      background-size: 100% 100%;
+      border: 0;
+      transform: rotate(90deg);
+      fill: var(--bs-sky);
+      vertical-align: bottom;
+    }
   }
 }

--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -670,6 +670,15 @@
       font-size: 18px;
     }
 
+    .navbar-az-fullscreen-nav-toggle {
+      padding: 0 0 0 12px;
+    }
+
+    .navbar-az-fullscreen-nav-toggle-icon {
+      width: 42px;
+      height: 42px;
+    }
+
     hr {
       margin-right: 0;
       margin-left: 0;

--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -613,6 +613,11 @@
 
   .navbar-az-fullscreen-actions {
     --bs-nav-link-padding-y: 12px;
+
+    .nav-link,
+    .vr {
+      color: var(--bs-sky);
+    }
   }
 
   .navbar-az-fullscreen-nav-primary {

--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -587,7 +587,7 @@
 }
 
 /* Mobile Nav styling */
-@include media-breakpoint-down(md) {
+@include media-breakpoint-down(lg) {
   .navbar-az-fullscreen {
     --az-navbar-fullscreen-height: 69px;
     --az-navbar-fullscreen-brand-height: 45px;

--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -603,11 +603,11 @@
 /* stylelint-disable selector-max-id */
 #navbar-az-fullscreen-nav-mobile-col {
   // https://fonts.google.com/icons?icon.style=Rounded&icon.set=Material+Symbols&icon.size=24&icon.color=%231e5288&selected=Material+Symbols+Rounded:expand_circle_down:FILL@0;wght@400;GRAD@0;opsz@24&icon.query=expand+ci
-  --az-navbar-fullscreen-back-icon: #{escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 -960 960 960' width='24px' fill='#{$sky}'><path d='m480-453-95-95q-11-11-27.5-11T329-548q-12 12-12 28.5t12 28.5l123 123q12 12 28 12t28-12l124-124q12-12 11.5-28T631-548q-12-11-28-11.5T575-548l-95 95Zm0 373q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z'/></svg>"))};
+  --az-navbar-fullscreen-back-icon: #{escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 -960 960 960' width='24px' fill='#{$white}'><path d='m480-453-95-95q-11-11-27.5-11T329-548q-12 12-12 28.5t12 28.5l123 123q12 12 28 12t28-12l124-124q12-12 11.5-28T631-548q-12-11-28-11.5T575-548l-95 95Zm0 373q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z'/></svg>"))};
   // https://fonts.google.com/icons?icon.style=Rounded&icon.set=Material+Symbols&icon.size=24&icon.color=%23AB0520&selected=Material+Symbols+Rounded:expand_circle_down:FILL@1;wght@400;GRAD@0;opsz@24&icon.query=expand+ci
-  --az-navbar-fullscreen-back-icon-active: #{escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 -960 960 960' width='24px' fill='#{$white}'><path d='m480-453-95-95q-11-11-27.5-11T329-548q-12 12-12 28.5t12 28.5l123 123q12 12 28 12t28-12l124-124q12-12 11.5-28T631-548q-12-11-28-11.5T575-548l-95 95Zm0 373q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Z'/></svg>"))};
+  --az-navbar-fullscreen-back-icon-active: #{escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 -960 960 960' width='24px' fill='#{$sky}'><path d='m480-453-95-95q-11-11-27.5-11T329-548q-12 12-12 28.5t12 28.5l123 123q12 12 28 12t28-12l124-124q12-12 11.5-28T631-548q-12-11-28-11.5T575-548l-95 95Zm0 373q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Z'/></svg>"))};
   // https://fonts.google.com/icons?icon.style=Rounded&icon.set=Material+Symbols&icon.size=24&icon.color=%23AB0520&selected=Material+Symbols+Rounded:expand_circle_down:FILL@0;wght@400;GRAD@0;opsz@24&icon.query=expand+ci
-  --az-navbar-fullscreen-back-icon-active-child: #{escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 -960 960 960' width='24px' fill='#{$white}'><path d='m480-453-95-95q-11-11-27.5-11T329-548q-12 12-12 28.5t12 28.5l123 123q12 12 28 12t28-12l124-124q12-12 11.5-28T631-548q-12-11-28-11.5T575-548l-95 95Zm0 373q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z'/></svg>"))};
+  --az-navbar-fullscreen-back-icon-active-child: #{escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 -960 960 960' width='24px' fill='#{$sky}'><path d='m480-453-95-95q-11-11-27.5-11T329-548q-12 12-12 28.5t12 28.5l123 123q12 12 28 12t28-12l124-124q12-12 11.5-28T631-548q-12-11-28-11.5T575-548l-95 95Zm0 373q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z'/></svg>"))};
 
   overflow: auto;
 
@@ -616,21 +616,37 @@
 
     .nav-link,
     .vr {
+      font-size: 20px;
+      line-height: 24px;
       color: var(--bs-sky);
     }
   }
 
-  .navbar-az-fullscreen-nav-primary {
-    font-size: 48px;
+  .nav.navbar-az-fullscreen-nav-primary .nav-link {
+    margin-top: 14px;
+    margin-bottom: 14px;
+    font-size: 38px;
+    line-height: 1em;
   }
 
   .navbar-az-fullscreen-nav-secondary {
     width: unset;
+
+    .nav-link {
+      padding-right: 0;
+      padding-left: 0;
+      font-size: 18px;
+    }
+
+    hr {
+      margin-right: 0;
+      margin-left: 0;
+    }
   }
 
   .navbar-az-fullscreen-nav-back-btn {
     padding: 8px 0;
-    color: var(--bs-sky);
+    color: var(--bs-white);
 
     &::before {
       display: inline-block;
@@ -640,6 +656,7 @@
       width: 24px;
       block-size: 24px;
       height: 24px;
+      margin-top: .5rem;
       margin-bottom: 0;
       line-height: 1;
       vertical-align: bottom;
@@ -649,9 +666,21 @@
       background-position: center;
       background-size: 100% 100%;
       border: 0;
-      fill: var(--bs-sky);
       transform: rotate(90deg);
     }
   }
+
+  .navbar-az-fullscreen-nav-toggle-icon {
+    pointer-events: none;
+  }
 }
 /* stylelint-enable selector-max-id */
+
+.navbar-az-fullscreen-nav-mobile-menu-heading {
+  font-family: proxima-nova-condensed, sans-serif;
+  font-size: 22px;
+  font-weight: 800;
+  line-height: 27px;
+  color: var(--bs-sky);
+  letter-spacing: .44px;
+}

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
@@ -199,7 +199,7 @@ title: AZ Navbar Fullscreen - Home
               </div>
               <div id="navbar-az-fullscreen-nav-mobile-col" class="col-12 d-md-none">
                 <!-- call-to-action items -->
-                <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-2 mt-2">
+                <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-2 mt-2 mb-card">
                   <li class="nav-item">
                     <a class="nav-link" href="http://localhost:9001/docs/5.1/examples/navbar-az-fullscreen/apply/">Apply</a>
                   </li>
@@ -218,11 +218,17 @@ title: AZ Navbar Fullscreen - Home
                 </ul>
                 <!-- initial mobile nav items -->
                 <div class="nav flex-column navbar-az-fullscreen-nav-primary" role="tablist" aria-orientation="vertical">
-                  <button class="nav-link" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-selected="false">Admissions</button>
-                  <button class="nav-link" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-selected="false">Academics</button>
-                  <button class="nav-link" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-selected="false">Research</button>
-                  <button class="nav-link" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-campus-life-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-campus-life-content" aria-selected="false">Campus Life</button>
-                  <button class="nav-link" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-about-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-about-content" aria-selected="false">About</button>
+                  <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                  <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Admissions</button>
+                  <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                  <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Academics</button>
+                  <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                  <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Research</button>
+                  <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                  <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Campus Life</button>
+                  <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                  <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-about-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">About</button>
+                  <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
                 </div>
               </div>
             </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
@@ -24,12 +24,13 @@ title: AZ Navbar Fullscreen - Home
             </li>
           </ul>
 
-          <form class="navbar-az-fullscreen-search me-4" role="search">
+          <form class="navbar-az-fullscreen-search me-2 me-md-4" role="search">
             <label class="visually-hidden" for="navbar-az-fullscreen-search">Search the site</label>
-            <div class="input-group">
+            <div class="input-group d-none d-md-flex">
               <input id="navbar-az-fullscreen-search" class="form-control" type="search" placeholder="Search" aria-label="Search the site">
               <button class="btn" type="submit" aria-label="Submit site search"></button>
             </div>
+            <button class="btn d-md-none navbar-toggler-search" type="button" aria-label="Search the site"></button>
           </form>
 
           <button class="navbar-toggler" type="button" data-bs-toggle="modal" data-bs-target="#navbar-az-fullscreen-menu" aria-controls="navbar-az-fullscreen-menu" aria-label="Open site menu">
@@ -69,7 +70,7 @@ title: AZ Navbar Fullscreen - Home
             </div>
           </div>
           <div class="container-lg">
-            <form class="navbar-az-fullscreen-search my-5" role="search">
+            <form class="navbar-az-fullscreen-search my-2 my-md-5" role="search">
               <label class="visually-hidden" for="navbar-az-fullscreen-modal-search">Search the site</label>
               <div class="input-group">
                 <input id="navbar-az-fullscreen-modal-search" class="form-control" type="search" placeholder="type your search term and press enter..." aria-label="Search the site">
@@ -82,7 +83,7 @@ title: AZ Navbar Fullscreen - Home
         <div class="modal-body">
           <div class="container-lg text-white navbar-az-fullscreen-modal-menu">
             <div class="row g-0">
-              <div class="col-4 navbar-az-fullscreen-nav-primary-col">
+              <div class="col-4 d-none d-md-block navbar-az-fullscreen-nav-primary-col">
                 <!-- primary nav items -->
                 <div class="nav flex-column navbar-az-fullscreen-nav-primary" id="az-navbar-az-fullscreen-primary-tablist" role="tablist" aria-orientation="vertical">
                   <button class="nav-link" id="az-navbar-az-fullscreen-primary-admissions-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-selected="false">Admissions</button>
@@ -92,7 +93,7 @@ title: AZ Navbar Fullscreen - Home
                   <button class="nav-link" id="az-navbar-az-fullscreen-primary-about-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-about-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-about-content" aria-selected="false">About</button>
                 </div>
               </div>
-              <div class="col-8 navbar-az-fullscreen-nav-secondary-tertiary-cols d-flex">
+              <div class="col-8 d-none d-md-flex navbar-az-fullscreen-nav-secondary-tertiary-cols">
                 <div class="tab-content d-flex flex-grow-1 w-100" id="az-navbar-az-fullscreen-primary-tab-content">
                   <div class="tab-pane fade flex-grow-1 h-100 w-100" id="az-navbar-az-fullscreen-primary-admissions-content" role="tabpanel" aria-labelledby="az-navbar-az-fullscreen-primary-admissions-tab" tabindex="0">
                     <div class="h-100">
@@ -194,6 +195,16 @@ title: AZ Navbar Fullscreen - Home
                     </div>
                   </div>
                   <div class="tab-pane fade flex-grow-1 h-100 w-100" id="az-navbar-az-fullscreen-primary-about-content" role="tabpanel" aria-labelledby="az-navbar-az-fullscreen-primary-about-tab" tabindex="0">About menu</div>
+                </div>
+              </div>
+              <div class="col-12 d-md-none navbar-az-fullscreen-nav-mobile-col">
+                <!-- initial mobile nav items -->
+                <div class="nav flex-column navbar-az-fullscreen-nav-primary" id="az-navbar-az-fullscreen-primary-tablist" role="tablist" aria-orientation="vertical">
+                  <button class="nav-link" id="az-navbar-az-fullscreen-primary-admissions-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-selected="false">Admissions</button>
+                  <button class="nav-link" id="az-navbar-az-fullscreen-primary-academics-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-selected="false">Academics</button>
+                  <button class="nav-link" id="az-navbar-az-fullscreen-primary-research-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-selected="false">Research</button>
+                  <button class="nav-link" id="az-navbar-az-fullscreen-primary-campus-life-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-campus-life-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-campus-life-content" aria-selected="false">Campus Life</button>
+                  <button class="nav-link" id="az-navbar-az-fullscreen-primary-about-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-about-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-about-content" aria-selected="false">About</button>
                 </div>
               </div>
             </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
@@ -215,7 +215,7 @@ title: AZ Navbar Fullscreen - Home
                 <!-- call-to-action items -->
                 <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-2 mt-2 mb-card">
                   <li class="nav-item">
-                    <a class="nav-link" href="http://localhost:9001/docs/5.1/examples/navbar-az-fullscreen/apply/">Apply</a>
+                    <a class="nav-link" href="{{< ref "apply" >}}">Apply</a>
                   </li>
                   <li class="nav-item" role="presentation">
                     <span class="vr" aria-hidden="true"></span>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
@@ -199,12 +199,18 @@ title: AZ Navbar Fullscreen - Home
               </div>
               <div id="navbar-az-fullscreen-nav-mobile-col" class="col-12 d-md-none">
                 <!-- call-to-action items -->
-                <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-4">
+                <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-2 mt-2">
                   <li class="nav-item">
                     <a class="nav-link" href="http://localhost:9001/docs/5.1/examples/navbar-az-fullscreen/apply/">Apply</a>
                   </li>
+                  <li class="nav-item" role="presentation">
+                    <span class="vr" aria-hidden="true"></span>
+                  </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">Visit</a>
+                  </li>
+                  <li class="nav-item" role="presentation">
+                    <span class="vr" aria-hidden="true"></span>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">Give</a>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
@@ -197,14 +197,26 @@ title: AZ Navbar Fullscreen - Home
                   <div class="tab-pane fade flex-grow-1 h-100 w-100" id="az-navbar-az-fullscreen-primary-about-content" role="tabpanel" aria-labelledby="az-navbar-az-fullscreen-primary-about-tab" tabindex="0">About menu</div>
                 </div>
               </div>
-              <div class="col-12 d-md-none navbar-az-fullscreen-nav-mobile-col">
+              <div id="navbar-az-fullscreen-nav-mobile-col" class="col-12 d-md-none">
+                <!-- call-to-action items -->
+                <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-4">
+                  <li class="nav-item">
+                    <a class="nav-link" href="http://localhost:9001/docs/5.1/examples/navbar-az-fullscreen/apply/">Apply</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link" href="#">Visit</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link" href="#">Give</a>
+                  </li>
+                </ul>
                 <!-- initial mobile nav items -->
-                <div class="nav flex-column navbar-az-fullscreen-nav-primary" id="az-navbar-az-fullscreen-primary-tablist" role="tablist" aria-orientation="vertical">
-                  <button class="nav-link" id="az-navbar-az-fullscreen-primary-admissions-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-selected="false">Admissions</button>
-                  <button class="nav-link" id="az-navbar-az-fullscreen-primary-academics-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-selected="false">Academics</button>
-                  <button class="nav-link" id="az-navbar-az-fullscreen-primary-research-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-selected="false">Research</button>
-                  <button class="nav-link" id="az-navbar-az-fullscreen-primary-campus-life-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-campus-life-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-campus-life-content" aria-selected="false">Campus Life</button>
-                  <button class="nav-link" id="az-navbar-az-fullscreen-primary-about-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-about-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-about-content" aria-selected="false">About</button>
+                <div class="nav flex-column navbar-az-fullscreen-nav-primary" role="tablist" aria-orientation="vertical">
+                  <button class="nav-link" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-selected="false">Admissions</button>
+                  <button class="nav-link" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-selected="false">Academics</button>
+                  <button class="nav-link" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-selected="false">Research</button>
+                  <button class="nav-link" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-campus-life-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-campus-life-content" aria-selected="false">Campus Life</button>
+                  <button class="nav-link" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-about-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-about-content" aria-selected="false">About</button>
                 </div>
               </div>
             </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
@@ -30,14 +30,14 @@ title: AZ Navbar Fullscreen - Home
             </li>
           </ul>
 
-          <form class="navbar-az-fullscreen-search me-2 me-md-4" role="search">
+          <form class="navbar-az-fullscreen-search me-2 me-lg-4" role="search">
             <label class="visually-hidden" for="navbar-az-fullscreen-search">Search the site</label>
-            <div class="input-group d-none d-md-flex">
+            <div class="input-group d-none d-lg-flex">
               <input id="navbar-az-fullscreen-search" class="form-control" type="search" placeholder="Search" aria-label="Search the site">
               <div class="vr"></div>
               <button class="btn" type="submit" aria-label="Submit site search"></button>
             </div>
-            <button class="btn d-md-none navbar-toggler-search" type="button" aria-label="Search the site"></button>
+            <button class="btn d-lg-none navbar-toggler-search" type="button" aria-label="Search the site"></button>
           </form>
 
           <button class="navbar-toggler" type="button" data-bs-toggle="modal" data-bs-target="#navbar-az-fullscreen-menu" aria-controls="navbar-az-fullscreen-menu" aria-label="Open site menu">
@@ -83,7 +83,7 @@ title: AZ Navbar Fullscreen - Home
             </div>
           </div>
           <div class="container-lg">
-            <form class="navbar-az-fullscreen-search my-2 my-md-5" role="search">
+            <form class="navbar-az-fullscreen-search my-2 my-lg-5" role="search">
               <label class="visually-hidden" for="navbar-az-fullscreen-modal-search">Search the site</label>
               <div class="input-group">
                 <input id="navbar-az-fullscreen-modal-search" class="form-control" type="search" placeholder="Search" aria-label="Search the site">
@@ -97,7 +97,7 @@ title: AZ Navbar Fullscreen - Home
         <div class="modal-body">
           <div class="container-lg text-white navbar-az-fullscreen-modal-menu">
             <div class="row g-0">
-              <div class="col-4 d-none d-md-block navbar-az-fullscreen-nav-primary-col">
+              <div class="col-4 d-none d-lg-block navbar-az-fullscreen-nav-primary-col">
                 <!-- primary nav items -->
                 <div class="nav flex-column navbar-az-fullscreen-nav-primary" id="az-navbar-az-fullscreen-primary-tablist" role="tablist" aria-orientation="vertical">
                   <button class="nav-link" id="az-navbar-az-fullscreen-primary-admissions-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-selected="false">Admissions</button>
@@ -107,7 +107,7 @@ title: AZ Navbar Fullscreen - Home
                   <button class="nav-link" id="az-navbar-az-fullscreen-primary-about-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-about-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-about-content" aria-selected="false">About</button>
                 </div>
               </div>
-              <div class="col-8 d-none d-md-flex navbar-az-fullscreen-nav-secondary-tertiary-cols">
+              <div class="col-8 d-none d-lg-flex navbar-az-fullscreen-nav-secondary-tertiary-cols">
                 <div class="tab-content d-flex flex-grow-1 w-100" id="az-navbar-az-fullscreen-primary-tab-content">
                   <div class="tab-pane fade flex-grow-1 h-100 w-100" id="az-navbar-az-fullscreen-primary-admissions-content" role="tabpanel" aria-labelledby="az-navbar-az-fullscreen-primary-admissions-tab" tabindex="0">
                     <div class="h-100">
@@ -211,7 +211,7 @@ title: AZ Navbar Fullscreen - Home
                   <div class="tab-pane fade flex-grow-1 h-100 w-100" id="az-navbar-az-fullscreen-primary-about-content" role="tabpanel" aria-labelledby="az-navbar-az-fullscreen-primary-about-tab" tabindex="0">About menu</div>
                 </div>
               </div>
-              <div id="navbar-az-fullscreen-nav-mobile-col" class="col-12 d-md-none">
+              <div id="navbar-az-fullscreen-nav-mobile-col" class="col-12 d-lg-none">
                 <!-- call-to-action items -->
                 <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-2 mt-2 mb-card">
                   <li class="nav-item">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
@@ -216,7 +216,7 @@ title: AZ Navbar Fullscreen - Admissions Overview
               <!-- call-to-action items -->
               <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-2 mt-2 mb-card">
                 <li class="nav-item">
-                  <a class="nav-link" href="http://localhost:9001/docs/5.1/examples/navbar-az-fullscreen/apply/">Apply</a>
+                  <a class="nav-link" href="{{< ref "apply" >}}">Apply</a>
                 </li>
                 <li class="nav-item" role="presentation">
                   <span class="vr" aria-hidden="true"></span>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
@@ -30,13 +30,14 @@ title: AZ Navbar Fullscreen - Admissions Overview
             </li>
           </ul>
 
-          <form class="navbar-az-fullscreen-search me-4" role="search">
+          <form class="navbar-az-fullscreen-search me-2 me-lg-4" role="search">
             <label class="visually-hidden" for="navbar-az-fullscreen-search">Search the site</label>
-            <div class="input-group">
+            <div class="input-group d-none d-lg-flex">
               <input id="navbar-az-fullscreen-search" class="form-control" type="search" placeholder="Search" aria-label="Search the site">
               <div class="vr"></div>
               <button class="btn" type="submit" aria-label="Submit site search"></button>
             </div>
+            <button class="btn d-lg-none navbar-toggler-search" type="button" aria-label="Search the site"></button>
           </form>
 
           <button class="navbar-toggler" type="button" data-bs-toggle="modal" data-bs-target="#navbar-az-fullscreen-menu" aria-controls="navbar-az-fullscreen-menu" aria-label="Open site menu">
@@ -82,7 +83,7 @@ title: AZ Navbar Fullscreen - Admissions Overview
             </div>
           </div>
           <div class="container-lg">
-            <form class="navbar-az-fullscreen-search my-5" role="search">
+            <form class="navbar-az-fullscreen-search my-2 my-lg-5" role="search">
               <label class="visually-hidden" for="navbar-az-fullscreen-modal-search">Search the site</label>
               <div class="input-group">
                 <input id="navbar-az-fullscreen-modal-search" class="form-control" type="search" placeholder="Search" aria-label="Search the site">
@@ -96,7 +97,7 @@ title: AZ Navbar Fullscreen - Admissions Overview
         <div class="modal-body">
           <div class="container-lg text-white navbar-az-fullscreen-modal-menu">
             <div class="row g-0">
-              <div class="col-4 navbar-az-fullscreen-nav-primary-col">
+              <div class="col-4 d-none d-lg-block navbar-az-fullscreen-nav-primary-col">
                 <!-- primary nav items -->
                 <div class="nav flex-column navbar-az-fullscreen-nav-primary" id="az-navbar-az-fullscreen-primary-tablist" role="tablist" aria-orientation="vertical">
                   <button class="nav-link active" id="az-navbar-az-fullscreen-primary-admissions-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-selected="false">Admissions</button>
@@ -106,7 +107,7 @@ title: AZ Navbar Fullscreen - Admissions Overview
                   <button class="nav-link" id="az-navbar-az-fullscreen-primary-about-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-about-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-about-content" aria-selected="false">About</button>
                 </div>
               </div>
-              <div class="col-8 navbar-az-fullscreen-nav-secondary-tertiary-cols d-flex">
+              <div class="col-8 d-none d-lg-flex navbar-az-fullscreen-nav-secondary-tertiary-cols">
                 <div class="tab-content d-flex flex-grow-1 w-100" id="az-navbar-az-fullscreen-primary-tab-content">
                   <div class="tab-pane fade active show flex-grow-1 h-100 w-100" id="az-navbar-az-fullscreen-primary-admissions-content" role="tabpanel" aria-labelledby="az-navbar-az-fullscreen-primary-admissions-tab" tabindex="0">
                     <div class="h-100">
@@ -209,6 +210,40 @@ title: AZ Navbar Fullscreen - Admissions Overview
                   </div>
                   <div class="tab-pane fade flex-grow-1 h-100 w-100" id="az-navbar-az-fullscreen-primary-about-content" role="tabpanel" aria-labelledby="az-navbar-az-fullscreen-primary-about-tab" tabindex="0">About menu</div>
                 </div>
+              </div>
+            </div>
+            <div id="navbar-az-fullscreen-nav-mobile-col" class="col-12 d-lg-none">
+              <!-- call-to-action items -->
+              <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-2 mt-2 mb-card">
+                <li class="nav-item">
+                  <a class="nav-link" href="http://localhost:9001/docs/5.1/examples/navbar-az-fullscreen/apply/">Apply</a>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <span class="vr" aria-hidden="true"></span>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="#">Visit</a>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <span class="vr" aria-hidden="true"></span>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="#">Give</a>
+                </li>
+              </ul>
+              <!-- initial mobile nav items -->
+              <div class="nav flex-column navbar-az-fullscreen-nav-primary" role="tablist" aria-orientation="vertical">
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link active" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Admissions</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Academics</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Research</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Campus Life</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-about-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">About</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
               </div>
             </div>
           </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
@@ -216,7 +216,7 @@ title: AZ Navbar Fullscreen - Apply
               <!-- call-to-action items -->
               <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-2 mt-2 mb-card">
                 <li class="nav-item">
-                  <a class="nav-link" href="http://localhost:9001/docs/5.1/examples/navbar-az-fullscreen/apply/">Apply</a>
+                  <a class="nav-link" href="{{< ref "apply" >}}">Apply</a>
                 </li>
                 <li class="nav-item" role="presentation">
                   <span class="vr" aria-hidden="true"></span>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
@@ -30,13 +30,14 @@ title: AZ Navbar Fullscreen - Apply
             </li>
           </ul>
 
-          <form class="navbar-az-fullscreen-search me-4" role="search">
+          <form class="navbar-az-fullscreen-search me-2 me-lg-4" role="search">
             <label class="visually-hidden" for="navbar-az-fullscreen-search">Search the site</label>
-            <div class="input-group">
+            <div class="input-group d-none d-lg-flex">
               <input id="navbar-az-fullscreen-search" class="form-control" type="search" placeholder="Search" aria-label="Search the site">
               <div class="vr"></div>
               <button class="btn" type="submit" aria-label="Submit site search"></button>
             </div>
+            <button class="btn d-lg-none navbar-toggler-search" type="button" aria-label="Search the site"></button>
           </form>
 
           <button class="navbar-toggler" type="button" data-bs-toggle="modal" data-bs-target="#navbar-az-fullscreen-menu" aria-controls="navbar-az-fullscreen-menu" aria-label="Open site menu">
@@ -82,7 +83,7 @@ title: AZ Navbar Fullscreen - Apply
             </div>
           </div>
           <div class="container-lg">
-            <form class="navbar-az-fullscreen-search my-5" role="search">
+            <form class="navbar-az-fullscreen-search my-2 my-lg-5" role="search">
               <label class="visually-hidden" for="navbar-az-fullscreen-modal-search">Search the site</label>
               <div class="input-group">
                 <input id="navbar-az-fullscreen-modal-search" class="form-control" type="search" placeholder="Search" aria-label="Search the site">
@@ -96,7 +97,7 @@ title: AZ Navbar Fullscreen - Apply
         <div class="modal-body">
           <div class="container-lg text-white navbar-az-fullscreen-modal-menu">
             <div class="row g-0">
-              <div class="col-4 navbar-az-fullscreen-nav-primary-col">
+              <div class="col-4 d-none d-lg-block navbar-az-fullscreen-nav-primary-col">
                 <!-- primary nav items -->
                 <div class="nav flex-column navbar-az-fullscreen-nav-primary" id="az-navbar-az-fullscreen-primary-tablist" role="tablist" aria-orientation="vertical">
                   <button class="nav-link" id="az-navbar-az-fullscreen-primary-admissions-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-selected="false">Admissions</button>
@@ -106,7 +107,7 @@ title: AZ Navbar Fullscreen - Apply
                   <button class="nav-link" id="az-navbar-az-fullscreen-primary-about-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-about-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-about-content" aria-selected="false">About</button>
                 </div>
               </div>
-              <div class="col-8 navbar-az-fullscreen-nav-secondary-tertiary-cols d-flex">
+              <div class="col-8 d-none d-lg-flex navbar-az-fullscreen-nav-secondary-tertiary-cols">
                 <div class="tab-content d-flex flex-grow-1 w-100" id="az-navbar-az-fullscreen-primary-tab-content">
                   <div class="tab-pane fade flex-grow-1 h-100 w-100" id="az-navbar-az-fullscreen-primary-admissions-content" role="tabpanel" aria-labelledby="az-navbar-az-fullscreen-primary-admissions-tab" tabindex="0">
                     <div class="h-100">
@@ -209,6 +210,40 @@ title: AZ Navbar Fullscreen - Apply
                   </div>
                   <div class="tab-pane fade flex-grow-1 h-100 w-100" id="az-navbar-az-fullscreen-primary-about-content" role="tabpanel" aria-labelledby="az-navbar-az-fullscreen-primary-about-tab" tabindex="0">About menu</div>
                 </div>
+              </div>
+            </div>
+            <div id="navbar-az-fullscreen-nav-mobile-col" class="col-12 d-lg-none">
+              <!-- call-to-action items -->
+              <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-2 mt-2 mb-card">
+                <li class="nav-item">
+                  <a class="nav-link" href="http://localhost:9001/docs/5.1/examples/navbar-az-fullscreen/apply/">Apply</a>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <span class="vr" aria-hidden="true"></span>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="#">Visit</a>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <span class="vr" aria-hidden="true"></span>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="#">Give</a>
+                </li>
+              </ul>
+              <!-- initial mobile nav items -->
+              <div class="nav flex-column navbar-az-fullscreen-nav-primary" role="tablist" aria-orientation="vertical">
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Admissions</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Academics</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Research</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Campus Life</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-about-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">About</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
               </div>
             </div>
           </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
@@ -30,13 +30,14 @@ title: AZ Navbar Fullscreen - Calendar & Events
             </li>
           </ul>
 
-          <form class="navbar-az-fullscreen-search me-4" role="search">
+          <form class="navbar-az-fullscreen-search me-2 me-lg-4" role="search">
             <label class="visually-hidden" for="navbar-az-fullscreen-search">Search the site</label>
-            <div class="input-group">
+            <div class="input-group d-none d-lg-flex">
               <input id="navbar-az-fullscreen-search" class="form-control" type="search" placeholder="Search" aria-label="Search the site">
               <div class="vr"></div>
               <button class="btn" type="submit" aria-label="Submit site search"></button>
             </div>
+            <button class="btn d-lg-none navbar-toggler-search" type="button" aria-label="Search the site"></button>
           </form>
 
           <button class="navbar-toggler" type="button" data-bs-toggle="modal" data-bs-target="#navbar-az-fullscreen-menu" aria-controls="navbar-az-fullscreen-menu" aria-label="Open site menu">
@@ -82,7 +83,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
             </div>
           </div>
           <div class="container-lg">
-            <form class="navbar-az-fullscreen-search my-5" role="search">
+            <form class="navbar-az-fullscreen-search my-2 my-lg-5" role="search">
               <label class="visually-hidden" for="navbar-az-fullscreen-modal-search">Search the site</label>
               <div class="input-group">
                 <input id="navbar-az-fullscreen-modal-search" class="form-control" type="search" placeholder="Search" aria-label="Search the site">
@@ -96,7 +97,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
         <div class="modal-body">
           <div class="container-lg text-white navbar-az-fullscreen-modal-menu">
             <div class="row g-0">
-              <div class="col-4 navbar-az-fullscreen-nav-primary-col">
+              <div class="col-4 d-none d-lg-block navbar-az-fullscreen-nav-primary-col">
                 <!-- primary nav items -->
                 <div class="nav flex-column navbar-az-fullscreen-nav-primary" id="az-navbar-az-fullscreen-primary-tablist" role="tablist" aria-orientation="vertical">
                   <button class="nav-link" id="az-navbar-az-fullscreen-primary-admissions-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-selected="false">Admissions</button>
@@ -106,7 +107,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
                   <button class="nav-link" id="az-navbar-az-fullscreen-primary-about-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-about-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-about-content" aria-selected="false">About</button>
                 </div>
               </div>
-              <div class="col-8 navbar-az-fullscreen-nav-secondary-tertiary-cols d-flex">
+              <div class="col-8 d-none d-lg-flex navbar-az-fullscreen-nav-secondary-tertiary-cols">
                 <div class="tab-content d-flex flex-grow-1 w-100" id="az-navbar-az-fullscreen-primary-tab-content">
                   <div class="tab-pane fade flex-grow-1 h-100 w-100" id="az-navbar-az-fullscreen-primary-admissions-content" role="tabpanel" aria-labelledby="az-navbar-az-fullscreen-primary-admissions-tab" tabindex="0">
                     <div class="h-100">
@@ -209,6 +210,40 @@ title: AZ Navbar Fullscreen - Calendar & Events
                   </div>
                   <div class="tab-pane fade flex-grow-1 h-100 w-100" id="az-navbar-az-fullscreen-primary-about-content" role="tabpanel" aria-labelledby="az-navbar-az-fullscreen-primary-about-tab" tabindex="0">About menu</div>
                 </div>
+              </div>
+            </div>
+            <div id="navbar-az-fullscreen-nav-mobile-col" class="col-12 d-lg-none">
+              <!-- call-to-action items -->
+              <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-2 mt-2 mb-card">
+                <li class="nav-item">
+                  <a class="nav-link" href="http://localhost:9001/docs/5.1/examples/navbar-az-fullscreen/apply/">Apply</a>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <span class="vr" aria-hidden="true"></span>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="#">Visit</a>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <span class="vr" aria-hidden="true"></span>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="#">Give</a>
+                </li>
+              </ul>
+              <!-- initial mobile nav items -->
+              <div class="nav flex-column navbar-az-fullscreen-nav-primary" role="tablist" aria-orientation="vertical">
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Admissions</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Academics</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Research</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link active" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Campus Life</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-about-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">About</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
               </div>
             </div>
           </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
@@ -216,7 +216,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
               <!-- call-to-action items -->
               <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-2 mt-2 mb-card">
                 <li class="nav-item">
-                  <a class="nav-link" href="http://localhost:9001/docs/5.1/examples/navbar-az-fullscreen/apply/">Apply</a>
+                  <a class="nav-link" href="{{< ref "apply" >}}">Apply</a>
                 </li>
                 <li class="nav-item" role="presentation">
                   <span class="vr" aria-hidden="true"></span>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
@@ -30,13 +30,14 @@ title: AZ Navbar Fullscreen - Campus Recreation
             </li>
           </ul>
 
-          <form class="navbar-az-fullscreen-search me-4" role="search">
+          <form class="navbar-az-fullscreen-search me-2 me-lg-4" role="search">
             <label class="visually-hidden" for="navbar-az-fullscreen-search">Search the site</label>
-            <div class="input-group">
+            <div class="input-group d-none d-lg-flex">
               <input id="navbar-az-fullscreen-search" class="form-control" type="search" placeholder="Search" aria-label="Search the site">
               <div class="vr"></div>
               <button class="btn" type="submit" aria-label="Submit site search"></button>
             </div>
+            <button class="btn d-lg-none navbar-toggler-search" type="button" aria-label="Search the site"></button>
           </form>
 
           <button class="navbar-toggler" type="button" data-bs-toggle="modal" data-bs-target="#navbar-az-fullscreen-menu" aria-controls="navbar-az-fullscreen-menu" aria-label="Open site menu">
@@ -82,7 +83,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
             </div>
           </div>
           <div class="container-lg">
-            <form class="navbar-az-fullscreen-search my-5" role="search">
+            <form class="navbar-az-fullscreen-search my-2 my-lg-5" role="search">
               <label class="visually-hidden" for="navbar-az-fullscreen-modal-search">Search the site</label>
               <div class="input-group">
                 <input id="navbar-az-fullscreen-modal-search" class="form-control" type="search" placeholder="Search" aria-label="Search the site">
@@ -96,7 +97,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
         <div class="modal-body">
           <div class="container-lg text-white navbar-az-fullscreen-modal-menu">
             <div class="row g-0">
-              <div class="col-4 navbar-az-fullscreen-nav-primary-col">
+              <div class="col-4 d-none d-lg-block navbar-az-fullscreen-nav-primary-col">
                 <!-- primary nav items -->
                 <div class="nav flex-column navbar-az-fullscreen-nav-primary" id="az-navbar-az-fullscreen-primary-tablist" role="tablist" aria-orientation="vertical">
                   <button class="nav-link" id="az-navbar-az-fullscreen-primary-admissions-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-selected="false">Admissions</button>
@@ -106,7 +107,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
                   <button class="nav-link" id="az-navbar-az-fullscreen-primary-about-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-about-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-about-content" aria-selected="false">About</button>
                 </div>
               </div>
-              <div class="col-8 navbar-az-fullscreen-nav-secondary-tertiary-cols d-flex">
+              <div class="col-8 d-none d-lg-flex navbar-az-fullscreen-nav-secondary-tertiary-cols">
                 <div class="tab-content d-flex flex-grow-1 w-100" id="az-navbar-az-fullscreen-primary-tab-content">
                   <div class="tab-pane fade flex-grow-1 h-100 w-100" id="az-navbar-az-fullscreen-primary-admissions-content" role="tabpanel" aria-labelledby="az-navbar-az-fullscreen-primary-admissions-tab" tabindex="0">
                     <div class="h-100">
@@ -209,6 +210,40 @@ title: AZ Navbar Fullscreen - Campus Recreation
                   </div>
                   <div class="tab-pane fade flex-grow-1 h-100 w-100" id="az-navbar-az-fullscreen-primary-about-content" role="tabpanel" aria-labelledby="az-navbar-az-fullscreen-primary-about-tab" tabindex="0">About menu</div>
                 </div>
+              </div>
+            </div>
+            <div id="navbar-az-fullscreen-nav-mobile-col" class="col-12 d-lg-none">
+              <!-- call-to-action items -->
+              <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-2 mt-2 mb-card">
+                <li class="nav-item">
+                  <a class="nav-link" href="http://localhost:9001/docs/5.1/examples/navbar-az-fullscreen/apply/">Apply</a>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <span class="vr" aria-hidden="true"></span>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="#">Visit</a>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <span class="vr" aria-hidden="true"></span>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="#">Give</a>
+                </li>
+              </ul>
+              <!-- initial mobile nav items -->
+              <div class="nav flex-column navbar-az-fullscreen-nav-primary" role="tablist" aria-orientation="vertical">
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Admissions</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Academics</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Research</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link active" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Campus Life</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-about-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">About</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
               </div>
             </div>
           </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
@@ -216,7 +216,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
               <!-- call-to-action items -->
               <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-2 mt-2 mb-card">
                 <li class="nav-item">
-                  <a class="nav-link" href="http://localhost:9001/docs/5.1/examples/navbar-az-fullscreen/apply/">Apply</a>
+                  <a class="nav-link" href="{{< ref "apply" >}}">Apply</a>
                 </li>
                 <li class="nav-item" role="presentation">
                   <span class="vr" aria-hidden="true"></span>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
@@ -216,7 +216,7 @@ title: AZ Navbar Fullscreen - Business or Partner
               <!-- call-to-action items -->
               <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-2 mt-2 mb-card">
                 <li class="nav-item">
-                  <a class="nav-link" href="http://localhost:9001/docs/5.1/examples/navbar-az-fullscreen/apply/">Apply</a>
+                  <a class="nav-link" href="{{< ref "apply" >}}">Apply</a>
                 </li>
                 <li class="nav-item" role="presentation">
                   <span class="vr" aria-hidden="true"></span>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
@@ -30,13 +30,14 @@ title: AZ Navbar Fullscreen - Business or Partner
             </li>
           </ul>
 
-          <form class="navbar-az-fullscreen-search me-4" role="search">
+          <form class="navbar-az-fullscreen-search me-2 me-lg-4" role="search">
             <label class="visually-hidden" for="navbar-az-fullscreen-search">Search the site</label>
-            <div class="input-group">
+            <div class="input-group d-none d-lg-flex">
               <input id="navbar-az-fullscreen-search" class="form-control" type="search" placeholder="Search" aria-label="Search the site">
               <div class="vr"></div>
               <button class="btn" type="submit" aria-label="Submit site search"></button>
             </div>
+            <button class="btn d-lg-none navbar-toggler-search" type="button" aria-label="Search the site"></button>
           </form>
 
           <button class="navbar-toggler" type="button" data-bs-toggle="modal" data-bs-target="#navbar-az-fullscreen-menu" aria-controls="navbar-az-fullscreen-menu" aria-label="Open site menu">
@@ -82,7 +83,7 @@ title: AZ Navbar Fullscreen - Business or Partner
             </div>
           </div>
           <div class="container-lg">
-            <form class="navbar-az-fullscreen-search my-5" role="search">
+            <form class="navbar-az-fullscreen-search my-2 my-lg-5" role="search">
               <label class="visually-hidden" for="navbar-az-fullscreen-modal-search">Search the site</label>
               <div class="input-group">
                 <input id="navbar-az-fullscreen-modal-search" class="form-control" type="search" placeholder="Search" aria-label="Search the site">
@@ -96,7 +97,7 @@ title: AZ Navbar Fullscreen - Business or Partner
         <div class="modal-body">
           <div class="container-lg text-white navbar-az-fullscreen-modal-menu">
             <div class="row g-0">
-              <div class="col-4 navbar-az-fullscreen-nav-primary-col">
+              <div class="col-4 d-none d-lg-block navbar-az-fullscreen-nav-primary-col">
                 <!-- primary nav items -->
                 <div class="nav flex-column navbar-az-fullscreen-nav-primary" id="az-navbar-az-fullscreen-primary-tablist" role="tablist" aria-orientation="vertical">
                   <button class="nav-link" id="az-navbar-az-fullscreen-primary-admissions-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-selected="false">Admissions</button>
@@ -106,7 +107,7 @@ title: AZ Navbar Fullscreen - Business or Partner
                   <button class="nav-link" id="az-navbar-az-fullscreen-primary-about-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-about-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-about-content" aria-selected="false">About</button>
                 </div>
               </div>
-              <div class="col-8 navbar-az-fullscreen-nav-secondary-tertiary-cols d-flex">
+              <div class="col-8 d-none d-lg-flex navbar-az-fullscreen-nav-secondary-tertiary-cols">
                 <div class="tab-content d-flex flex-grow-1 w-100" id="az-navbar-az-fullscreen-primary-tab-content">
                   <div class="tab-pane fade flex-grow-1 h-100 w-100" id="az-navbar-az-fullscreen-primary-admissions-content" role="tabpanel" aria-labelledby="az-navbar-az-fullscreen-primary-admissions-tab" tabindex="0">
                     <div class="h-100">
@@ -209,6 +210,40 @@ title: AZ Navbar Fullscreen - Business or Partner
                   </div>
                   <div class="tab-pane fade flex-grow-1 h-100 w-100" id="az-navbar-az-fullscreen-primary-about-content" role="tabpanel" aria-labelledby="az-navbar-az-fullscreen-primary-about-tab" tabindex="0">About menu</div>
                 </div>
+              </div>
+            </div>
+            <div id="navbar-az-fullscreen-nav-mobile-col" class="col-12 d-lg-none">
+              <!-- call-to-action items -->
+              <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-2 mt-2 mb-card">
+                <li class="nav-item">
+                  <a class="nav-link" href="http://localhost:9001/docs/5.1/examples/navbar-az-fullscreen/apply/">Apply</a>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <span class="vr" aria-hidden="true"></span>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="#">Visit</a>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <span class="vr" aria-hidden="true"></span>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="#">Give</a>
+                </li>
+              </ul>
+              <!-- initial mobile nav items -->
+              <div class="nav flex-column navbar-az-fullscreen-nav-primary" role="tablist" aria-orientation="vertical">
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Admissions</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Academics</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Research</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Campus Life</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-about-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">About</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
               </div>
             </div>
           </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
@@ -216,7 +216,7 @@ title: AZ Navbar Fullscreen - Tuition & Aid
               <!-- call-to-action items -->
               <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-2 mt-2 mb-card">
                 <li class="nav-item">
-                  <a class="nav-link" href="http://localhost:9001/docs/5.1/examples/navbar-az-fullscreen/apply/">Apply</a>
+                  <a class="nav-link" href="{{< ref "apply" >}}">Apply</a>
                 </li>
                 <li class="nav-item" role="presentation">
                   <span class="vr" aria-hidden="true"></span>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
@@ -30,13 +30,14 @@ title: AZ Navbar Fullscreen - Tuition & Aid
             </li>
           </ul>
 
-          <form class="navbar-az-fullscreen-search me-4" role="search">
+          <form class="navbar-az-fullscreen-search me-2 me-lg-4" role="search">
             <label class="visually-hidden" for="navbar-az-fullscreen-search">Search the site</label>
-            <div class="input-group">
+            <div class="input-group d-none d-lg-flex">
               <input id="navbar-az-fullscreen-search" class="form-control" type="search" placeholder="Search" aria-label="Search the site">
               <div class="vr"></div>
               <button class="btn" type="submit" aria-label="Submit site search"></button>
             </div>
+            <button class="btn d-lg-none navbar-toggler-search" type="button" aria-label="Search the site"></button>
           </form>
 
           <button class="navbar-toggler" type="button" data-bs-toggle="modal" data-bs-target="#navbar-az-fullscreen-menu" aria-controls="navbar-az-fullscreen-menu" aria-label="Open site menu">
@@ -82,7 +83,7 @@ title: AZ Navbar Fullscreen - Tuition & Aid
             </div>
           </div>
           <div class="container-lg">
-            <form class="navbar-az-fullscreen-search my-5" role="search">
+            <form class="navbar-az-fullscreen-search my-2 my-lg-5" role="search">
               <label class="visually-hidden" for="navbar-az-fullscreen-modal-search">Search the site</label>
               <div class="input-group">
                 <input id="navbar-az-fullscreen-modal-search" class="form-control" type="search" placeholder="Search" aria-label="Search the site">
@@ -96,7 +97,7 @@ title: AZ Navbar Fullscreen - Tuition & Aid
         <div class="modal-body">
           <div class="container-lg text-white navbar-az-fullscreen-modal-menu">
             <div class="row g-0">
-              <div class="col-4 navbar-az-fullscreen-nav-primary-col">
+              <div class="col-4 d-none d-lg-block navbar-az-fullscreen-nav-primary-col">
                 <!-- primary nav items -->
                 <div class="nav flex-column navbar-az-fullscreen-nav-primary" id="az-navbar-az-fullscreen-primary-tablist" role="tablist" aria-orientation="vertical">
                   <button class="nav-link active" id="az-navbar-az-fullscreen-primary-admissions-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-selected="false">Admissions</button>
@@ -106,7 +107,7 @@ title: AZ Navbar Fullscreen - Tuition & Aid
                   <button class="nav-link" id="az-navbar-az-fullscreen-primary-about-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-about-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-about-content" aria-selected="false">About</button>
                 </div>
               </div>
-              <div class="col-8 navbar-az-fullscreen-nav-secondary-tertiary-cols d-flex">
+              <div class="col-8 d-none d-lg-flex navbar-az-fullscreen-nav-secondary-tertiary-cols">
                 <div class="tab-content d-flex flex-grow-1 w-100" id="az-navbar-az-fullscreen-primary-tab-content">
                   <div class="tab-pane fade active show flex-grow-1 h-100 w-100" id="az-navbar-az-fullscreen-primary-admissions-content" role="tabpanel" aria-labelledby="az-navbar-az-fullscreen-primary-admissions-tab" tabindex="0">
                     <div class="h-100">
@@ -209,6 +210,40 @@ title: AZ Navbar Fullscreen - Tuition & Aid
                   </div>
                   <div class="tab-pane fade flex-grow-1 h-100 w-100" id="az-navbar-az-fullscreen-primary-about-content" role="tabpanel" aria-labelledby="az-navbar-az-fullscreen-primary-about-tab" tabindex="0">About menu</div>
                 </div>
+              </div>
+            </div>
+            <div id="navbar-az-fullscreen-nav-mobile-col" class="col-12 d-lg-none">
+              <!-- call-to-action items -->
+              <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-2 mt-2 mb-card">
+                <li class="nav-item">
+                  <a class="nav-link" href="http://localhost:9001/docs/5.1/examples/navbar-az-fullscreen/apply/">Apply</a>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <span class="vr" aria-hidden="true"></span>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="#">Visit</a>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <span class="vr" aria-hidden="true"></span>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="#">Give</a>
+                </li>
+              </ul>
+              <!-- initial mobile nav items -->
+              <div class="nav flex-column navbar-az-fullscreen-nav-primary" role="tablist" aria-orientation="vertical">
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link active" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Admissions</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Academics</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Research</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Campus Life</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-about-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">About</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
               </div>
             </div>
           </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
@@ -216,7 +216,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
               <!-- call-to-action items -->
               <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-2 mt-2 mb-card">
                 <li class="nav-item">
-                  <a class="nav-link" href="http://localhost:9001/docs/5.1/examples/navbar-az-fullscreen/apply/">Apply</a>
+                  <a class="nav-link" href="{{< ref "apply" >}}">Apply</a>
                 </li>
                 <li class="nav-item" role="presentation">
                   <span class="vr" aria-hidden="true"></span>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
@@ -30,13 +30,14 @@ title: AZ Navbar Fullscreen - Undergraduate Students
             </li>
           </ul>
 
-          <form class="navbar-az-fullscreen-search me-4" role="search">
+          <form class="navbar-az-fullscreen-search me-2 me-lg-4" role="search">
             <label class="visually-hidden" for="navbar-az-fullscreen-search">Search the site</label>
-            <div class="input-group">
+            <div class="input-group d-none d-lg-flex">
               <input id="navbar-az-fullscreen-search" class="form-control" type="search" placeholder="Search" aria-label="Search the site">
               <div class="vr"></div>
               <button class="btn" type="submit" aria-label="Submit site search"></button>
             </div>
+            <button class="btn d-lg-none navbar-toggler-search" type="button" aria-label="Search the site"></button>
           </form>
 
           <button class="navbar-toggler" type="button" data-bs-toggle="modal" data-bs-target="#navbar-az-fullscreen-menu" aria-controls="navbar-az-fullscreen-menu" aria-label="Open site menu">
@@ -82,7 +83,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
             </div>
           </div>
           <div class="container-lg">
-            <form class="navbar-az-fullscreen-search my-5" role="search">
+            <form class="navbar-az-fullscreen-search my-2 my-lg-5" role="search">
               <label class="visually-hidden" for="navbar-az-fullscreen-modal-search">Search the site</label>
               <div class="input-group">
                 <input id="navbar-az-fullscreen-modal-search" class="form-control" type="search" placeholder="Search" aria-label="Search the site">
@@ -96,7 +97,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
         <div class="modal-body">
           <div class="container-lg text-white navbar-az-fullscreen-modal-menu">
             <div class="row g-0">
-              <div class="col-4 navbar-az-fullscreen-nav-primary-col">
+              <div class="col-4 d-none d-lg-block navbar-az-fullscreen-nav-primary-col">
                 <!-- primary nav items -->
                 <div class="nav flex-column navbar-az-fullscreen-nav-primary" id="az-navbar-az-fullscreen-primary-tablist" role="tablist" aria-orientation="vertical">
                   <button class="nav-link active" id="az-navbar-az-fullscreen-primary-admissions-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-selected="false">Admissions</button>
@@ -106,7 +107,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
                   <button class="nav-link" id="az-navbar-az-fullscreen-primary-about-tab" data-bs-toggle="pill-hover" data-bs-target="#az-navbar-az-fullscreen-primary-about-content" type="button" role="tab" aria-controls="az-navbar-az-fullscreen-primary-about-content" aria-selected="false">About</button>
                 </div>
               </div>
-              <div class="col-8 navbar-az-fullscreen-nav-secondary-tertiary-cols d-flex">
+              <div class="col-8 d-none d-lg-flex navbar-az-fullscreen-nav-secondary-tertiary-cols">
                 <div class="tab-content d-flex flex-grow-1 w-100" id="az-navbar-az-fullscreen-primary-tab-content">
                   <div class="tab-pane fade show active flex-grow-1 h-100 w-100" id="az-navbar-az-fullscreen-primary-admissions-content" role="tabpanel" aria-labelledby="az-navbar-az-fullscreen-primary-admissions-tab" tabindex="0">
                     <div class="h-100">
@@ -209,6 +210,40 @@ title: AZ Navbar Fullscreen - Undergraduate Students
                   </div>
                   <div class="tab-pane fade flex-grow-1 h-100 w-100" id="az-navbar-az-fullscreen-primary-about-content" role="tabpanel" aria-labelledby="az-navbar-az-fullscreen-primary-about-tab" tabindex="0">About menu</div>
                 </div>
+              </div>
+            </div>
+            <div id="navbar-az-fullscreen-nav-mobile-col" class="col-12 d-lg-none">
+              <!-- call-to-action items -->
+              <ul class="navbar-nav navbar-az-fullscreen-actions d-flex flex-row align-items-center justify-content-center gap-2 mt-2 mb-card">
+                <li class="nav-item">
+                  <a class="nav-link" href="http://localhost:9001/docs/5.1/examples/navbar-az-fullscreen/apply/">Apply</a>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <span class="vr" aria-hidden="true"></span>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="#">Visit</a>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <span class="vr" aria-hidden="true"></span>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="#">Give</a>
+                </li>
+              </ul>
+              <!-- initial mobile nav items -->
+              <div class="nav flex-column navbar-az-fullscreen-nav-primary" role="tablist" aria-orientation="vertical">
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link active" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Admissions</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Academics</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Research</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">Campus Life</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
+                <button class="nav-link" data-az-menu-element="#az-navbar-az-fullscreen-primary-about-content" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col">About</button>
+                <hr class="border-bottom border-azurite opacity-100 my-0" aria-hidden="true" role="presentation">
               </div>
             </div>
           </div>


### PR DESCRIPTION
This branch is intended to be merged into this PR:
 - #1938

## Changes
 - Adds JS and SCSS to support a mobile display for AZ Navbar Fullscreen. The mobile display has a paged presentation which is generated using JavaScript and the existing DOM for the desktop navigation.
 - Updates example pages to support the new mobile display.

## How to review
https://review.digital.arizona.edu/arizona-bootstrap/issue/1937-mobile/docs/5.1/examples/navbar-az-fullscreen/

At this point, I would recommend simply reviewing the existing functionality that this PR adds. Review of the code is welcome, but it needs a lot more work and refactoring, which is planned for the next couple weeks.