### PR TITLE
Closes #2126: Prevent Dependabot from bumping Babel to the new v8 major version.

### DIFF
--- a/.babelrc.mjs
+++ b/.babelrc.mjs
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   presets: [
     [
       '@babel/preset-env',
@@ -9,4 +9,4 @@ module.exports = {
       }
     ]
   ]
-};
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
       interval: "daily"
     target-branch: "2.x"
     ignore:
+      - dependency-name: "@babel/cli"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@babel/core"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@babel/preset-env"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "bootstrap"
       - dependency-name: "eslint"
       - dependency-name: "eslint-config-xo"
@@ -31,6 +37,12 @@ updates:
       interval: "daily"
     target-branch: "main"
     ignore:
+      - dependency-name: "@babel/cli"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@babel/core"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@babel/preset-env"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "bootstrap"
       - dependency-name: "eslint"
       - dependency-name: "eslint-config-xo"

--- a/package.json
+++ b/package.json
@@ -66,9 +66,9 @@
     "@popperjs/core": "^2.11.8"
   },
   "devDependencies": {
-    "@babel/cli": "^7.28.6",
-    "@babel/core": "^7.29.0",
-    "@babel/preset-env": "^7.29.5",
+    "@babel/cli": "^7.29.7",
+    "@babel/core": "^7.29.7",
+    "@babel/preset-env": "^7.29.7",
     "@popperjs/core": "^2.11.8",
     "@rollup/plugin-babel": "^7.1.0",
     "@rollup/plugin-commonjs": "^29.0.3",


### PR DESCRIPTION
The config file change is a copy of the upstream Bootstrap v6-dev one, in anticipation of further changes.