### PR TITLE
Fixes #2028: Fix AZ Navbar list element accessibility error

### DIFF
--- a/site/content/docs/5.1/components/navbar.md
+++ b/site/content/docs/5.1/components/navbar.md
@@ -391,20 +391,20 @@ Add `.navbar-az` to an existing `.navbar` to gain additional Brand-approved styl
         <li class="nav-item">
           <a class="nav-link active" aria-current="page" href="#">Home</a>
         </li>
-        <li class="nav-item" role="presentation">
-          <span class="vr" aria-hidden="true"></span>
+        <li class="nav-item" aria-hidden="true">
+          <span class="vr"></span>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="#">Link</a>
         </li>
-        <li class="nav-item" role="presentation">
-          <span class="vr" aria-hidden="true"></span>
+        <li class="nav-item" aria-hidden="true">
+          <span class="vr"></span>
         </li>
         <li class="nav-item">
           <a class="nav-link disabled" aria-disabled="true">Disabled</a>
         </li>
-        <li class="nav-item" role="presentation">
-          <span class="vr" aria-hidden="true"></span>
+        <li class="nav-item" aria-hidden="true">
+          <span class="vr"></span>
         </li>
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
@@ -416,8 +416,8 @@ Add `.navbar-az` to an existing `.navbar` to gain additional Brand-approved styl
             <li><a class="dropdown-item disabled" aria-disabled="true">Secondary Navigation - Disabled</a></li>
           </ul>
         </li>
-        <li class="nav-item" role="presentation">
-          <span class="vr" aria-hidden="true"></span>
+        <li class="nav-item" aria-hidden="true">
+          <span class="vr"></span>
         </li>
         <li class="nav-item dropdown btn-group">
           <a class="nav-link" href="#">Split Dropdown</a>

--- a/site/content/docs/5.1/examples/navbar-az/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az/_index.html
@@ -16,20 +16,20 @@ extra_css:
           <li class="nav-item">
             <a class="nav-link" aria-current="page" href="{{< ref "navbar-az" >}}">Home</a>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="{{< ref "navbar-az" >}}">Link</a>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item">
             <a class="nav-link disabled" aria-disabled="true">Disabled</a>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
@@ -41,8 +41,8 @@ extra_css:
               <li><a class="dropdown-item disabled" aria-disabled="true">Secondary Navigation - Disabled</a></li>
             </ul>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item dropdown btn-group">
             <a class="nav-link active" href="{{< ref "navbar-az" >}}">Split Dropdown</a>
@@ -80,8 +80,8 @@ extra_css:
               </li>
             </ul>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item dropdown btn-group">
             <a class="nav-link" href="{{< ref "navbar-az" >}}">Long Children</a>
@@ -120,8 +120,8 @@ extra_css:
               </li>
             </ul>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item dropdown btn-group">
             <a class="nav-link" href="{{< ref "navbar-az" >}}">Long Navbar</a>
@@ -170,8 +170,8 @@ extra_css:
               </li>
             </ul>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item dropdown btn-group">
             <a class="nav-link" href="{{< ref "navbar-az" >}}">Longer Navbar</a>

--- a/site/content/docs/5.1/examples/navbar-az/secondary/index.html
+++ b/site/content/docs/5.1/examples/navbar-az/secondary/index.html
@@ -16,20 +16,20 @@ extra_css:
           <li class="nav-item">
             <a class="nav-link" aria-current="page" href="{{< ref "navbar-az" >}}">Home</a>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="{{< ref "navbar-az" >}}">Link</a>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item">
             <a class="nav-link disabled" aria-disabled="true">Disabled</a>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
@@ -41,8 +41,8 @@ extra_css:
               <li><a class="dropdown-item disabled" aria-disabled="true">Secondary Navigation - Disabled</a></li>
             </ul>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item dropdown btn-group">
             <a class="nav-link" href="{{< ref "navbar-az" >}}">Split Dropdown</a>
@@ -80,8 +80,8 @@ extra_css:
               </li>
             </ul>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item dropdown btn-group">
             <a class="nav-link" href="{{< ref "navbar-az" >}}">Long Children</a>
@@ -120,8 +120,8 @@ extra_css:
               </li>
             </ul>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item dropdown btn-group">
             <a class="nav-link" href="{{< ref "navbar-az" >}}">Long Navbar</a>
@@ -170,8 +170,8 @@ extra_css:
               </li>
             </ul>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item dropdown btn-group">
             <a class="nav-link" href="{{< ref "navbar-az" >}}">Longer Navbar</a>

--- a/site/content/docs/5.1/examples/navbar-az/tertiary/index.html
+++ b/site/content/docs/5.1/examples/navbar-az/tertiary/index.html
@@ -16,20 +16,20 @@ extra_css:
           <li class="nav-item">
             <a class="nav-link" aria-current="page" href="{{< ref "navbar-az" >}}">Home</a>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="{{< ref "navbar-az" >}}">Link</a>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item">
             <a class="nav-link disabled" aria-disabled="true">Disabled</a>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
@@ -41,8 +41,8 @@ extra_css:
               <li><a class="dropdown-item disabled" aria-disabled="true">Secondary Navigation - Disabled</a></li>
             </ul>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item dropdown btn-group">
             <a class="nav-link" href="{{< ref "navbar-az" >}}">Split Dropdown</a>
@@ -80,8 +80,8 @@ extra_css:
               </li>
             </ul>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item dropdown btn-group">
             <a class="nav-link" href="{{< ref "navbar-az" >}}">Long Children</a>
@@ -120,8 +120,8 @@ extra_css:
               </li>
             </ul>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item dropdown btn-group">
             <a class="nav-link" href="{{< ref "navbar-az" >}}">Long Navbar</a>
@@ -170,8 +170,8 @@ extra_css:
               </li>
             </ul>
           </li>
-          <li class="nav-item" role="presentation">
-            <span class="vr" aria-hidden="true"></span>
+          <li class="nav-item" aria-hidden="true">
+            <span class="vr"></span>
           </li>
           <li class="nav-item dropdown btn-group">
             <a class="nav-link" href="{{< ref "navbar-az" >}}">Longer Navbar</a>


### PR DESCRIPTION
See #2028.

### How to test
[Review site](https://review.digital.arizona.edu/arizona-bootstrap/bug/2028/)
1. Navigate to the [Navbar](https://review.digital.arizona.edu/arizona-bootstrap/bug/2028/docs/5.1/components/navbar/) Docs page and then to the [AZ Navbar](https://review.digital.arizona.edu/arizona-bootstrap/bug/2028/docs/5.1/components/navbar/#az-navbar) section.
2. Confirm that offending instances of:
    ```
    <li class="nav-item" role="presentation">
       <span class="vr" aria-hidden="true"></span>
    </li>
    ```
    have been replaced with:
    ```
    <li class="nav-item" aria-hidden="true">
      <span class="vr"></span>
    </li>
    ```
    in the code snippet and rendered markup.
3. Navigate to the [AZ Navbar](https://review.digital.arizona.edu/arizona-bootstrap/bug/2028/docs/5.1/examples/navbar-az/) Examples page.
4. Confirm that no accessibility issues remain within the AZ Navbar example markup.

A follow up AZQS issue is needed to change [this line](https://github.com/az-digital/az_quickstart/blob/bdcd364e88323158aa196f1641d58038b55c11cb/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig#L86) accordingly in the AZ Navbar template file.