### PR TITLE
Closes #2011: Add font utility classes, Garamond Premier Pro

### DIFF
--- a/dist/css/arizona-bootstrap.css
+++ b/dist/css/arizona-bootstrap.css
@@ -21690,6 +21690,18 @@ a:not(.btn, .nav-link, .page-link, .dropdown-item, .arizona-logo):focus-visible 
     column-count: 4;
   }
 }
+.proxima-nova {
+  font-family: proxima-nova, calibri, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}
+
+.proxima-nova-condensed {
+  font-family: proxima-nova-condensed, proxima-nova, calibri, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
+}
+
+.garamond-premier-pro {
+  font-family: garamond-premier-pro, garamond-premier-pro, serif;
+}
+
 .list-group-item.active h1,
 .list-group-item.active h2,
 .list-group-item.active h3,

--- a/scss/arizona-bootstrap.scss
+++ b/scss/arizona-bootstrap.scss
@@ -84,6 +84,7 @@
 @import "custom/card";
 @import "custom/color-background";
 @import "custom/column-split";
+@import "custom/font";
 @import "custom/list-group";
 @import "override/nav";
 @import "custom/nav";

--- a/scss/custom/_font.scss
+++ b/scss/custom/_font.scss
@@ -1,0 +1,15 @@
+//
+// > Custom font styles
+//
+
+.proxima-nova {
+    font-family: $font-family-sans-serif;
+}
+
+.proxima-nova-condensed {
+    font-family: proxima-nova-condensed, #{$font-family-sans-serif};
+}
+
+.garamond-premier-pro {
+    font-family: garamond-premier-pro, #{$font-family-sans-serif};
+}

--- a/scss/custom/_variables.scss
+++ b/scss/custom/_variables.scss
@@ -389,6 +389,8 @@ $colors: (
 $font-family-sans-serif: proxima-nova, calibri, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 // stylelint-enable value-keyword-case
 
+$font-family-serif: 'garamond-premier-pro', serif;
+
 $heading-margins: 1.042em 0 .667em;
 
 /*

--- a/site/content/docs/5.1/content/font.md
+++ b/site/content/docs/5.1/content/font.md
@@ -11,12 +11,12 @@ extra_js:
 
 <div class="alert alert-warning" role="alert">
   <p class="h4 mt-0">Heads Up!</p>
-  If you're using Arizona Bootstrap, Proxima Nova will still need to be added to
+  If you're using Arizona Bootstrap, Proxima Nova and Garamond Premier Pro will still need to be added to
   your project.
 </div>
 
 ## How to Use
-The Proxima Nova font suite is available for official use by University of Arizona
+The Proxima Nova and Garamond Premier Pro font suites are available for official use by University of Arizona
 employees through a license with Adobe Typekit.
 
 ### Reference link
@@ -29,6 +29,8 @@ Put this within your `<head>` tag **above** the reference to Arizona Bootstrap.
 ```html
 <!-- Proxima Nova reference. -->
 <link href="https://use.typekit.net/emv3zbo.css" rel="stylesheet" crossorigin="anonymous">
+<!-- Garamond Premier Pro reference. -->
+<link href="https://use.typekit.net/eyf6fhr.css" rel="stylesheet" crossorigin="anonymous">
 <!-- Arizona Bootstrap reference. -->
 <link rel="stylesheet" href="{{< param "cdn.css" >}}" crossorigin="anonymous">
 ```
@@ -88,6 +90,57 @@ globally throughout Bootstrap. To switch the global `font-family`, update
 ## Adding Specific CSS Classes
 <span class="badge bg-warning align-text-top">Important</span> The following instructions are for adding specific CSS classes for font weights or styles. If using Arizona Bootstrap, you will most likely not need to do this unless you are trying to use a specific variant.
 
+
+
+## Utility Classes
+
+<span class="badge badge-az-custom">Custom Arizona Bootstrap Classes</span>
+
+`.proxima-nova`.
+
+{{< example >}}
+<p class="proxima-nova">
+  This is the regular Proxima Nova font.
+</p>
+{{< /example >}}
+
+`.proxima-nova-condensed`.
+
+{{< example >}}
+<p class="proxima-nova-condensed">
+  This is the condensed Proxima Nova font.
+</p>
+{{< /example >}}
+
+`.garamond-premier-pro`.
+
+{{< example >}}
+<p class="garamond-premier-pro">
+  This is the Garamond Premier Pro font.
+</p>
+{{< /example >}}
+
+<div>
+  <button class="js-specimen-modal-trigger btn btn-info float-end mt-2" data-font-class='garamond-premier-pro' data-font-name='Garamond Premier Pro' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>
+</div>
+
+### Garamond Premier Pro
+
+```css
+.garamond-premier-pro {
+font-family: garamond-premier-pro, serif;
+font-weight: 500;
+font-style: normal;
+}
+```
+{{< example >}}
+<div class="garamond-premier-pro">
+  <span class="text-uppercase">abcdefghijklmnopqrstuvwxyz</span>
+  <span>abcdefghijklmnopqrstuvwxyz</span> <br>
+  <span>0123456789</span> <br>
+  <span>!@#$%^&</span>
+</div>
+{{< /example >}}
 
 <div>
   <button class="js-specimen-modal-trigger btn btn-info float-end" data-font-class='proxima-nova-bold' data-font-name='Proxima Nova Bold' data-bs-target='.bs-example-modal-lg' data-bs-toggle='modal' type='button'>View Sample</button>

--- a/site/layouts/partials/stylesheet.html
+++ b/site/layouts/partials/stylesheet.html
@@ -2,6 +2,8 @@
 <link href="https://cdn.digital.arizona.edu/lib/az-icons/main/az-icons-styles.css" rel="stylesheet">
 <link href="https://use.typekit.net/emv3zbo.css" rel="stylesheet" crossorigin="anonymous">
 <link href="https://use.typekit.net/eyf6fhr.css" rel="stylesheet" crossorigin="anonymous">
+<!-- Garamond Premier Pro style sheet. -->
+<link href="https://use.typekit.net/eyf6fhr.css" rel="stylesheet" crossorigin="anonymous">
 {{ if hugo.IsProduction -}}
 {{ if eq .Page.Params.direction "rtl" -}}
 <link href="{{- (printf `docs/%s%s` $.Site.Params.docs_version `/dist/css/arizona-bootstrap.rtl.min.css`) | relURL -}}" rel="stylesheet">


### PR DESCRIPTION
(Custom work to make sure Garamond works on its own with its necessary classes).

#2011 

https://github.com/az-digital/arizona-bootstrap/pull/2140
https://github.com/az-digital/arizona-bootstrap/pull/2066

These two PRs both do similar things, but have their own issues. This PR attempts to preserve their work while merging just the necessary work for Serif font sizes.

2140 - This lays most of the groundwork, but also contains a large amount of different code for navigation, headers, and versions, which has lead to a massive amount of unessessary, outdated files. Many of them are now conflicting. I recommend we close this PR out.

2066 - This one has the most work that's similar to what I've done here, except we're not redoing class names. I'd prefer to close this out and just work with that one instead.