### PR TITLE
Fixes #2085: AZ Navbar Fullscreen: Check scrollbar styling in non-Safari browsers

### DIFF
--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -252,6 +252,8 @@
   --az-navbar-fullscreen-modal-footer-nav-link-padding-y: 10px;
   --az-navbar-fullscreen-modal-fade-size: 56px;
   --az-navbar-fullscreen-modal-fade-color: var(--bs-blue);
+  --az-navbar-fullscreen-modal-scrollbar-thumb-color: #{shade-color($blue, 50%)};
+  --az-navbar-fullscreen-modal-scrollbar-track-color: transparent;
   --bs-modal-bg: var(--bs-blue);
   --bs-modal-padding: 0;
   --bs-modal-header-padding: 0;
@@ -573,6 +575,7 @@
     padding-top: 32px; // 56px - 24px
     overflow-x: hidden;
     overflow-y: auto;
+    scrollbar-color: var(--az-navbar-fullscreen-modal-scrollbar-thumb-color) var(--az-navbar-fullscreen-modal-scrollbar-track-color);
     border-right: 1px solid var(--bs-azurite);
 
     .nav-item {


### PR DESCRIPTION
## Summary
Updates AZ Fullscreen Navbar scrollbar styling tokens and applies scoped scrollbar coloring for the fullscreen menu navigation column.

## What Changed
- Added scoped fullscreen modal scrollbar tokens in `.navbar-az-fullscreen-modal`:
  - `--az-navbar-fullscreen-modal-scrollbar-thumb-color: #{shade-color($blue, 50%)}`
  - `--az-navbar-fullscreen-modal-scrollbar-track-color: transparent`
- Applied `scrollbar-color` in `.navbar-az-fullscreen-modal-menu-nav-col`:
  - `scrollbar-color: var(--az-navbar-fullscreen-modal-scrollbar-thumb-color) var(--az-navbar-fullscreen-modal-scrollbar-track-color)`

## Scope
- Changes are limited to `scss/custom/_navbar-fullscreen.scss`
- No global scrollbar utilities or shared component styles were modified

## Testing Instructions
1. Run lint checks:
   - `npm run css-lint`
2. Open the AZ Navbar Fullscreen example page in this PR review environment:
   - https://review.digital.arizona.edu/arizona-bootstrap/bug/2085/docs/5.1/examples/navbar-az-fullscreen/
3. Open the fullscreen menu and verify the scrollable navigation column (`.navbar-az-fullscreen-modal-menu-nav-col`) shows the intended scrollbar colors.
4. Validate behavior in Firefox specifically:
   - Confirm `scrollbar-color` is applied (thumb uses the configured shaded blue, track is transparent).
5. Spot-check Chromium/Safari behavior to ensure no regressions in fullscreen navbar scrolling UX.

## Notes
- This PR currently contains SCSS source changes for fullscreen navbar scrollbar tokens and color application.
