### PR TITLE
Closes #2011: Add font utility classes for 2026 university brand updates

### DIFF
--- a/scss/arizona-bootstrap.scss
+++ b/scss/arizona-bootstrap.scss
@@ -84,6 +84,7 @@
 @import "custom/card";
 @import "custom/color-background";
 @import "custom/column-split";
+@import "custom/font";
 @import "custom/list-group";
 @import "override/nav";
 @import "custom/nav";

--- a/scss/custom/_font.scss
+++ b/scss/custom/_font.scss
@@ -7,7 +7,7 @@
 }
 
 .proxima-nova-condensed {
-  font-family: proxima-nova-condensed, #{$font-family-sans-serif}
+  font-family: proxima-nova-condensed, #{$font-family-sans-serif};
 }
 
 .garamond-premier-pro {

--- a/scss/custom/_font.scss
+++ b/scss/custom/_font.scss
@@ -11,5 +11,5 @@
 }
 
 .garamond-premier-pro {
-  font-family: garamond-premier-pro, #{$font-family-sans-serif};
+  font-family: garamond-premier-pro, serif;
 }

--- a/scss/custom/_font.scss
+++ b/scss/custom/_font.scss
@@ -1,0 +1,15 @@
+//
+// > Custom font styles
+//
+
+.proxima-nova {
+  font-family: $font-family-sans-serif;
+}
+
+.proxima-nova-condensed {
+  font-family: proxima-nova-condensed, #{$font-family-sans-serif}
+}
+
+.garamond-premier-pro {
+  font-family: garamond-premier-pro, #{$font-family-sans-serif};
+}

--- a/site/assets/scss/_custom-docs.scss
+++ b/site/assets/scss/_custom-docs.scss
@@ -290,142 +290,58 @@
   font-family: proxima-nova, sans-serif;
   font-style: normal;
   font-weight: 700;
-  word-wrap: break-word;
-
-  span:first-child {
-    text-transform: uppercase;
-  }
-}
-
-.proxima-nova-bold-italic {
-  font-family: proxima-nova, sans-serif;
-  font-style: italic;
-  font-weight: 700;
-  word-wrap: break-word;
-
-  span:first-child {
-    text-transform: uppercase;
-  }
-}
-
-.proxima-nova {
-  font-family: proxima-nova, sans-serif;
-  font-style: normal;
-  font-weight: 400;
-  word-wrap: break-word;
-
-  span:first-child {
-    text-transform: uppercase;
-  }
 }
 
 .proxima-nova-italic {
   font-family: proxima-nova, sans-serif;
   font-style: italic;
   font-weight: 400;
-  word-wrap: break-word;
-
-  span:first-child {
-    text-transform: uppercase;
-  }
 }
 
-.proxima-nova-ec-bold {
+.proxima-nova-bold-italic {
+  font-family: proxima-nova, sans-serif;
+  font-style: italic;
+  font-weight: 700;
+}
+
+.proxima-nova-condensed-bold {
+  font-family: proxima-nova-condensed, sans-serif;
+  font-style: normal;
+  font-weight: 700;
+}
+
+.proxima-nova-condensed-italic {
+  font-family: proxima-nova-condensed, sans-serif;
+  font-style: italic;
+  font-weight: 400;
+}
+
+.proxima-nova-condensed-bold-italic {
+  font-family: proxima-nova-condensed, sans-serif;
+  font-style: italic;
+  font-weight: 700;
+}
+
+.proxima-nova-extra-condensed {
+  font-family: proxima-nova-extra-condensed, sans-serif;
+  font-style: normal;
+  font-weight: 400;
+}
+
+.proxima-nova-extra-condensed-bold {
   font-family: proxima-nova-extra-condensed, sans-serif;
   font-style: normal;
   font-weight: 700;
-  word-wrap: break-word;
-
-  span:first-child {
-    text-transform: uppercase;
-  }
 }
 
-.proxima-nova-ec-bold-italic {
-  font-family: proxima-nova-extra-condensed, sans-serif;
-  font-style: italic;
-  font-weight: 700;
-  word-wrap: break-word;
-
-  span:first-child {
-    text-transform: uppercase;
-  }
-}
-
-.proxima-nova-ec-italic {
+.proxima-nova-extra-condensed-italic {
   font-family: proxima-nova, sans-serif;
   font-style: italic;
   font-weight: 400;
-  word-wrap: break-word;
-
-  span:first-child {
-    text-transform: uppercase;
-  }
 }
 
-.proxima-nova-ec {
+.proxima-nova-extra-condensed-bold-italic {
   font-family: proxima-nova-extra-condensed, sans-serif;
-  font-style: normal;
-  font-weight: 400;
-  word-wrap: break-word;
-
-  span:first-child {
-    text-transform: uppercase;
-  }
-}
-
-.proxima-nova-c-bold {
-  font-family: proxima-nova-condensed, sans-serif;
-  font-style: normal;
-  font-weight: 700;
-  word-wrap: break-word;
-
-  span:first-child {
-    text-transform: uppercase;
-  }
-}
-
-.proxima-nova-c-bold-italic {
-  font-family: proxima-nova-condensed, sans-serif;
   font-style: italic;
-  font-weight: 700;
-  word-wrap: break-word;
-
-  span:first-child {
-    text-transform: uppercase;
-  }
-}
-
-.proxima-nova-c {
-  font-family: proxima-nova-condensed, sans-serif;
-  font-style: normal;
-  font-weight: 400;
-  word-wrap: break-word;
-
-  span:first-child {
-    text-transform: uppercase;
-  }
-}
-
-.proxima-nova-c-italic {
-  font-family: proxima-nova, sans-serif;
-  font-style: italic;
-  font-weight: 400;
-  word-wrap: break-word;
-
-  span:first-child {
-    text-transform: uppercase;
-  }
-}
-
-.pn {
-  font-family: proxima-nova-condensed, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-
-  em {
-    font-style: italic;
-  }
-}
-
-.pn strong {
   font-weight: 700;
 }

--- a/site/content/docs/5.1/content/font.md
+++ b/site/content/docs/5.1/content/font.md
@@ -117,9 +117,8 @@ globally throughout Bootstrap. To switch the global `font-family`, update
 ## Adding Specific CSS Classes
 <span class="badge bg-warning align-text-top">Important</span> The following instructions are for adding specific CSS classes for font weights or styles to your project. If using Arizona Bootstrap, you will most likely not need to do this unless you are trying to use a specific variant.
 
-<div>
-  <button class="js-specimen-modal-trigger btn btn-info float-end" data-font-class='proxima-nova-bold' data-font-name='Proxima Nova Bold' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
-</div>
+
+<button class="js-specimen-modal-trigger btn btn-info float-end mt-2" data-font-class='proxima-nova-bold' data-font-name='Proxima Nova Bold' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
 
 ### Proxima Nova Bold
 
@@ -134,38 +133,13 @@ font-style: normal;
 {{< example >}}
 <div class="proxima-nova-bold">
   <span class="text-uppercase">abcdefghijklmnopqrstuvwxyz</span>
-  <span>abcdefghijklmnopqrstuvwxyz</span> <br>
-  <span>0123456789</span> <br>
+  <span>abcdefghijklmnopqrstuvwxyz</span><br>
+  <span>0123456789</span><br>
   <span>!@#$%^&</span>
 </div>
 {{< /example >}}
 
-<div>
-  <button class="js-specimen-modal-trigger btn btn-info float-end" data-font-class='proxima-nova-bold-italic' data-font-name='Proxima Nova Bold Italic' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
-</div>
-
-### Proxima Nova Bold Italic
-
-```css
-.proxima-nova-bold-italic {
-font-family: proxima-nova, sans-serif;
-font-weight: 700;
-font-style: italic;
-}
-```
-
-{{< example >}}
-<div class="proxima-nova-bold-italic">
-  <span class="text-uppercase">abcdefghijklmnopqrstuvwxyz</span>
-  <span>abcdefghijklmnopqrstuvwxyz</span> <br>
-  <span>0123456789</span> <br>
-  <span>!@#$%^&</span>
-</div>
-{{< /example >}}
-
-<div>
-  <button class="js-specimen-modal-trigger btn btn-info float-end" data-font-class='proxima-nova-italic' data-font-name='Proxima Nova Italic' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
-</div>
+<button class="js-specimen-modal-trigger btn btn-info float-end mt-2" data-font-class='proxima-nova-italic' data-font-name='Proxima Nova Italic' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
 
 ### Proxima Nova Italic
 
@@ -180,112 +154,39 @@ font-style: italic;
 {{< example >}}
 <div class="proxima-nova-italic">
   <span class="text-uppercase">abcdefghijklmnopqrstuvwxyz</span>
-  <span>abcdefghijklmnopqrstuvwxyz</span> <br>
-  <span>0123456789</span> <br>
+  <span>abcdefghijklmnopqrstuvwxyz</span><br>
+  <span>0123456789</span><br>
   <span>!@#$%^&</span>
 </div>
 {{< /example >}}
 
-<div>
-  <button class="js-specimen-modal-trigger btn btn-info float-end" data-font-class='proxima-nova-ec-bold-italic' data-font-name='Proxima Nova Extra Condensed Bold Italic' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
-</div>
+<button class="js-specimen-modal-trigger btn btn-info float-end mt-2" data-font-class='proxima-nova-bold-italic' data-font-name='Proxima Nova Bold Italic' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
 
-### Proxima Nova Extra Condensed Bold Italic
+### Proxima Nova Bold Italic
 
 ```css
-.proxima-nova-ec-bold-italic {
-font-family: proxima-nova-extra-condensed, sans-serif;
-font-weight: 700;
-font-style: italic;
-}
-```
-
-{{< example >}}
-<div class="proxima-nova-ec-bold-italic">
-  <span class="text-uppercase">abcdefghijklmnopqrstuvwxyz</span>
-  <span>abcdefghijklmnopqrstuvwxyz</span> <br>
-  <span>0123456789</span> <br>
-  <span>!@#$%^&</span>
-</div>
-{{< /example >}}
-
-<div>
-  <button class="js-specimen-modal-trigger btn btn-info float-end" data-font-class='proxima-nova-ec-bold' data-font-name='Proxima Nova Extra Condensed Bold' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
-</div>
-
-### Proxima Nova Extra Condensed Bold
-
-```css
-.proxima-nova-ec-bold {
-font-family: proxima-nova-extra-condensed, sans-serif;
-font-weight: 700;
-font-style: normal;
-}
-```
-
-{{< example >}}
-<div class="proxima-nova-ec-bold">
-  <span class="text-uppercase">abcdefghijklmnopqrstuvwxyz</span>
-  <span>abcdefghijklmnopqrstuvwxyz</span> <br>
-  <span>0123456789</span> <br>
-  <span>!@#$%^&</span>
-</div>
-{{< /example >}}
-
-<div>
-  <button class="js-specimen-modal-trigger btn btn-info float-end" data-font-class='proxima-nova-ec-italic' data-font-name='Proxima Nova Extra Condensed Italic' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
-</div>
-
-### Proxima Nova Extra Condensed Italic
-
-```css
-.proxima-nova-ec-italic {
+.proxima-nova-bold-italic {
 font-family: proxima-nova, sans-serif;
-font-weight: 400;
+font-weight: 700;
 font-style: italic;
 }
 ```
 
 {{< example >}}
-<div class="proxima-nova-ec-italic">
+<div class="proxima-nova-bold-italic">
   <span class="text-uppercase">abcdefghijklmnopqrstuvwxyz</span>
-  <span>abcdefghijklmnopqrstuvwxyz</span> <br>
-  <span>0123456789</span> <br>
+  <span>abcdefghijklmnopqrstuvwxyz</span><br>
+  <span>0123456789</span><br>
   <span>!@#$%^&</span>
 </div>
 {{< /example >}}
 
-<div>
-  <button class="js-specimen-modal-trigger btn btn-info float-end" data-font-class='proxima-nova-ec' data-font-name='Proxima Nova Extra Condensed Regular' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
-</div>
-
-### Proxima Nova Extra Condensed Regular
-
-```css
-.proxima-nova-ec {
-font-family: proxima-nova-extra-condensed, sans-serif;
-font-weight: 400;
-font-style: normal;
-}
-```
-
-{{< example >}}
-<div class="proxima-nova-ec">
-  <span class="text-uppercase">abcdefghijklmnopqrstuvwxyz</span>
-  <span>abcdefghijklmnopqrstuvwxyz</span> <br>
-  <span>0123456789</span> <br>
-  <span>!@#$%^&</span>
-</div>
-{{< /example >}}
-
-<div>
-  <button class="js-specimen-modal-trigger btn btn-info float-end" data-font-class='proxima-nova-c-bold' data-font-name='Proxima Nova Condensed Bold' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
-</div>
+<button class="js-specimen-modal-trigger btn btn-info float-end mt-2" data-font-class='proxima-nova-condensed-bold' data-font-name='Proxima Nova Condensed Bold' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
 
 ### Proxima Nova Condensed Bold
 
 ```css
-.proxima-nova-c-bold {
+.proxima-nova-condensed-bold {
 font-family: proxima-nova-condensed, sans-serif;
 font-weight: 700;
 font-style: normal;
@@ -293,45 +194,20 @@ font-style: normal;
 ```
 
 {{< example >}}
-<div class="proxima-nova-c-bold">
+<div class="proxima-nova-condensed-bold">
   <span class="text-uppercase">abcdefghijklmnopqrstuvwxyz</span>
-  <span>abcdefghijklmnopqrstuvwxyz</span> <br>
-  <span>0123456789</span> <br>
+  <span>abcdefghijklmnopqrstuvwxyz</span><br>
+  <span>0123456789</span><br>
   <span>!@#$%^&</span>
 </div>
 {{< /example >}}
 
-<div>
-  <button class="js-specimen-modal-trigger btn btn-info float-end" data-font-class='proxima-nova-c-bold-italic' data-font-name='Proxima Nova Condensed Bold Italic' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
-</div>
-
-### Proxima Nova Condensed Bold Italic
-
-```css
-.proxima-nova-c-bold-italic {
-font-family: proxima-nova-condensed, sans-serif;
-font-weight: 700;
-font-style: italic;
-}
-```
-
-{{< example >}}
-<div class="proxima-nova-c-bold-italic">
-  <span class="text-uppercase">abcdefghijklmnopqrstuvwxyz</span>
-  <span>abcdefghijklmnopqrstuvwxyz</span> <br>
-  <span>0123456789</span> <br>
-  <span>!@#$%^&</span>
-</div>
-{{< /example >}}
-
-<div>
-  <button class="js-specimen-modal-trigger btn btn-info float-end" data-font-class='proxima-nova-c-italic' data-font-name='Proxima Nova Condensed Italic' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
-</div>
+<button class="js-specimen-modal-trigger btn btn-info float-end mt-2" data-font-class='proxima-nova-condensed-italic' data-font-name='Proxima Nova Condensed Italic' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
 
 ### Proxima Nova Condensed Italic
 
 ```css
-.proxima-nova-c-italic {
+.proxima-nova-condensed-italic {
   font-family: proxima-nova, sans-serif;
   font-weight: 400;
   font-style: italic;
@@ -339,15 +215,120 @@ font-style: italic;
 ```
 
 {{< example >}}
-<div class="proxima-nova-c-italic">
+<div class="proxima-nova-condensed-italic">
   <span class="text-uppercase">abcdefghijklmnopqrstuvwxyz</span>
-  <span>abcdefghijklmnopqrstuvwxyz</span> <br>
-  <span>0123456789</span> <br>
+  <span>abcdefghijklmnopqrstuvwxyz</span><br>
+  <span>0123456789</span><br>
   <span>!@#$%^&</span>
 </div>
 {{< /example >}}
 
-### Examples
+<button class="js-specimen-modal-trigger btn btn-info float-end mt-2" data-font-class='proxima-nova-condensed-bold-italic' data-font-name='Proxima Nova Condensed Bold Italic' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
+
+### Proxima Nova Condensed Bold Italic
+
+```css
+.proxima-nova-condensed-bold-italic {
+font-family: proxima-nova-condensed, sans-serif;
+font-weight: 700;
+font-style: italic;
+}
+```
+
+{{< example >}}
+<div class="proxima-nova-condensed-bold-italic">
+  <span class="text-uppercase">abcdefghijklmnopqrstuvwxyz</span>
+  <span>abcdefghijklmnopqrstuvwxyz</span><br>
+  <span>0123456789</span><br>
+  <span>!@#$%^&</span>
+</div>
+{{< /example >}}
+
+<button class="js-specimen-modal-trigger btn btn-info float-end mt-2" data-font-class='proxima-nova-extra-condensed' data-font-name='Proxima Nova Extra Condensed Regular' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
+
+### Proxima Nova Extra Condensed
+
+```css
+.proxima-nova-extra-condensed {
+font-family: proxima-nova-extra-condensed, sans-serif;
+font-weight: 400;
+font-style: normal;
+}
+```
+
+{{< example >}}
+<div class="proxima-nova-extra-condensed">
+  <span class="text-uppercase">abcdefghijklmnopqrstuvwxyz</span>
+  <span>abcdefghijklmnopqrstuvwxyz</span><br>
+  <span>0123456789</span><br>
+  <span>!@#$%^&</span>
+</div>
+{{< /example >}}
+
+<button class="js-specimen-modal-trigger btn btn-info float-end mt-2" data-font-class='proxima-nova-extra-condensed-bold' data-font-name='Proxima Nova Extra Condensed Bold' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
+
+### Proxima Nova Extra Condensed Bold
+
+```css
+.proxima-nova-extra-condensed-bold {
+font-family: proxima-nova-extra-condensed, sans-serif;
+font-weight: 700;
+font-style: normal;
+}
+```
+
+{{< example >}}
+<div class="proxima-nova-extra-condensed-bold">
+  <span class="text-uppercase">abcdefghijklmnopqrstuvwxyz</span>
+  <span>abcdefghijklmnopqrstuvwxyz</span><br>
+  <span>0123456789</span><br>
+  <span>!@#$%^&</span>
+</div>
+{{< /example >}}
+
+<button class="js-specimen-modal-trigger btn btn-info float-end mt-2" data-font-class='proxima-nova-extra-condensed-italic' data-font-name='Proxima Nova Extra Condensed Italic' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
+
+### Proxima Nova Extra Condensed Italic
+
+```css
+.proxima-nova-extra-condensed-italic {
+font-family: proxima-nova, sans-serif;
+font-weight: 400;
+font-style: italic;
+}
+```
+
+{{< example >}}
+<div class="proxima-nova-extra-condensed-italic">
+  <span class="text-uppercase">abcdefghijklmnopqrstuvwxyz</span>
+  <span>abcdefghijklmnopqrstuvwxyz</span><br>
+  <span>0123456789</span><br>
+  <span>!@#$%^&</span>
+</div>
+{{< /example >}}
+
+<button class="js-specimen-modal-trigger btn btn-info float-end mt-2" data-font-class='proxima-nova-extra-condensed-bold-italic' data-font-name='Proxima Nova Extra Condensed Bold Italic' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
+
+### Proxima Nova Extra Condensed Bold Italic
+
+```css
+.proxima-nova-extra-condensed-bold-italic {
+font-family: proxima-nova-extra-condensed, sans-serif;
+font-weight: 700;
+font-style: italic;
+}
+```
+
+{{< example >}}
+<div class="proxima-nova-extra-condensed-bold-italic">
+  <span class="text-uppercase">abcdefghijklmnopqrstuvwxyz</span>
+  <span>abcdefghijklmnopqrstuvwxyz</span><br>
+  <span>0123456789</span><br>
+  <span>!@#$%^&</span>
+</div>
+{{< /example >}}
+
+## Examples
 
 Below are two examples of how you would use the Proxima Nova fonts in your project.
 
@@ -367,13 +348,6 @@ Below are two examples of how you would use the Proxima Nova fonts in your proje
 {{< /example >}}
 
 **Example 2: Using a Project-Specific Class**
-
-<!-- Include new class for Example 2. -->
-<style>
-.proxima-nova-extra-condensed {
-  font-family: proxima-nova-extra-condensed, sans-serif;
-}
-</style>
 
 ```css
 .proxima-nova-extra-condensed {

--- a/site/content/docs/5.1/content/font.md
+++ b/site/content/docs/5.1/content/font.md
@@ -62,12 +62,12 @@ Put this within your `<head>` tag **above** the reference to Arizona Bootstrap.
 {{< /example >}}
 
 
-## Centrally-managed Typekit Webfont
+## Centrally-managed Typekit Webfonts
 
 For ease of integration into web projects around campus, the Arizona Digital
-team manages a Typekit webfont project that can be referenced by your site.
+team manages Typekit webfont projects that can be referenced by your site.
 
-#### Notes to consider when using the centrally managed webfont project.
+#### Notes to consider when using the centrally managed webfont projects.
 Our license with Typekit allows anyone with a NetID to create their own webfont
 project in Creative Cloud Typekit and use it in all of their web projects.
 
@@ -109,6 +109,7 @@ every device and OS. Read more about [native font stacks in this Smashing Magazi
   // Emoji fonts
   "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
 ```
+<p></p>
 
 This `font-family` is applied to the `<body>` and automatically inherited
 globally throughout Bootstrap. To switch the global `font-family`, update

--- a/site/content/docs/5.1/content/font.md
+++ b/site/content/docs/5.1/content/font.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Font
-description: The Proxima Nova font suite is available for official use by University of Arizona employees through a license with Adobe.
+description: Additional fonts are available for official use by University of Arizona employees through a license with Adobe.
 group: content
 toc: true
 extra_js:
@@ -11,13 +11,11 @@ extra_js:
 
 <div class="alert alert-warning" role="alert">
   <p class="h4 mt-0">Heads Up!</p>
-  If you're using Arizona Bootstrap, Proxima Nova will still need to be added to
-  your project.
+  If you're using Arizona Bootstrap, Proxima Nova and Garamond Premier Pro will still need to be added to your project.
 </div>
 
 ## How to Use
-The Proxima Nova font suite is available for official use by University of Arizona
-employees through a license with Adobe Typekit.
+The Proxima Nova and Garamond Premier Pro font suites are available for official use by University of Arizona employees through a license with Adobe Typekit.
 
 ### Reference link
 
@@ -29,9 +27,40 @@ Put this within your `<head>` tag **above** the reference to Arizona Bootstrap.
 ```html
 <!-- Proxima Nova reference. -->
 <link href="https://use.typekit.net/emv3zbo.css" rel="stylesheet" crossorigin="anonymous">
+<!-- Garamond Premier Pro reference. -->
+<link href="https://use.typekit.net/eyf6fhr.css" rel="stylesheet" crossorigin="anonymous">
 <!-- Arizona Bootstrap reference. -->
 <link rel="stylesheet" href="{{< param "cdn.css" >}}" crossorigin="anonymous">
 ```
+
+## Utility Classes
+
+<span class="badge badge-az-custom">Custom Arizona Bootstrap Classes</span>
+
+`.proxima-nova`.
+
+{{< example >}}
+<p class="proxima-nova">
+  This is the regular Proxima Nova font.
+</p>
+{{< /example >}}
+
+`.proxima-nova-condensed`.
+
+{{< example >}}
+<p class="proxima-nova-condensed">
+  This is the condensed Proxima Nova font.
+</p>
+{{< /example >}}
+
+`.garamond-premier-pro`.
+
+{{< example >}}
+<p class="garamond-premier-pro">
+  This is the Garamond Premier Pro font.
+</p>
+{{< /example >}}
+
 
 ## Centrally-managed Typekit Webfont
 
@@ -86,8 +115,7 @@ globally throughout Bootstrap. To switch the global `font-family`, update
 `$font-family-base` and recompile Arizona Bootstrap.
 
 ## Adding Specific CSS Classes
-<span class="badge bg-warning align-text-top">Important</span> The following instructions are for adding specific CSS classes for font weights or styles. If using Arizona Bootstrap, you will most likely not need to do this unless you are trying to use a specific variant.
-
+<span class="badge bg-warning align-text-top">Important</span> The following instructions are for adding specific CSS classes for font weights or styles to your project. If using Arizona Bootstrap, you will most likely not need to do this unless you are trying to use a specific variant.
 
 <div>
   <button class="js-specimen-modal-trigger btn btn-info float-end" data-font-class='proxima-nova-bold' data-font-name='Proxima Nova Bold' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
@@ -132,29 +160,6 @@ font-style: italic;
   <span>abcdefghijklmnopqrstuvwxyz</span> <br>
   <span>0123456789</span> <br>
   <span>!@#$%^&</span>
-</div>
-{{< /example >}}
-
-<div>
-  <button class="js-specimen-modal-trigger btn btn-info float-end" data-font-class='proxima-nova' data-font-name='Proxima Nova Regular' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
-</div>
-
-### Proxima Nova Regular
-
-```css
-.proxima-nova {
-font-family: proxima-nova, sans-serif;
-font-weight: 400;
-font-style: normal;
-}
-```
-
-{{< example >}}
-<div class="proxima-nova">
- <span class="text-uppercase">abcdefghijklmnopqrstuvwxyz</span>
- <span>abcdefghijklmnopqrstuvwxyz</span> <br>
- <span>0123456789</span> <br>
- <span>!@#$%^&</span>
 </div>
 {{< /example >}}
 
@@ -320,29 +325,6 @@ font-style: italic;
 {{< /example >}}
 
 <div>
-  <button class="js-specimen-modal-trigger btn btn-info float-end" data-font-class='proxima-nova-c' data-font-name='Proxima Nova Condensed Regular' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
-</div>
-
-### Proxima Nova Condensed Regular
-
-```css
-.proxima-nova-c {
-font-family: proxima-nova-condensed, sans-serif;
-font-weight: 400;
-font-style: normal;
-}
-```
-
-{{< example >}}
-<div class="proxima-nova-c">
-  <span class="text-uppercase">abcdefghijklmnopqrstuvwxyz</span>
-  <span>abcdefghijklmnopqrstuvwxyz</span> <br>
-  <span>0123456789</span> <br>
-  <span>!@#$%^&</span>
-</div>
-{{< /example >}}
-
-<div>
   <button class="js-specimen-modal-trigger btn btn-info float-end" data-font-class='proxima-nova-c-italic' data-font-name='Proxima Nova Condensed Italic' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
 </div>
 
@@ -350,9 +332,9 @@ font-style: normal;
 
 ```css
 .proxima-nova-c-italic {
-font-family: proxima-nova, sans-serif;
-font-weight: 400;
-font-style: italic;
+  font-family: proxima-nova, sans-serif;
+  font-weight: 400;
+  font-style: italic;
 }
 ```
 
@@ -365,60 +347,42 @@ font-style: italic;
 </div>
 {{< /example >}}
 
-### Examples in CSS
+### Examples
 
-Below are two examples of how you would use the Proxima Nova fonts in your code.
+Below are two examples of how you would use the Proxima Nova fonts in your project.
 
-**Example 1**
+**Example 1: Using Existing Arizona Bootstrap Classes**
 
 {{< example >}}
-  <h2 class="pn">Hello World!</h2>
-  <div class="pn">
-    <em>Hello World!</em>
+  <h2 class="proxima-nova">Proxima Nova Heading</h2>
+  <div class="proxima-nova">
+    <em>Proxima Nova with emphasis</em>
   </div>
-  <div class="pn">
-    <strong>Hello World!</strong>
+  <div class="proxima-nova">
+    <strong>Proxima Nova with strong importance</strong>
   </div>
-  <div class="pn">
-    <strong><em>Hello World!</em></strong>
+  <div class="proxima-nova">
+    <strong><em>Proxima Nova with emphasis and strong importance</em></strong>
   </div>
 {{< /example >}}
 
-```css
-.pn {
-font-family: proxima-nova-condensed, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-}
-// Not strictly necessary, since Arizona Bootstrap already sets <em> to italic.
-.pn em {
-font-style: italic;
-}
-// Not strictly necessary, since Arizona Bootstrap already sets <strong> to
-bolder.
-.pn strong {
-font-weight:700;
-}
-```
-{{< example >}}
-<h2 class="pn">Hello World!</h2>
-<div>
-  <em class="pn">Hello World!</em>
-</div>
-<div>
-  <strong class="pn">Hello World!</strong>
-</div>
-<div>
-  <strong class="pn"><em>Hello World!</em></strong>
-</div>
-{{< /example >}}
+**Example 2: Using a Project-Specific Class**
 
-**Example 2**
+<!-- Include new class for Example 2. -->
+<style>
+.proxima-nova-extra-condensed {
+  font-family: proxima-nova-extra-condensed, sans-serif;
+}
+</style>
 
 ```css
-p { font-family: proxima-nova-condensed, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
+.proxima-nova-extra-condensed {
+  font-family: proxima-nova-extra-condensed, sans-serif;
+}
 ```
 
 {{< example >}}
-<p>Hello World!</p>
+<p class="proxima-nova-extra-condensed">Proxima Nova Extra Condensed</p>
 {{< /example >}}
 
 <div id="specimen-modal" tabindex="-1" class="modal fade bs-example-modal-lg" aria-labelledby="myModalLabel" aria-hidden="true">

--- a/site/content/docs/5.1/content/font.md
+++ b/site/content/docs/5.1/content/font.md
@@ -27,8 +27,8 @@ Put this within your `<head>` tag **above** the reference to Arizona Bootstrap.
 ```html
 <!-- Proxima Nova reference. -->
 <link href="https://use.typekit.net/emv3zbo.css" rel="stylesheet" crossorigin="anonymous">
-<!-- Garamond Premier Pro reference. -->
-<link href="https://use.typekit.net/eyf6fhr.css" rel="stylesheet" crossorigin="anonymous">
+<!-- Proxima Nova + Garamond Premier Pro reference. -->
+<link href="https://use.typekit.net/sgx0zzg.css" rel="stylesheet" crossorigin="anonymous">
 <!-- Arizona Bootstrap reference. -->
 <link rel="stylesheet" href="{{< param "cdn.css" >}}" crossorigin="anonymous">
 ```

--- a/site/content/docs/5.1/content/font.md
+++ b/site/content/docs/5.1/content/font.md
@@ -25,10 +25,18 @@ manage our font reference links within Arizona Bootstrap.
 Put this within your `<head>` tag **above** the reference to Arizona Bootstrap.
 
 ```html
-<!-- Proxima Nova reference. -->
-<link href="https://use.typekit.net/emv3zbo.css" rel="stylesheet" crossorigin="anonymous">
 <!-- Proxima Nova + Garamond Premier Pro reference. -->
 <link href="https://use.typekit.net/sgx0zzg.css" rel="stylesheet" crossorigin="anonymous">
+<!-- Arizona Bootstrap reference. -->
+<link rel="stylesheet" href="{{< param "cdn.css" >}}" crossorigin="anonymous">
+```
+
+Previous versions of Arizona Bootstrap required only Proxima Nova (and Garamond Premier Pro if AZ Navbar Fullscreen was used). Arizona Bootstrap 5.2 now requires both Proxima Nova and Garamond Premier Pro. If your application requires a lower version of Arizona Bootstrap than 5.2, use the legacy embed code(s).
+```html
+<!-- Proxima Nova reference. -->
+<link href="https://use.typekit.net/emv3zbo.css" rel="stylesheet" crossorigin="anonymous">
+<!-- Garamond Premier Pro reference (only needed for AZ Navbar Fullscreen). -->
+<link href="https://use.typekit.net/eyf6fhr.css" rel="stylesheet" crossorigin="anonymous">
 <!-- Arizona Bootstrap reference. -->
 <link rel="stylesheet" href="{{< param "cdn.css" >}}" crossorigin="anonymous">
 ```

--- a/site/layouts/partials/stylesheet.html
+++ b/site/layouts/partials/stylesheet.html
@@ -1,6 +1,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,1,0" rel="stylesheet">
 <link href="https://cdn.digital.arizona.edu/lib/az-icons/main/az-icons-styles.css" rel="stylesheet">
+<!-- Proxima Nova style sheet. -->
 <link href="https://use.typekit.net/emv3zbo.css" rel="stylesheet" crossorigin="anonymous">
+<!-- Garamond Premier Pro style sheet. -->
 <link href="https://use.typekit.net/eyf6fhr.css" rel="stylesheet" crossorigin="anonymous">
 {{ if hugo.IsProduction -}}
 {{ if eq .Page.Params.direction "rtl" -}}

--- a/site/layouts/partials/stylesheet.html
+++ b/site/layouts/partials/stylesheet.html
@@ -1,9 +1,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,1,0" rel="stylesheet">
 <link href="https://cdn.digital.arizona.edu/lib/az-icons/main/az-icons-styles.css" rel="stylesheet">
-<!-- Proxima Nova style sheet. -->
-<link href="https://use.typekit.net/emv3zbo.css" rel="stylesheet" crossorigin="anonymous">
-<!-- Garamond Premier Pro style sheet. -->
-<link href="https://use.typekit.net/eyf6fhr.css" rel="stylesheet" crossorigin="anonymous">
+<!-- Proxima Nova and Garamond Premier Pro style sheet. -->
+<link href="https://use.typekit.net/sgx0zzg.css" rel="stylesheet" crossorigin="anonymous">
 {{ if hugo.IsProduction -}}
 {{ if eq .Page.Params.direction "rtl" -}}
 <link href="{{- (printf `docs/%s%s` $.Site.Params.docs_version `/dist/css/arizona-bootstrap.rtl.min.css`) | relURL -}}" rel="stylesheet">


### PR DESCRIPTION
## Changes
 - Adds custom classes for Proxima Nova, Proxima Nova Condensed, and Garamond Premier Pro.
 - Imports the new custom fonts SCSS file accordingly.
 - Updates the Font docs page (especially the Adding Specific CSS Classes section).
 - Refactors the Proxima Nova class examples in `_custom-docs.scss`.
 - Adds comments to `stylesheet.html` for the docs site to help identify which style sheet is which.

### To Do:

- [x] Create an embed code that includes both Proxima Nova and Garamond Premier Pro. Update the embed code sections in the Font page and `site/layouts/partials/stylesheet.html`.

## Related issue
 - #2011 

## How to review
Confirm the new custom classes and updated content on the Font page of the docs site:
 - https://review.digital.arizona.edu/arizona-bootstrap/issue/2011/docs/5.1/content/font/

## Questions

1. Is it correct that projects should continue to load the Adobe font stylesheets separately and they should not be imported as part of Arizona Bootstrap?
   - Continuing to load the font stylesheets separately would allow sites to avoid loading Garamond Premier Pro if they aren't using AZ Navbar Fullscreen.
2. Should we add a step on the Getting Started [Introduction page](https://review.digital.arizona.edu/arizona-bootstrap/issue/2011/docs/5.1/getting-started/introduction/) for loading the Adobe font style sheets?
3. Is the new class for Garamond Premier Pro necessary/desired?