### PR TITLE
Simpler approach to handling scrollbars in AZ Navbar Fullscreen

### DIFF
--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -576,6 +576,7 @@
     --bs-nav-link-hover-color: var(--az-navbar-fullscreen-modal-menu-hover-color);
     flex-direction: column;
     flex-wrap: nowrap;
+    padding-right: var(--az-navbar-fullscreen-modal-menu-col-spacing-x);
     padding-left: var(--az-navbar-fullscreen-modal-menu-col-spacing-x);
     font: var(--az-navbar-fullscreen-modal-menu-font);
   }
@@ -586,8 +587,8 @@
     .navbar-az-fullscreen-modal-menu-nav-col {
       padding-right: 0;
       scrollbar-color: var(--az-navbar-fullscreen-modal-scrollbar-thumb-color) var(--az-navbar-fullscreen-modal-scrollbar-track-color);
-      scrollbar-gutter: stable;
-      scrollbar-width: thin;
+      // scrollbar-gutter: stable;
+      // scrollbar-width: thin;
       border-right: 1px solid transparent;
       border-image:
         linear-gradient(
@@ -620,13 +621,13 @@
         border-image: none;
       }
 
-      .nav-item {
-        margin-right: 12px;
-      }
+      // .nav-item {
+      //   margin-right: 12px;
+      // }
 
-      &::-webkit-scrollbar {
-        width: 12px;
-      }
+      // &::-webkit-scrollbar {
+      //   width: 12px;
+      // }
 
       &::-webkit-scrollbar-track {
         background: var(--az-navbar-fullscreen-modal-scrollbar-track-color);
@@ -893,6 +894,7 @@
     border-right: 0;
 
     .nav {
+      padding-right: 0;
       padding-left: 0;
     }
 


### PR DESCRIPTION
See #2101.

This approach makes no attempt to reserve any space for scrollbars. Instead, `.nav`s now have left and right padding at the desired 24px. When scrolling is needed, it is left to the browser to render and size them. `scrollbar-gutter: stable` is removed with this approach (since this does not appear to be working anyways).

https://review.digital.arizona.edu/arizona-bootstrap/issue/2090-simple/docs/5.1/examples/navbar-az-fullscreen/