### PR TITLE
Closes #2062: AZ Navbar Fullscreen: Update experimental badge

### DIFF
--- a/site/content/docs/5.1/components/navbar.md
+++ b/site/content/docs/5.1/components/navbar.md
@@ -462,7 +462,7 @@ Add `.navbar-az` to an existing `.navbar` to gain additional Brand-approved styl
 {{< /example >}}
 
 ## AZ Navbar Fullscreen
-<span class="badge badge-az-custom">Arizona Bootstrap Experimental Feature</span>
+<span class="badge badge-az-experimental mt-0">Arizona Bootstrap Experimental Feature</span>
 
 The fullscreen AZ Navbar navigation pattern presents a minimal, (non-modal) navbar with the option to toggle open a comprehensive, fullscreen menu as a modal. The non-modal element supports a [logo (brand)](#brand-1), a minimal [Call to Actions](#calls-to-action-menu) menu, a [search](#search) box, and a modal activation toggle. When the [modal menu](#modal-menu) is open, the same [header elements](#modal-menu-header) are supported along with a multicolumn, 3-tier deep menu structure, and support for modal [footer menu bars](#modal-menu-footer).
 


### PR DESCRIPTION
See #2062 

In #2046, we updated the styling of the Experimental Feature badge. This PR updates the experimental badge of AZ Navbar Fullscreen (that has already been deployed to main) to that new style.

### How to test
[Review site](https://review.digital.arizona.edu/arizona-bootstrap/issue/2062/)

1. Navigate to the [AZ Navbar Fullscreen](https://review.digital.arizona.edu/arizona-bootstrap/issue/2062/docs/5.1/components/navbar/#az-navbar-fullscreen) docs section at `/docs/5.1/components/navbar/#az-navbar-fullscreen`.
2. Verify the updated style by comparing against the Experimental Feature badge already deployed in the [Blue header](https://review.digital.arizona.edu/arizona-bootstrap/issue/2062/docs/5.1/components/arizona-header/#blue-header) docs section at `/docs/5.1/components/arizona-header/#blue-header`.