### PR TITLE
Closes #2089: Hide the light-dark mode toggle button on the Examples docs pages.

### DIFF
--- a/site/layouts/_default/examples.html
+++ b/site/layouts/_default/examples.html
@@ -114,9 +114,11 @@
   <body{{ with .Page.Params.body_class }} class="{{ . }}"{{ end }}>
     {{ partial "examples/icons" . }}
 
-    <div class="dropdown position-fixed bottom-0 end-0 mb-3 me-3 bd-mode-toggle">
-      {{ partial "theme-toggler" . }}
-    </div>
+    {{- if .Site.Params.enable_color_mode_toggler -}}
+      <div class="dropdown position-fixed bottom-0 end-0 mb-3 me-3 bd-mode-toggle">
+        {{ partial "theme-toggler" . }}
+      </div>
+    {{- end -}}
 
     {{ .Content }}
 


### PR DESCRIPTION
Follow the example of `layouts/partials/docs-navbar.html` and wrap the display of the light-dark mode button in a condition.