### PR TITLE
Fixes #2047, #1782: Documentation bug related to Javascript tool initialiazion

### DIFF
--- a/site/content/docs/5.1/components/alerts.md
+++ b/site/content/docs/5.1/components/alerts.md
@@ -178,7 +178,7 @@ Initialize elements as alerts
 
 ```js
 const alertList = document.querySelectorAll('.alert')
-const alerts = [...alertList].map(element => new bootstrap.Alert(element))
+const alerts = [...alertList].map(element => new arizonaBootstrap.Alert(element))
 ```
 
 {{< callout info >}}
@@ -198,7 +198,7 @@ See the [triggers](#triggers) section for more details.
 You can create an alert instance with the alert constructor, for example:
 
 ```js
-const bsAlert = new bootstrap.Alert('#myAlert')
+const bsAlert = new arizonaBootstrap.Alert('#myAlert')
 ```
 
 This makes an alert listen for click events on descendant elements which have the `data-bs-dismiss="alert"` attribute. (Not necessary when using the data-api’s auto-initialization.)
@@ -208,14 +208,14 @@ This makes an alert listen for click events on descendant elements which have th
 | --- | --- |
 | `close` | Closes an alert by removing it from the DOM. If the `.fade` and `.show` classes are present on the element, the alert will fade out before it is removed. |
 | `dispose` | Destroys an element's alert. (Removes stored data on the DOM element) |
-| `getInstance` | Static method which allows you to get the alert instance associated to a DOM element. For example: `bootstrap.Alert.getInstance(alert)`. |
-| `getOrCreateInstance` | Static method which returns an alert instance associated to a DOM element or create a new one in case it wasn't initialized. You can use it like this: `bootstrap.Alert.getOrCreateInstance(element)`. |
+| `getInstance` | Static method which allows you to get the alert instance associated to a DOM element. For example: `arizonaBootstrap.Alert.getInstance(alert)`. |
+| `getOrCreateInstance` | Static method which returns an alert instance associated to a DOM element or create a new one in case it wasn't initialized. You can use it like this: `arizonaBootstrap.Alert.getOrCreateInstance(element)`. |
 {{< /bs-table >}}
 
 Basic usage:
 
 ```js
-const alert = bootstrap.Alert.getOrCreateInstance('#myAlert')
+const alert = arizonaBootstrap.Alert.getOrCreateInstance('#myAlert')
 alert.close()
 ```
 

--- a/site/content/docs/5.1/components/buttons.md
+++ b/site/content/docs/5.1/components/buttons.md
@@ -254,15 +254,15 @@ Add `data-bs-toggle="button"` to toggle a button's `active` state. If you're pre
 You can create a button instance with the button constructor, for example:
 
 ```js
-const bsButton = new bootstrap.Button('#myButton')
+const bsButton = new arizonaBootstrap.Button('#myButton')
 ```
 
 {{< bs-table "table" >}}
 | Method | Description |
 | --- | --- |
 | `dispose` | Destroys an element's button. (Removes stored data on the DOM element) |
-| `getInstance` | Static method which allows you to get the button instance associated with a DOM element, you can use it like this: `bootstrap.Button.getInstance(element)`. |
-| `getOrCreateInstance` | Static method which returns a button instance associated with a DOM element or creates a new one in case it wasn't initialized. You can use it like this: `bootstrap.Button.getOrCreateInstance(element)`. |
+| `getInstance` | Static method which allows you to get the button instance associated with a DOM element, you can use it like this: `arizonaBootstrap.Button.getInstance(element)`. |
+| `getOrCreateInstance` | Static method which returns a button instance associated with a DOM element or creates a new one in case it wasn't initialized. You can use it like this: `arizonaBootstrap.Button.getOrCreateInstance(element)`. |
 | `toggle` | Toggles push state. Gives the button the appearance that it has been activated. |
 {{< /bs-table >}}
 
@@ -270,7 +270,7 @@ For example, to toggle all buttons
 
 ```js
 document.querySelectorAll('.btn').forEach(buttonElement => {
-  const button = bootstrap.Button.getOrCreateInstance(buttonElement)
+  const button = arizonaBootstrap.Button.getOrCreateInstance(buttonElement)
   button.toggle()
 })
 ```

--- a/site/content/docs/5.1/components/carousel.md
+++ b/site/content/docs/5.1/components/carousel.md
@@ -321,7 +321,7 @@ Use data attributes to easily control the position of the carousel. `data-bs-sli
 Call carousel manually with:
 
 ```js
-const carousel = new bootstrap.Carousel('#myCarousel')
+const carousel = new arizonaBootstrap.Carousel('#myCarousel')
 ```
 
 ### Options
@@ -352,7 +352,7 @@ You can create a carousel instance with the carousel constructor, and pass on an
 ```js
 const myCarouselElement = document.querySelector('#myCarousel')
 
-const carousel = new bootstrap.Carousel(myCarouselElement, {
+const carousel = new arizonaBootstrap.Carousel(myCarouselElement, {
   interval: 2000,
   touch: false
 })
@@ -363,8 +363,8 @@ const carousel = new bootstrap.Carousel(myCarouselElement, {
 | --- | --- |
 | `cycle` | Starts cycling through the carousel items from left to right. |
 | `dispose` | Destroys an element's carousel. (Removes stored data on the DOM element) |
-| `getInstance` | Static method which allows you to get the carousel instance associated to a DOM element. You can use it like this: `bootstrap.Carousel.getInstance(element)`. |
-| `getOrCreateInstance` | Static method which returns a carousel instance associated to a DOM element, or creates a new one in case it wasn't initialized. You can use it like this: `bootstrap.Carousel.getOrCreateInstance(element)`. |
+| `getInstance` | Static method which allows you to get the carousel instance associated to a DOM element. You can use it like this: `arizonaBootstrap.Carousel.getInstance(element)`. |
+| `getOrCreateInstance` | Static method which returns a carousel instance associated to a DOM element, or creates a new one in case it wasn't initialized. You can use it like this: `arizonaBootstrap.Carousel.getOrCreateInstance(element)`. |
 | `next` | Cycles to the next item. **Returns to the caller before the next item has been shown** (e.g., before the `slid.bs.carousel` event occurs). |
 | `nextWhenVisible` | Don't cycle carousel to next when the page, the carousel, or the carousel's parent aren't visible. **Returns to the caller before the target item has been shown**. |
 | `pause` | Stops the carousel from cycling through items. |

--- a/site/content/docs/5.1/components/collapse.md
+++ b/site/content/docs/5.1/components/collapse.md
@@ -134,7 +134,7 @@ Enable manually with:
 
 ```js
 const collapseElementList = document.querySelectorAll('.collapse')
-const collapseList = [...collapseElementList].map(collapseEl => new bootstrap.Collapse(collapseEl))
+const collapseList = [...collapseElementList].map(collapseEl => new arizonaBootstrap.Collapse(collapseEl))
 ```
 
 ### Options
@@ -177,7 +177,7 @@ Activates your content as a collapsible element. Accepts an optional options `ob
 You can create a collapse instance with the constructor, for example:
 
 ```js
-const bsCollapse = new bootstrap.Collapse('#myCollapse', {
+const bsCollapse = new arizonaBootstrap.Collapse('#myCollapse', {
   toggle: false
 })
 ```
@@ -186,8 +186,8 @@ const bsCollapse = new bootstrap.Collapse('#myCollapse', {
 | Method | Description |
 | --- | --- |
 | `dispose` | Destroys an element's collapse. (Removes stored data on the DOM element) |
-| `getInstance` | Static method which allows you to get the collapse instance associated to a DOM element, you can use it like this: `bootstrap.Collapse.getInstance(element)`. |
-| `getOrCreateInstance` | Static method which returns a collapse instance associated to a DOM element or create a new one in case it wasn't initialized. You can use it like this: `bootstrap.Collapse.getOrCreateInstance(element)`. |
+| `getInstance` | Static method which allows you to get the collapse instance associated to a DOM element, you can use it like this: `arizonaBootstrap.Collapse.getInstance(element)`. |
+| `getOrCreateInstance` | Static method which returns a collapse instance associated to a DOM element or create a new one in case it wasn't initialized. You can use it like this: `arizonaBootstrap.Collapse.getOrCreateInstance(element)`. |
 | `hide` | Hides a collapsible element. **Returns to the caller before the collapsible element has actually been hidden** (e.g., before the `hidden.bs.collapse` event occurs). |
 | `show` | Shows a collapsible element. **Returns to the caller before the collapsible element has actually been shown** (e.g., before the `shown.bs.collapse` event occurs). |
 | `toggle` | Toggles a collapsible element to shown or hidden. **Returns to the caller before the collapsible element has actually been shown or hidden** (i.e. before the `shown.bs.collapse` or `hidden.bs.collapse` event occurs). |

--- a/site/content/docs/5.1/components/dropdowns.md
+++ b/site/content/docs/5.1/components/dropdowns.md
@@ -10,7 +10,7 @@ toc: true
 
 Dropdowns are toggleable, contextual overlays for displaying lists of links and more. They're made interactive with the included Bootstrap dropdown JavaScript plugin. They're toggled by clicking, not by hovering; this is [an intentional design decision](https://markdotto.com/blog/bootstrap-explained-dropdowns/).
 
-Dropdowns are built on a third party library, [Popper](https://popper.js.org/docs/v2/), which provides dynamic positioning and viewport detection. Be sure to include [popper.min.js]({{< param "cdn.popper" >}}) before Bootstrap's JavaScript or use `bootstrap.bundle.min.js` / `bootstrap.bundle.js` which contains Popper. Popper isn't used to position dropdowns in navbars though as dynamic positioning isn't required.
+Dropdowns are built on a third party library, [Popper](https://popper.js.org/docs/v2/), which provides dynamic positioning and viewport detection. Be sure to include [popper.min.js]({{< param "cdn.popper" >}}) before Arizona Bootstrap's JavaScript or use `arizona-bootstrap.bundle.min.js` / `arizona-bootstrap.bundle.js`, which contain Popper. Popper isn't used to position dropdowns in navbars though as dynamic positioning isn't required.
 
 ## Accessibility
 
@@ -922,7 +922,7 @@ Call the dropdowns via JavaScript:
 
 ```js
 const dropdownElementList = document.querySelectorAll('.dropdown-toggle')
-const dropdownList = [...dropdownElementList].map(dropdownToggleEl => new bootstrap.Dropdown(dropdownToggleEl))
+const dropdownList = [...dropdownElementList].map(dropdownToggleEl => new arizonaBootstrap.Dropdown(dropdownToggleEl))
 ```
 
 ### Options
@@ -945,7 +945,7 @@ const dropdownList = [...dropdownElementList].map(dropdownToggleEl => new bootst
 #### Using function with `popperConfig`
 
 ```js
-const dropdown = new bootstrap.Dropdown(element, {
+const dropdown = new arizonaBootstrap.Dropdown(element, {
   popperConfig(defaultBsPopperConfig) {
     // const newPopperConfig = {...}
     // use defaultBsPopperConfig if needed...
@@ -960,8 +960,8 @@ const dropdown = new bootstrap.Dropdown(element, {
 | Method | Description |
 | --- | --- |
 | `dispose` | Destroys an element's dropdown. (Removes stored data on the DOM element) |
-| `getInstance` | Static method which allows you to get the dropdown instance associated to a DOM element, you can use it like this: `bootstrap.Dropdown.getInstance(element)`. |
-| `getOrCreateInstance` | Static method which returns a dropdown instance associated to a DOM element or create a new one in case it wasn't initialized. You can use it like this: `bootstrap.Dropdown.getOrCreateInstance(element)`. |
+| `getInstance` | Static method which allows you to get the dropdown instance associated to a DOM element, you can use it like this: `arizonaBootstrap.Dropdown.getInstance(element)`. |
+| `getOrCreateInstance` | Static method which returns a dropdown instance associated to a DOM element or create a new one in case it wasn't initialized. You can use it like this: `arizonaBootstrap.Dropdown.getOrCreateInstance(element)`. |
 | `hide` | Hides the dropdown menu of a given navbar or tabbed navigation. |
 | `show` | Shows the dropdown menu of a given navbar or tabbed navigation. |
 | `toggle` | Toggles the dropdown menu of a given navbar or tabbed navigation. |

--- a/site/content/docs/5.1/components/list-group.md
+++ b/site/content/docs/5.1/components/list-group.md
@@ -331,7 +331,7 @@ Loop that generates the modifier classes with an overriding of CSS variables.
 
 ## JavaScript behavior
 
-Use the tab JavaScript plugin—include it individually or through the compiled `bootstrap.js` file—to extend our list group to create tabbable panes of local content.
+Use the tab JavaScript plugin—include it individually or through the compiled `arizona-bootstrap.js` file—to extend our list group to create tabbable panes of local content.
 
 <div class="bd-example" role="tabpanel">
   <div class="row">
@@ -414,7 +414,7 @@ Enable tabbable list item via JavaScript (each list item needs to be activated i
 ```js
 const triggerTabList = document.querySelectorAll('#myTab a')
 triggerTabList.forEach(triggerEl => {
-  const tabTrigger = new bootstrap.Tab(triggerEl)
+  const tabTrigger = new arizonaBootstrap.Tab(triggerEl)
 
   triggerEl.addEventListener('click', event => {
     event.preventDefault()
@@ -427,10 +427,10 @@ You can activate individual list item in several ways:
 
 ```js
 const triggerEl = document.querySelector('#myTab a[href="#profile"]')
-bootstrap.Tab.getInstance(triggerEl).show() // Select tab by name
+arizonaBootstrap.Tab.getInstance(triggerEl).show() // Select tab by name
 
 const triggerFirstTabEl = document.querySelector('#myTab li:first-child a')
-bootstrap.Tab.getInstance(triggerFirstTabEl).show() // Select first tab
+arizonaBootstrap.Tab.getInstance(triggerFirstTabEl).show() // Select first tab
 ```
 
 ### Fade effect
@@ -457,15 +457,15 @@ Activates your content as a tab element.
 You can create a tab instance with the constructor, for example:
 
 ```js
-const bsTab = new bootstrap.Tab('#myTab')
+const bsTab = new arizonaBootstrap.Tab('#myTab')
 ```
 
 {{< bs-table >}}
 | Method | Description |
 | --- | --- |
 | `dispose` | Destroys an element's tab. |
-| `getInstance` | Static method which allows you to get the tab instance associated with a DOM element, you can use it like this: `bootstrap.Tab.getInstance(element)`. |
-| `getOrCreateInstance` | Static method which returns a tab instance associated to a DOM element or create a new one in case it wasn't initialized. You can use it like this: `bootstrap.Tab.getOrCreateInstance(element)`. |
+| `getInstance` | Static method which allows you to get the tab instance associated with a DOM element, you can use it like this: `arizonaBootstrap.Tab.getInstance(element)`. |
+| `getOrCreateInstance` | Static method which returns a tab instance associated to a DOM element or create a new one in case it wasn't initialized. You can use it like this: `arizonaBootstrap.Tab.getOrCreateInstance(element)`. |
 | `show` | Selects the given tab and shows its associated pane. Any other tab that was previously selected becomes unselected and its associated pane is hidden. **Returns to the caller before the tab pane has actually been shown** (i.e. before the `shown.bs.tab` event occurs). |
 {{< /bs-table >}}
 

--- a/site/content/docs/5.1/components/modal.md
+++ b/site/content/docs/5.1/components/modal.md
@@ -802,9 +802,9 @@ While both ways to dismiss a modal are supported, keep in mind that dismissing f
 Create a modal with a single line of JavaScript:
 
 ```js
-const myModal = new bootstrap.Modal(document.getElementById('myModal'), options)
+const myModal = new arizonaBootstrap.Modal(document.getElementById('myModal'), options)
 // or
-const myModalAlternative = new bootstrap.Modal('#myModal', options)
+const myModalAlternative = new arizonaBootstrap.Modal('#myModal', options)
 ```
 
 ### Options
@@ -832,7 +832,7 @@ const myModalAlternative = new bootstrap.Modal('#myModal', options)
 Activates your content as a modal. Accepts an optional options `object`.
 
 ```js
-const myModal = new bootstrap.Modal('#myModal', {
+const myModal = new arizonaBootstrap.Modal('#myModal', {
   keyboard: false
 })
 ```

--- a/site/content/docs/5.1/components/navs-tabs.md
+++ b/site/content/docs/5.1/components/navs-tabs.md
@@ -422,7 +422,7 @@ On the `.nav-underline` modifier class:
 
 ## JavaScript behavior
 
-Use the tab JavaScript plugin—include it individually or through the compiled `bootstrap.js` file—to extend our navigational tabs and pills to create tabbable panes of local content.
+Use the tab JavaScript plugin—include it individually or through the compiled `arizona-bootstrap.js` file—to extend our navigational tabs and pills to create tabbable panes of local content.
 
 <div class="bd-example">
   <ul class="nav nav-tabs mb-3" id="myTab" role="tablist">
@@ -679,7 +679,7 @@ Enable tabbable tabs via JavaScript (each tab needs to be activated individually
 ```js
 const triggerTabList = document.querySelectorAll('#myTab button')
 triggerTabList.forEach(triggerEl => {
-  const tabTrigger = new bootstrap.Tab(triggerEl)
+  const tabTrigger = new arizonaBootstrap.Tab(triggerEl)
 
   triggerEl.addEventListener('click', event => {
     event.preventDefault()
@@ -692,10 +692,10 @@ You can activate individual tabs in several ways:
 
 ```js
 const triggerEl = document.querySelector('#myTab button[data-bs-target="#profile"]')
-bootstrap.Tab.getInstance(triggerEl).show() // Select tab by name
+arizonaBootstrap.Tab.getInstance(triggerEl).show() // Select tab by name
 
 const triggerFirstTabEl = document.querySelector('#myTab li:first-child button')
-bootstrap.Tab.getInstance(triggerFirstTabEl).show() // Select first tab
+arizonaBootstrap.Tab.getInstance(triggerFirstTabEl).show() // Select first tab
 ```
 
 ### Fade effect
@@ -722,15 +722,15 @@ Activates your content as a tab element.
 You can create a tab instance with the constructor, for example:
 
 ```js
-const bsTab = new bootstrap.Tab('#myTab')
+const bsTab = new arizonaBootstrap.Tab('#myTab')
 ```
 
 {{< bs-table >}}
 | Method | Description |
 | --- | --- |
 | `dispose` | Destroys an element's tab. |
-| `getInstance` | Static method which allows you to get the tab instance associated with a DOM element, you can use it like this: `bootstrap.Tab.getInstance(element)`. |
-| `getOrCreateInstance` | Static method which returns a tab instance associated to a DOM element or create a new one in case it wasn't initialized. You can use it like this: `bootstrap.Tab.getOrCreateInstance(element)`. |
+| `getInstance` | Static method which allows you to get the tab instance associated with a DOM element, you can use it like this: `arizonaBootstrap.Tab.getInstance(element)`. |
+| `getOrCreateInstance` | Static method which returns a tab instance associated to a DOM element or create a new one in case it wasn't initialized. You can use it like this: `arizonaBootstrap.Tab.getOrCreateInstance(element)`. |
 | `show` | Selects the given tab and shows its associated pane. Any other tab that was previously selected becomes unselected and its associated pane is hidden. **Returns to the caller before the tab pane has actually been shown** (i.e. before the `shown.bs.tab` event occurs). |
 {{< /bs-table >}}
 

--- a/site/content/docs/5.1/components/offcanvas.md
+++ b/site/content/docs/5.1/components/offcanvas.md
@@ -272,7 +272,7 @@ Enable manually with:
 
 ```js
 const offcanvasElementList = document.querySelectorAll('.offcanvas')
-const offcanvasList = [...offcanvasElementList].map(offcanvasEl => new bootstrap.Offcanvas(offcanvasEl))
+const offcanvasList = [...offcanvasElementList].map(offcanvasEl => new arizonaBootstrap.Offcanvas(offcanvasEl))
 ```
 
 ### Options
@@ -300,7 +300,7 @@ Activates your content as an offcanvas element. Accepts an optional options `obj
 You can create an offcanvas instance with the constructor, for example:
 
 ```js
-const bsOffcanvas = new bootstrap.Offcanvas('#myOffcanvas')
+const bsOffcanvas = new arizonaBootstrap.Offcanvas('#myOffcanvas')
 ```
 
 {{< bs-table "table" >}}

--- a/site/content/docs/5.1/components/popovers.md
+++ b/site/content/docs/5.1/components/popovers.md
@@ -10,7 +10,7 @@ toc: true
 
 Things to know when using the popover plugin:
 
-- Popovers rely on the third party library [Popper](https://popper.js.org/docs/v2/) for positioning. You must include [popper.min.js]({{< param "cdn.popper" >}}) before `bootstrap.js`, or use one `bootstrap.bundle.min.js` which contains Popper.
+- Popovers rely on the third party library [Popper](https://popper.js.org/docs/v2/) for positioning. You must include [popper.min.js]({{< param "cdn.popper" >}}) before `arizona-bootstrap.js`, or use `arizona-bootstrap.bundle.min.js`, which contains Popper.
 - Popovers require the [popover plugin]({{< docsref "/components/popovers" >}}) as a dependency.
 - Popovers are opt-in for performance reasons, so **you must initialize them yourself**.
 - Zero-length `title` and `content` values will never show a popover.
@@ -39,7 +39,7 @@ As mentioned above, you must initialize popovers before they can be used. One wa
 
 ```js
 const popoverTriggerList = document.querySelectorAll('[data-bs-toggle="popover"]')
-const popoverList = [...popoverTriggerList].map(popoverTriggerEl => new bootstrap.Popover(popoverTriggerEl))
+const popoverList = [...popoverTriggerList].map(popoverTriggerEl => new arizonaBootstrap.Popover(popoverTriggerEl))
 ```
 
 ### Live demo
@@ -78,7 +78,7 @@ Four options are available: top, right, bottom, and left. Directions are mirrore
 When you have some styles on a parent element that interfere with a popover, you'll want to specify a custom `container` so that the popover's HTML appears within that element instead. This is common in responsive tables, input groups, and the like.
 
 ```js
-const popover = new bootstrap.Popover('.example-popover', {
+const popover = new arizonaBootstrap.Popover('.example-popover', {
   container: 'body'
 })
 ```
@@ -86,7 +86,7 @@ const popover = new bootstrap.Popover('.example-popover', {
 Another situation where you'll want to set an explicit custom `container` are popovers inside a [modal dialog]({{< docsref "/components/modal" >}}), to make sure that the popover itself is appended to the modal. This is particularly important for popovers that contain interactive elements – modal dialogs will trap focus, so unless the popover is a child element of the modal, users won't be able to focus or activate these interactive elements.
 
 ```js
-const popover = new bootstrap.Popover('.example-popover', {
+const popover = new arizonaBootstrap.Popover('.example-popover', {
   container: '.modal-body'
 })
 ```
@@ -122,7 +122,7 @@ Use the `focus` trigger to dismiss popovers on the user's next click of an eleme
 {{< /example >}}
 
 ```js
-const popover = new bootstrap.Popover('.popover-dismiss', {
+const popover = new arizonaBootstrap.Popover('.popover-dismiss', {
   trigger: 'focus'
 })
 ```
@@ -159,7 +159,7 @@ Enable popovers via JavaScript:
 
 ```js
 const exampleEl = document.getElementById('example')
-const popover = new bootstrap.Popover(exampleEl, options)
+const popover = new arizonaBootstrap.Popover(exampleEl, options)
 ```
 
 {{< callout warning >}}
@@ -212,7 +212,7 @@ Options for individual popovers can alternatively be specified through the use o
 #### Using function with `popperConfig`
 
 ```js
-const popover = new bootstrap.Popover(element, {
+const popover = new arizonaBootstrap.Popover(element, {
   popperConfig(defaultBsPopperConfig) {
     // const newPopperConfig = {...}
     // use defaultBsPopperConfig if needed...
@@ -246,7 +246,7 @@ const popover = new bootstrap.Popover(element, {
 
 ```js
 // getOrCreateInstance example
-const popover = bootstrap.Popover.getOrCreateInstance('#example') // Returns a Bootstrap popover instance
+const popover = arizonaBootstrap.Popover.getOrCreateInstance('#example') // Returns an Arizona Bootstrap popover instance
 
 // setContent example
 popover.setContent({

--- a/site/content/docs/5.1/components/scrollspy.md
+++ b/site/content/docs/5.1/components/scrollspy.md
@@ -337,7 +337,7 @@ document.querySelectorAll('#nav-tab>[data-bs-toggle="tab"]').forEach(el => {
   el.addEventListener('shown.bs.tab', () => {
     const target = el.getAttribute('data-bs-target')
     const scrollElem = document.querySelector(`${target} [data-bs-spy="scroll"]`)
-    bootstrap.ScrollSpy.getOrCreateInstance(scrollElem).refresh()
+    arizonaBootstrap.ScrollSpy.getOrCreateInstance(scrollElem).refresh()
   })
 })
 ```
@@ -363,7 +363,7 @@ To easily add scrollspy behavior to your topbar navigation, add `data-bs-spy="sc
 ### Via JavaScript
 
 ```js
-const scrollSpy = new bootstrap.ScrollSpy(document.body, {
+const scrollSpy = new arizonaBootstrap.ScrollSpy(document.body, {
   target: '#navbar-example'
 })
 ```
@@ -407,7 +407,7 @@ Here's an example using the refresh method:
 ```js
 const dataSpyList = document.querySelectorAll('[data-bs-spy="scroll"]')
 dataSpyList.forEach(dataSpyEl => {
-  bootstrap.ScrollSpy.getInstance(dataSpyEl).refresh()
+  arizonaBootstrap.ScrollSpy.getInstance(dataSpyEl).refresh()
 })
 ```
 

--- a/site/content/docs/5.1/components/toasts.md
+++ b/site/content/docs/5.1/components/toasts.md
@@ -334,7 +334,7 @@ Initialize toasts via JavaScript:
 
 ```js
 const toastElList = document.querySelectorAll('.toast')
-const toastList = [...toastElList].map(toastEl => new bootstrap.Toast(toastEl, option))
+const toastList = [...toastElList].map(toastEl => new arizonaBootstrap.Toast(toastEl, option))
 ```
 
 ### Triggers
@@ -365,8 +365,8 @@ const toastList = [...toastElList].map(toastEl => new bootstrap.Toast(toastEl, o
 | Method | Description |
 | --- | --- |
 | `dispose` | Hides an element's toast. Your toast will remain on the DOM but won't show anymore. |
-| `getInstance` | *Static* method which allows you to get the toast instance associated with a DOM element. <br> For example: `const myToastEl = document.getElementById('myToastEl')` `const myToast = bootstrap.Toast.getInstance(myToastEl)` Returns a Bootstrap toast instance. |
-| `getOrCreateInstance` | *Static* method which allows you to get the toast instance associated with a DOM element, or create a new one, in case it wasn't initialized. <br>`const myToastEl = document.getElementById('myToastEl')` `const myToast = bootstrap.Toast.getOrCreateInstance(myToastEl)` Returns a Bootstrap toast instance. |
+| `getInstance` | *Static* method which allows you to get the toast instance associated with a DOM element. <br> For example: `const myToastEl = document.getElementById('myToastEl')` `const myToast = arizonaBootstrap.Toast.getInstance(myToastEl)` Returns an Arizona Bootstrap toast instance. |
+| `getOrCreateInstance` | *Static* method which allows you to get the toast instance associated with a DOM element, or create a new one, in case it wasn't initialized. <br>`const myToastEl = document.getElementById('myToastEl')` `const myToast = arizonaBootstrap.Toast.getOrCreateInstance(myToastEl)` Returns an Arizona Bootstrap toast instance. |
 | `hide` | Hides an element's toast. **Returns to the caller before the toast has actually been hidden** (i.e. before the `hidden.bs.toast` event occurs). You have to manually call this method if you made `autohide` to `false`. |
 | `isShown` | Returns a boolean according to toast's visibility state. |
 | `show` | Reveals an element's toast. **Returns to the caller before the toast has actually been shown** (i.e. before the `shown.bs.toast` event occurs). You have to manually call this method, instead your toast won't show. |

--- a/site/content/docs/5.1/components/tooltips.md
+++ b/site/content/docs/5.1/components/tooltips.md
@@ -10,7 +10,7 @@ toc: true
 
 Things to know when using the tooltip plugin:
 
-- Tooltips rely on the third party library [Popper](https://popper.js.org/docs/v2/) for positioning. You must include [popper.min.js]({{< param "cdn.popper" >}}) before `bootstrap.js`, or use one `bootstrap.bundle.min.js` which contains Popper.
+- Tooltips rely on the third party library [Popper](https://popper.js.org/docs/v2/) for positioning. You must include [popper.min.js]({{< param "cdn.popper" >}}) before `arizona-bootstrap.js`, or use `arizona-bootstrap.bundle.min.js`, which contains Popper.
 - Tooltips are opt-in for performance reasons, so **you must initialize them yourself**.
 - Tooltips with zero-length titles are never displayed.
 - Specify `container: 'body'` to avoid rendering problems in more complex components (like our input groups, button groups, etc).
@@ -38,7 +38,7 @@ As mentioned above, you must initialize tooltips before they can be used. One wa
 
 ```js
 const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
-const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new arizonaBootstrap.Tooltip(tooltipTriggerEl))
 ```
 
 ### Tooltips on links
@@ -139,14 +139,14 @@ The tooltip plugin generates content and markup on demand, and by default places
 
 ```js
 const exampleEl = document.getElementById('example')
-const tooltip = new bootstrap.Tooltip(exampleEl, options)
+const tooltip = new arizonaBootstrap.Tooltip(exampleEl, options)
 ```
 
 {{< callout warning >}}
 Tooltips automatically attempt to change positions when a parent container has `overflow: auto` or `overflow: scroll`, but still keeps the original placement's positioning. Set the [`boundary` option](https://popper.js.org/docs/v2/modifiers/flip/#boundary) (for the flip modifier using the `popperConfig` option) to any HTMLElement to override the default value, `'clippingParents'`, such as `document.body`:
 
 ```js
-const tooltip = new bootstrap.Tooltip('#example', {
+const tooltip = new arizonaBootstrap.Tooltip('#example', {
   boundary: document.body // or document.querySelector('#boundary')
 })
 ```
@@ -225,7 +225,7 @@ Options for individual tooltips can alternatively be specified through the use o
 #### Using function with `popperConfig`
 
 ```js
-const tooltip = new bootstrap.Tooltip(element, {
+const tooltip = new arizonaBootstrap.Tooltip(element, {
   popperConfig(defaultBsPopperConfig) {
     // const newPopperConfig = {...}
     // use defaultBsPopperConfig if needed...
@@ -257,7 +257,7 @@ const tooltip = new bootstrap.Tooltip(element, {
 {{< /bs-table >}}
 
 ```js
-const tooltip = bootstrap.Tooltip.getInstance('#example') // Returns a Bootstrap tooltip instance
+const tooltip = arizonaBootstrap.Tooltip.getInstance('#example') // Returns an Arizona Bootstrap tooltip instance
 
 // setContent example
 tooltip.setContent({ '.tooltip-inner': 'another title' })
@@ -282,7 +282,7 @@ The `setContent` method accepts an `object` argument, where each property-key is
 
 ```js
 const myTooltipEl = document.getElementById('myTooltip')
-const tooltip = bootstrap.Tooltip.getOrCreateInstance(myTooltipEl)
+const tooltip = arizonaBootstrap.Tooltip.getOrCreateInstance(myTooltipEl)
 
 myTooltipEl.addEventListener('hidden.bs.tooltip', () => {
   // do something...

--- a/site/content/docs/5.1/examples/cheatsheet/cheatsheet.js
+++ b/site/content/docs/5.1/examples/cheatsheet/cheatsheet.js
@@ -1,4 +1,4 @@
-/* global bootstrap: false */
+/* global arizonaBootstrap: false */
 
 (() => {
   'use strict'
@@ -6,19 +6,19 @@
   // Tooltip and popover demos
   document.querySelectorAll('.tooltip-demo')
     .forEach(tooltip => {
-      new bootstrap.Tooltip(tooltip, {
+      new arizonaBootstrap.Tooltip(tooltip, {
         selector: '[data-bs-toggle="tooltip"]'
       })
     })
 
   document.querySelectorAll('[data-bs-toggle="popover"]')
     .forEach(popover => {
-      new bootstrap.Popover(popover)
+      new arizonaBootstrap.Popover(popover)
     })
 
   document.querySelectorAll('.toast')
     .forEach(toastNode => {
-      const toast = new bootstrap.Toast(toastNode, {
+      const toast = new arizonaBootstrap.Toast(toastNode, {
         autohide: false
       })
 

--- a/site/content/docs/5.1/examples/sidebars/sidebars.js
+++ b/site/content/docs/5.1/examples/sidebars/sidebars.js
@@ -1,8 +1,8 @@
-/* global bootstrap: false */
+/* global arizonaBootstrap: false */
 (() => {
   'use strict'
   const tooltipTriggerList = Array.from(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
   tooltipTriggerList.forEach(tooltipTriggerEl => {
-    new bootstrap.Tooltip(tooltipTriggerEl)
+    new arizonaBootstrap.Tooltip(tooltipTriggerEl)
   })
 })()

--- a/site/content/docs/5.1/getting-started/javascript.md
+++ b/site/content/docs/5.1/getting-started/javascript.md
@@ -18,7 +18,7 @@ While the Arizona Bootstrap CSS can be used with any framework, **the Arizona Bo
 
 ## Using Arizona Bootstrap as a module
 
-We provide a version of Arizona Bootstrap built as `ESM` (`bootstrap.esm.js` and `bootstrap.esm.min.js`) which allows you to use Arizona Bootstrap as a module in the browser, if your [targeted browsers support it](https://caniuse.com/es6-module).
+We provide a version of Arizona Bootstrap built as `ESM` (`arizona-bootstrap.esm.js` and `arizona-bootstrap.esm.min.js`) which allows you to use Arizona Bootstrap as a module in the browser, if your [targeted browsers support it](https://caniuse.com/es6-module).
 
 <!-- eslint-skip -->
 ```html

--- a/site/content/docs/5.1/migration.md
+++ b/site/content/docs/5.1/migration.md
@@ -727,8 +727,8 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 - **All plugins can now accept a CSS selector as the first argument.** You can either pass a DOM element or any valid CSS selector to create a new instance of the plugin:
 
   ```js
-  const modal = new bootstrap.Modal('#myModal')
-  const dropdown = new bootstrap.Dropdown('[data-bs-toggle="dropdown"]')
+  const modal = new arizonaBootstrap.Modal('#myModal')
+  const dropdown = new arizonaBootstrap.Dropdown('[data-bs-toggle="dropdown"]')
   ```
 
 - `popperConfig` can be passed as a function that accepts the Bootstrap's default Popper config as an argument, so that you can merge this default configuration in your way. **Applies to dropdowns, popovers, and tooltips.**


### PR DESCRIPTION
See #2047 and #1782.

### How to test
[Review site](https://review.digital.arizona.edu/arizona-bootstrap/bug/2047)

1. Confirm that the namespace `bootstrap` has been replaced with `arizonaBootstrap` in JS docs areas. Since these are only docs changes, there should be no visual changes to consumer apps.