### PR TITLE
Closes #2070: AZ Navbar Fullscreen (mobile): Fix nav buttons active state on menu pages

### DIFF
--- a/js/src/navbar-az-fullscreen-mobile-nav.js
+++ b/js/src/navbar-az-fullscreen-mobile-nav.js
@@ -150,7 +150,7 @@ class NavbarAzFullscreenMobileNav {
 
     let html = `<button class="btn navbar-az-fullscreen-mobile-footer-btn navbar-az-fullscreen-mobile-footer-btn-text" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="${ariaLabel}" data-az-menu-element="${menuElementId}"><h2 class="navbar-brand nav-link-text m-0" id="${headingId}">${headingText}</h2><span class="text-white">${footerText}</span></button>`
 
-    html += `<button class="btn nav-toggle navbar-az-fullscreen-mobile-footer-btn" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="${ariaLabel}" data-az-menu-element="${menuElementId}">`
+    html += `<button class="btn nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn" type="button" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="${ariaLabel}" data-az-menu-element="${menuElementId}">`
     html += '<span class="nav-toggle-icon" aria-hidden="true"></span>'
     html += '</button>'
 
@@ -295,6 +295,9 @@ class NavbarAzFullscreenMobileNav {
         }
       }
 
+      // Confirm if any active links are present
+      const activeLinkExists = navClone.querySelectorAll('.nav-link.active').length > 0
+
       // Process all buttons in the cloned nav
       let buttonCounter = 0
       const buttons = navClone.querySelectorAll('button')
@@ -317,6 +320,11 @@ class NavbarAzFullscreenMobileNav {
         // Add data-az-menu-element attribute with original target value
         if (targetId) {
           button.setAttribute('data-az-menu-element', targetId)
+        }
+
+        // Add collapsed class if this menu page has an active link
+        if (activeLinkExists) {
+          button.classList.add('collapsed')
         }
       }
 

--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -446,11 +446,11 @@
       box-shadow: none;
     }
 
-    &:not([aria-expanded="true"]):hover .nav-toggle-icon {
+    &.collapsed:hover .nav-toggle-icon {
       background-image: var(--az-navbar-fullscreen-nav-toggle-icon-hover);
     }
 
-    &[aria-expanded="true"] .nav-toggle-icon {
+    &:not(.collapsed) .nav-toggle-icon {
       background-image: var(--az-navbar-fullscreen-nav-toggle-icon-active);
       transform: scaleX(-1);
     }
@@ -882,6 +882,10 @@
 
   .nav-toggle-icon {
     pointer-events: none;
+  }
+
+  .nav-toggle:not(.collapsed) .nav-toggle-icon {
+    transform: none;
   }
 }
 /* stylelint-enable selector-max-id */

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
@@ -106,7 +106,7 @@ title: AZ Navbar Fullscreen - Home
                       <a class="nav-link" href="{{< ref "admissions" >}}">
                         <span class="nav-link-text">Admissions</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-label="Toggle Admissions submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-label="Toggle Admissions submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-admissions-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -117,7 +117,7 @@ title: AZ Navbar Fullscreen - Home
                                 <a class="nav-link" href="{{< ref "undergraduate" >}}">
                                   <span class="nav-link-text">Undergraduate Students</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" aria-label="Toggle Undergraduate Students submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" aria-label="Toggle Undergraduate Students submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content">
@@ -179,7 +179,7 @@ title: AZ Navbar Fullscreen - Home
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Academics</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-label="Toggle Academics submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-label="Toggle Academics submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-academics-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -190,7 +190,7 @@ title: AZ Navbar Fullscreen - Home
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Degrees &amp; Programs</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-academics-secondary-degrees-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-academics-secondary-degrees-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-academics-secondary-degrees-content" aria-label="Toggle Degrees &amp; Programs submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-academics-secondary-degrees-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-academics-secondary-degrees-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-academics-secondary-degrees-content" aria-label="Toggle Degrees &amp; Programs submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-academics-secondary-degrees-content">
@@ -242,7 +242,7 @@ title: AZ Navbar Fullscreen - Home
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Research</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-label="Toggle Research submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-label="Toggle Research submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-research-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -264,7 +264,7 @@ title: AZ Navbar Fullscreen - Home
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Campus Life</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-campus-life-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-campus-life-content" aria-label="Toggle Campus Life submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-campus-life-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-campus-life-content" aria-label="Toggle Campus Life submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-campus-life-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -280,7 +280,7 @@ title: AZ Navbar Fullscreen - Home
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Visit Campus</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-campus-life-secondary-visit-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-visit-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-visit-content" aria-label="Toggle Visit Campus submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-campus-life-secondary-visit-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-visit-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-visit-content" aria-label="Toggle Visit Campus submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-campus-life-secondary-visit-content" data-bs-parent="#az-navbar-az-fullscreen-campus-life-secondary-nav">
@@ -361,7 +361,7 @@ title: AZ Navbar Fullscreen - Home
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Health &amp; Wellness</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-wellness-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" aria-label="Toggle Health &amp; Wellness submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-wellness-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" aria-label="Toggle Health &amp; Wellness submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" data-bs-parent="#az-navbar-az-fullscreen-campus-life-secondary-nav">
@@ -423,7 +423,7 @@ title: AZ Navbar Fullscreen - Home
                       <a class="nav-link" href="{{< ref "admissions" >}}">
                         <span class="nav-link-text">Admissions</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Admissions submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Admissions submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -431,7 +431,7 @@ title: AZ Navbar Fullscreen - Home
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Academics</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Academics submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Academics submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -439,7 +439,7 @@ title: AZ Navbar Fullscreen - Home
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Research</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Research submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Research submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -447,7 +447,7 @@ title: AZ Navbar Fullscreen - Home
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Campus Life</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Campus Life submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Campus Life submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
@@ -115,7 +115,7 @@ title: AZ Navbar Fullscreen - Admissions
                                 <a class="nav-link" href="{{< ref "undergraduate" >}}">
                                   <span class="nav-link-text">Undergraduate Students</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" aria-label="Toggle Undergraduate Students submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" aria-label="Toggle Undergraduate Students submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content">
@@ -176,7 +176,7 @@ title: AZ Navbar Fullscreen - Admissions
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Academics</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-label="Toggle Academics submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-label="Toggle Academics submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-academics-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -187,7 +187,7 @@ title: AZ Navbar Fullscreen - Admissions
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Degrees &amp; Programs</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-academics-secondary-degrees-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-academics-secondary-degrees-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-academics-secondary-degrees-content" aria-label="Toggle Degrees &amp; Programs submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-academics-secondary-degrees-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-academics-secondary-degrees-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-academics-secondary-degrees-content" aria-label="Toggle Degrees &amp; Programs submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-academics-secondary-degrees-content">
@@ -238,7 +238,7 @@ title: AZ Navbar Fullscreen - Admissions
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Research</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-label="Toggle Research submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-label="Toggle Research submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-research-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -259,7 +259,7 @@ title: AZ Navbar Fullscreen - Admissions
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Campus Life</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-campus-life-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-campus-life-content" aria-label="Toggle Campus Life submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-campus-life-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-campus-life-content" aria-label="Toggle Campus Life submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-campus-life-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -275,7 +275,7 @@ title: AZ Navbar Fullscreen - Admissions
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Visit Campus</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-campus-life-secondary-visit-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-visit-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-visit-content" aria-label="Toggle Visit Campus submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-campus-life-secondary-visit-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-visit-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-visit-content" aria-label="Toggle Visit Campus submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-campus-life-secondary-visit-content" data-bs-parent="#az-navbar-az-fullscreen-campus-life-secondary-nav">
@@ -356,7 +356,7 @@ title: AZ Navbar Fullscreen - Admissions
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Health &amp; Wellness</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-wellness-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" aria-label="Toggle Health &amp; Wellness submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-wellness-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" aria-label="Toggle Health &amp; Wellness submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" data-bs-parent="#az-navbar-az-fullscreen-campus-life-secondary-nav">
@@ -417,7 +417,7 @@ title: AZ Navbar Fullscreen - Admissions
                       <a class="nav-link active" href="{{< ref "admissions" >}}">
                         <span class="nav-link-text">Admissions</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Admissions submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Admissions submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -425,7 +425,7 @@ title: AZ Navbar Fullscreen - Admissions
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Academics</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Academics submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Academics submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -433,7 +433,7 @@ title: AZ Navbar Fullscreen - Admissions
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Research</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Research submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Research submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -441,7 +441,7 @@ title: AZ Navbar Fullscreen - Admissions
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Campus Life</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Campus Life submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Campus Life submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
@@ -105,7 +105,7 @@ title: AZ Navbar Fullscreen - Apply
                       <a class="nav-link" href="{{< ref "admissions" >}}">
                         <span class="nav-link-text">Admissions</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-label="Toggle Admissions submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-label="Toggle Admissions submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-admissions-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -116,7 +116,7 @@ title: AZ Navbar Fullscreen - Apply
                                 <a class="nav-link" href="{{< ref "undergraduate" >}}">
                                   <span class="nav-link-text">Undergraduate Students</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" aria-label="Toggle Undergraduate Students submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" aria-label="Toggle Undergraduate Students submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content">
@@ -178,7 +178,7 @@ title: AZ Navbar Fullscreen - Apply
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Academics</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-label="Toggle Academics submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-label="Toggle Academics submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-academics-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -189,7 +189,7 @@ title: AZ Navbar Fullscreen - Apply
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Degrees &amp; Programs</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-academics-secondary-degrees-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-academics-secondary-degrees-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-academics-secondary-degrees-content" aria-label="Toggle Degrees &amp; Programs submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-academics-secondary-degrees-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-academics-secondary-degrees-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-academics-secondary-degrees-content" aria-label="Toggle Degrees &amp; Programs submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-academics-secondary-degrees-content">
@@ -241,7 +241,7 @@ title: AZ Navbar Fullscreen - Apply
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Research</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-label="Toggle Research submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-label="Toggle Research submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-research-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -263,7 +263,7 @@ title: AZ Navbar Fullscreen - Apply
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Campus Life</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-campus-life-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-campus-life-content" aria-label="Toggle Campus Life submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-campus-life-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-campus-life-content" aria-label="Toggle Campus Life submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-campus-life-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -279,7 +279,7 @@ title: AZ Navbar Fullscreen - Apply
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Visit Campus</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-campus-life-secondary-visit-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-visit-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-visit-content" aria-label="Toggle Visit Campus submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-campus-life-secondary-visit-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-visit-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-visit-content" aria-label="Toggle Visit Campus submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-campus-life-secondary-visit-content" data-bs-parent="#az-navbar-az-fullscreen-campus-life-secondary-nav">
@@ -360,7 +360,7 @@ title: AZ Navbar Fullscreen - Apply
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Health &amp; Wellness</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-wellness-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" aria-label="Toggle Health &amp; Wellness submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-wellness-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" aria-label="Toggle Health &amp; Wellness submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" data-bs-parent="#az-navbar-az-fullscreen-campus-life-secondary-nav">
@@ -422,7 +422,7 @@ title: AZ Navbar Fullscreen - Apply
                       <a class="nav-link" href="{{< ref "admissions" >}}">
                         <span class="nav-link-text">Admissions</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Admissions submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Admissions submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -430,7 +430,7 @@ title: AZ Navbar Fullscreen - Apply
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Academics</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Academics submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Academics submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -438,7 +438,7 @@ title: AZ Navbar Fullscreen - Apply
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Research</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Research submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Research submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -446,7 +446,7 @@ title: AZ Navbar Fullscreen - Apply
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Campus Life</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Campus Life submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Campus Life submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
@@ -104,7 +104,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
                       <a class="nav-link" href="{{< ref "admissions" >}}">
                         <span class="nav-link-text">Admissions</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-label="Toggle Admissions submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-label="Toggle Admissions submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-admissions-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -115,7 +115,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
                                 <a class="nav-link" href="{{< ref "undergraduate" >}}">
                                   <span class="nav-link-text">Undergraduate Students</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" aria-label="Toggle Undergraduate Students submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" aria-label="Toggle Undergraduate Students submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content">
@@ -176,7 +176,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Academics</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-label="Toggle Academics submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-label="Toggle Academics submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-academics-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -187,7 +187,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Degrees &amp; Programs</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-academics-secondary-degrees-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-academics-secondary-degrees-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-academics-secondary-degrees-content" aria-label="Toggle Degrees &amp; Programs submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-academics-secondary-degrees-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-academics-secondary-degrees-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-academics-secondary-degrees-content" aria-label="Toggle Degrees &amp; Programs submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-academics-secondary-degrees-content">
@@ -238,7 +238,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Research</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-label="Toggle Research submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-label="Toggle Research submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-research-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -356,7 +356,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Health &amp; Wellness</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-wellness-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" aria-label="Toggle Health &amp; Wellness submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-wellness-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" aria-label="Toggle Health &amp; Wellness submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" data-bs-parent="#az-navbar-az-fullscreen-campus-life-secondary-nav">
@@ -417,7 +417,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
                       <a class="nav-link" href="{{< ref "admissions" >}}">
                         <span class="nav-link-text">Admissions</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Admissions submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Admissions submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -425,7 +425,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Academics</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Academics submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Academics submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -433,7 +433,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Research</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Research submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Research submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -441,7 +441,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Campus Life</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Campus Life submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Campus Life submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
@@ -104,7 +104,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
                       <a class="nav-link" href="{{< ref "admissions" >}}">
                         <span class="nav-link-text">Admissions</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-label="Toggle Admissions submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-label="Toggle Admissions submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-admissions-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -115,7 +115,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
                                 <a class="nav-link" href="{{< ref "undergraduate" >}}">
                                   <span class="nav-link-text">Undergraduate Students</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" aria-label="Toggle Undergraduate Students submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" aria-label="Toggle Undergraduate Students submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content">
@@ -176,7 +176,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Academics</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-label="Toggle Academics submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-label="Toggle Academics submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-academics-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -187,7 +187,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Degrees &amp; Programs</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-academics-secondary-degrees-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-academics-secondary-degrees-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-academics-secondary-degrees-content" aria-label="Toggle Degrees &amp; Programs submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-academics-secondary-degrees-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-academics-secondary-degrees-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-academics-secondary-degrees-content" aria-label="Toggle Degrees &amp; Programs submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-academics-secondary-degrees-content">
@@ -238,7 +238,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Research</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-label="Toggle Research submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-label="Toggle Research submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-research-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -275,7 +275,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Visit Campus</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-campus-life-secondary-visit-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-visit-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-visit-content" aria-label="Toggle Visit Campus submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-campus-life-secondary-visit-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-visit-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-visit-content" aria-label="Toggle Visit Campus submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-campus-life-secondary-visit-content" data-bs-parent="#az-navbar-az-fullscreen-campus-life-secondary-nav">
@@ -417,7 +417,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
                       <a class="nav-link" href="{{< ref "admissions" >}}">
                         <span class="nav-link-text">Admissions</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Admissions submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Admissions submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -425,7 +425,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Academics</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Academics submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Academics submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -433,7 +433,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Research</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Research submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Research submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -441,7 +441,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Campus Life</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Campus Life submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Campus Life submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
@@ -104,7 +104,7 @@ title: AZ Navbar Fullscreen - Business or Partner
                       <a class="nav-link" href="{{< ref "admissions" >}}">
                         <span class="nav-link-text">Admissions</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-label="Toggle Admissions submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-admissions-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-admissions-content" aria-label="Toggle Admissions submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-admissions-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -115,7 +115,7 @@ title: AZ Navbar Fullscreen - Business or Partner
                                 <a class="nav-link" href="{{< ref "undergraduate" >}}">
                                   <span class="nav-link-text">Undergraduate Students</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" aria-label="Toggle Undergraduate Students submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" aria-label="Toggle Undergraduate Students submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content">
@@ -176,7 +176,7 @@ title: AZ Navbar Fullscreen - Business or Partner
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Academics</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-label="Toggle Academics submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-label="Toggle Academics submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-academics-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -187,7 +187,7 @@ title: AZ Navbar Fullscreen - Business or Partner
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Degrees &amp; Programs</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-academics-secondary-degrees-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-academics-secondary-degrees-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-academics-secondary-degrees-content" aria-label="Toggle Degrees &amp; Programs submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-academics-secondary-degrees-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-academics-secondary-degrees-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-academics-secondary-degrees-content" aria-label="Toggle Degrees &amp; Programs submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-academics-secondary-degrees-content">
@@ -238,7 +238,7 @@ title: AZ Navbar Fullscreen - Business or Partner
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Research</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-label="Toggle Research submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-label="Toggle Research submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-research-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -259,7 +259,7 @@ title: AZ Navbar Fullscreen - Business or Partner
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Campus Life</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-campus-life-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-campus-life-content" aria-label="Toggle Campus Life submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-campus-life-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-campus-life-content" aria-label="Toggle Campus Life submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-campus-life-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -275,7 +275,7 @@ title: AZ Navbar Fullscreen - Business or Partner
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Visit Campus</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-campus-life-secondary-visit-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-visit-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-visit-content" aria-label="Toggle Visit Campus submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-campus-life-secondary-visit-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-visit-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-visit-content" aria-label="Toggle Visit Campus submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-campus-life-secondary-visit-content" data-bs-parent="#az-navbar-az-fullscreen-campus-life-secondary-nav">
@@ -356,7 +356,7 @@ title: AZ Navbar Fullscreen - Business or Partner
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Health &amp; Wellness</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-wellness-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" aria-label="Toggle Health &amp; Wellness submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-wellness-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" aria-label="Toggle Health &amp; Wellness submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" data-bs-parent="#az-navbar-az-fullscreen-campus-life-secondary-nav">
@@ -417,7 +417,7 @@ title: AZ Navbar Fullscreen - Business or Partner
                       <a class="nav-link" href="{{< ref "admissions" >}}">
                         <span class="nav-link-text">Admissions</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Admissions submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Admissions submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -425,7 +425,7 @@ title: AZ Navbar Fullscreen - Business or Partner
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Academics</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Academics submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Academics submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -433,7 +433,7 @@ title: AZ Navbar Fullscreen - Business or Partner
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Research</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Research submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Research submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -441,7 +441,7 @@ title: AZ Navbar Fullscreen - Business or Partner
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Campus Life</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Campus Life submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Campus Life submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
@@ -188,7 +188,7 @@ title: AZ Navbar Fullscreen - Tuition & Aid
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Academics</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-label="Toggle Academics submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-label="Toggle Academics submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-academics-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -199,7 +199,7 @@ title: AZ Navbar Fullscreen - Tuition & Aid
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Degrees &amp; Programs</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-academics-secondary-degrees-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-academics-secondary-degrees-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-academics-secondary-degrees-content" aria-label="Toggle Degrees &amp; Programs submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-academics-secondary-degrees-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-academics-secondary-degrees-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-academics-secondary-degrees-content" aria-label="Toggle Degrees &amp; Programs submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-academics-secondary-degrees-content">
@@ -251,7 +251,7 @@ title: AZ Navbar Fullscreen - Tuition & Aid
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Research</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-label="Toggle Research submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-label="Toggle Research submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-research-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -273,7 +273,7 @@ title: AZ Navbar Fullscreen - Tuition & Aid
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Campus Life</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-campus-life-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-campus-life-content" aria-label="Toggle Campus Life submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-campus-life-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-campus-life-content" aria-label="Toggle Campus Life submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-campus-life-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -289,7 +289,7 @@ title: AZ Navbar Fullscreen - Tuition & Aid
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Visit Campus</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-campus-life-secondary-visit-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-visit-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-visit-content" aria-label="Toggle Visit Campus submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-campus-life-secondary-visit-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-visit-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-visit-content" aria-label="Toggle Visit Campus submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-campus-life-secondary-visit-content" data-bs-parent="#az-navbar-az-fullscreen-campus-life-secondary-nav">
@@ -370,7 +370,7 @@ title: AZ Navbar Fullscreen - Tuition & Aid
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Health &amp; Wellness</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-wellness-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" aria-label="Toggle Health &amp; Wellness submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-wellness-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" aria-label="Toggle Health &amp; Wellness submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" data-bs-parent="#az-navbar-az-fullscreen-campus-life-secondary-nav">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
@@ -115,7 +115,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
                                 <a class="nav-link active" href="{{< ref "undergraduate" >}}">
                                   <span class="nav-link-text">Undergraduate Students</span>
                                 </a>
-                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" type="button" aria-expanded="true" aria-controls="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" aria-label="Toggle Undergraduate Students submenu">
+                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" type="button" aria-expanded="true" aria-controls="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" aria-label="Toggle Undergraduate Students submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse show" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
@@ -115,7 +115,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
                                 <a class="nav-link active" href="{{< ref "undergraduate" >}}">
                                   <span class="nav-link-text">Undergraduate Students</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" type="button" aria-expanded="true" aria-controls="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" aria-label="Toggle Undergraduate Students submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" type="button" aria-expanded="true" aria-controls="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content" aria-label="Toggle Undergraduate Students submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse show" id="az-navbar-az-fullscreen-admissions-secondary-undergraduate-content">
@@ -176,7 +176,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Academics</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-label="Toggle Academics submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-academics-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-academics-content" aria-label="Toggle Academics submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-academics-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -187,7 +187,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Degrees &amp; Programs</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-academics-secondary-degrees-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-academics-secondary-degrees-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-academics-secondary-degrees-content" aria-label="Toggle Degrees &amp; Programs submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-academics-secondary-degrees-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-academics-secondary-degrees-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-academics-secondary-degrees-content" aria-label="Toggle Degrees &amp; Programs submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-academics-secondary-degrees-content">
@@ -238,7 +238,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Research</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-label="Toggle Research submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-research-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-research-content" aria-label="Toggle Research submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-research-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -259,7 +259,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Campus Life</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-campus-life-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-campus-life-content" aria-label="Toggle Campus Life submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-primary-campus-life-content" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-primary-campus-life-content" aria-label="Toggle Campus Life submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse" id="az-navbar-az-fullscreen-primary-campus-life-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
@@ -275,7 +275,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Visit Campus</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-campus-life-secondary-visit-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-visit-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-visit-content" aria-label="Toggle Visit Campus submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-campus-life-secondary-visit-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-visit-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-visit-content" aria-label="Toggle Visit Campus submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-campus-life-secondary-visit-content" data-bs-parent="#az-navbar-az-fullscreen-campus-life-secondary-nav">
@@ -356,7 +356,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
                                 <a class="nav-link" href="#">
                                   <span class="nav-link-text">Health &amp; Wellness</span>
                                 </a>
-                                <button class="btn nav-toggle" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-wellness-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" aria-label="Toggle Health &amp; Wellness submenu">
+                                <button class="btn nav-toggle collapsed" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-tab" data-bs-toggle="collapse" data-bs-target="#az-navbar-az-fullscreen-campus-life-secondary-wellness-content" type="button" aria-expanded="false" aria-controls="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" aria-label="Toggle Health &amp; Wellness submenu">
                                   <span class="nav-toggle-icon" aria-hidden="true"></span>
                                 </button>
                                 <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse" id="az-navbar-az-fullscreen-campus-life-secondary-wellness-content" data-bs-parent="#az-navbar-az-fullscreen-campus-life-secondary-nav">
@@ -417,7 +417,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
                       <a class="nav-link" href="{{< ref "admissions" >}}">
                         <span class="nav-link-text">Admissions</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Admissions submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-admissions-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Admissions submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -425,7 +425,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Academics</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Academics submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-academics-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Academics submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -433,7 +433,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Research</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Research submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-research-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Research submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>
@@ -441,7 +441,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
                       <a class="nav-link" href="#">
                         <span class="nav-link-text">Campus Life</span>
                       </a>
-                      <button class="btn nav-toggle" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Campus Life submenu">
+                      <button class="btn nav-toggle collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-campus-life-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Campus Life submenu">
                         <span class="nav-toggle-icon" aria-hidden="true"></span>
                       </button>
                     </div>


### PR DESCRIPTION
## Changes

- Updates `.nav-toggle-icon` styling to use the `collapsed` class instead of `[aria-expanded="true"]`
- For mobile, updates `.nav-toggle-icon` styling to prevent transformation if active (so the chevron does not change direction) 
- Adds the `collapsed` class where appropriate to `.nav-toggle` buttons in example page HTML
- Updates NavbarAzFullscreenMobileNav JavaScript to add the `collapsed` class to `.nav-toggle` buttons as appropriate

## Related issue
 - #2070

## How to review

1. Go to https://review.digital.arizona.edu/arizona-bootstrap/issue/2070/docs/5.1/examples/navbar-az-fullscreen/.
2. On desktop, confirm that the active state styling for the navigation buttons on the modal menu has not changed.
3. Simulating a mobile device, visit the selection of example pages and confirm that the navigation buttons for the menu pages have the appropriate active state to reflect the current page you are on. (Note: The active state is not added to the buttons in the top and bottom footers.)

<img width="420" height="395" alt="Screenshot 2026-06-03 at 1 59 58 PM" src="https://github.com/user-attachments/assets/17e2d580-20c0-4545-b5de-ed055eeb0de3" />

