### PR TITLE
docs: add note about online autoprefixing tools for non-build workflows

### DIFF
--- a/site/content/docs/5.1/getting-started/browsers-devices.md
+++ b/site/content/docs/5.1/getting-started/browsers-devices.md
@@ -20,7 +20,7 @@ You can find our supported range of browsers and their versions [in our `.browse
 {{< /rf.inline >}}
 ```
 
-We use [Autoprefixer](https://github.com/postcss/autoprefixer) to handle intended browser support via CSS prefixes, which uses [Browserslist](https://github.com/browserslist/browserslist) to manage these browser versions. Consult their documentation for how to integrate these tools into your projects.
+We use [Autoprefixer](https://github.com/postcss/autoprefixer) to handle intended browser support via CSS prefixes, which uses [Browserslist](https://github.com/browserslist/browserslist) to manage these browser versions. Consult their documentation for how to integrate these tools into your projects. If you’re not using a build pipeline, you can also use online tools to apply vendor prefixes automatically, such as [this autoprefixer tool](https://goonlinetools.com/autoprefixer/).
 
 ### Mobile devices
 


### PR DESCRIPTION
Updates the autoprefixer section to mention that vendor prefixes can also be applied using online tools for projects without a build setup, with support for selecting different PostCSS and Autoprefixer versions.