### PR TITLE
Closes #2137: AZ Navbar Fullscreen (mobile): Update scroll behavior of modal body

### DIFF
--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -1038,7 +1038,7 @@
     &::before {
       position: sticky;
       top: 0;
-      z-index: 1;
+      z-index: 2;
       display: block;
       height: 2px;
       content: "";
@@ -1079,7 +1079,7 @@
     &::before {
       position: sticky;
       top: 0;
-      z-index: 1;
+      z-index: 2;
       display: block;
       height: 1px;
       content: "";

--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -1066,7 +1066,6 @@
     .nav {
       margin-right: 0;
       margin-left: 0;
-      border-top: 1px solid var(--az-navbar-fullscreen-modal-menu-separator-color);
       border-bottom: 1px solid var(--az-navbar-fullscreen-modal-menu-separator-color);
     }
 
@@ -1156,14 +1155,16 @@
 /* stylelint-enable selector-max-id */
 
 .navbar-az-fullscreen-nav-mobile-menu-heading {
+  padding-bottom: 16px;
   margin-top: 0;
-  margin-bottom: 16px;
+  margin-bottom: 0;
   font-family: proxima-nova-condensed, #{$font-family-sans-serif};
   font-size: 22px;
   font-weight: 800;
   line-height: 27px;
   color: var(--bs-sky);
   letter-spacing: .44px;
+  border-bottom: 1px solid var(--az-navbar-fullscreen-modal-menu-separator-color);
 }
 
 .nav-toggle.navbar-az-fullscreen-mobile-footer-btn {

--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -416,23 +416,6 @@
     margin-bottom: 8px;
   }
 
-  .modal-content > .modal-footer:not(.modal-footer ~ .modal-footer) {
-    @include media-breakpoint-up(lg) {
-      &::before {
-        position: absolute;
-        top: 0;
-        right: 0;
-        left: 0;
-        z-index: 1;
-        height: var(--az-navbar-fullscreen-modal-bottom-fade-size);
-        pointer-events: none;
-        content: "";
-        background: linear-gradient(to bottom, rgb(0 0 0 / 0) 0%, var(--az-navbar-fullscreen-modal-fade-color) 100%);
-        transform: translateY(-100%);
-      }
-    }
-  }
-
   .modal-footer {
     .navbar {
       --bs-navbar-padding-y: var(--az-navbar-fullscreen-modal-footer-navbar-padding-y);
@@ -604,6 +587,21 @@
       @include border-radius(999px);
     }
   }
+
+  /* stylelint-disable selector-max-id */
+  #navbar-az-fullscreen-modal-footer-top::before {
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    z-index: 1;
+    height: var(--az-navbar-fullscreen-modal-bottom-fade-size);
+    pointer-events: none;
+    content: "";
+    background: linear-gradient(to top, var(--az-navbar-fullscreen-modal-fade-color) 0%, rgb(0 0 0 / 0) 100%);
+    transform: translateY(-100%);
+  }
+  /* stylelint-enable selector-max-id */
 }
 
 .navbar-az-fullscreen-modal-menu {

--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -1033,13 +1033,25 @@
     }
   }
 
+  .navbar-az-fullscreen-modal-menu-nav-col-primary {
+    // Sticky separator that stays put while the nav items scroll under it.
+    &::before {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      display: block;
+      height: 2px;
+      content: "";
+      background-color: var(--az-navbar-fullscreen-modal-menu-separator-color);
+    }
+  }
+
   .nav.navbar-az-fullscreen-nav-primary {
     --az-navbar-fullscreen-nav-toggle-size: 38px;
     --az-navbar-fullscreen-nav-toggle-separator-offset: 20px;
     --az-navbar-fullscreen-nav-toggle-padding-y: 6px;
     margin-right: 0;
     margin-left: 0;
-    border-top: 2px solid var(--az-navbar-fullscreen-modal-menu-separator-color);
     border-bottom: 2px solid var(--az-navbar-fullscreen-modal-menu-separator-color);
 
     .nav-item:not(:last-child) {
@@ -1062,6 +1074,17 @@
     --az-navbar-fullscreen-nav-toggle-padding-y: 6px;
     padding-top: 0;
     border-right: 0;
+
+    // Sticky separator that stays put while the nav items scroll under it.
+    &::before {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      display: block;
+      height: 1px;
+      content: "";
+      background-color: var(--az-navbar-fullscreen-modal-menu-separator-color);
+    }
 
     .nav {
       margin-right: 0;
@@ -1155,16 +1178,14 @@
 /* stylelint-enable selector-max-id */
 
 .navbar-az-fullscreen-nav-mobile-menu-heading {
-  padding-bottom: 16px;
   margin-top: 0;
-  margin-bottom: 0;
+  margin-bottom: 16px;
   font-family: proxima-nova-condensed, #{$font-family-sans-serif};
   font-size: 22px;
   font-weight: 800;
   line-height: 27px;
   color: var(--bs-sky);
   letter-spacing: .44px;
-  border-bottom: 1px solid var(--az-navbar-fullscreen-modal-menu-separator-color);
 }
 
 .nav-toggle.navbar-az-fullscreen-mobile-footer-btn {

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
@@ -427,7 +427,7 @@ title: AZ Navbar Fullscreen - Home
                   </li>
                 </ul>
                 <!-- initial mobile nav items -->
-                <div class="navbar-az-fullscreen-modal-menu-nav-col col-12">
+                <div class="navbar-az-fullscreen-modal-menu-nav-col navbar-az-fullscreen-modal-menu-nav-col-primary col-12 col-lg-4">
                   <nav class="nav navbar-az-fullscreen-nav-primary" aria-label="Main navigation sections">
                     <div class="nav-item">
                       <a class="nav-link" href="{{< ref "admissions" >}}">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
@@ -411,7 +411,7 @@ title: AZ Navbar Fullscreen - Admissions
                   </li>
                 </ul>
                 <!-- initial mobile nav items -->
-                <div class="navbar-az-fullscreen-modal-menu-nav-col col-12">
+                <div class="navbar-az-fullscreen-modal-menu-nav-col navbar-az-fullscreen-modal-menu-nav-col-primary col-12 col-lg-4">
                   <nav class="nav navbar-az-fullscreen-nav-primary" aria-label="Main navigation sections">
                     <div class="nav-item">
                       <a class="nav-link active" href="{{< ref "admissions" >}}">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
@@ -416,7 +416,7 @@ title: AZ Navbar Fullscreen - Apply
                   </li>
                 </ul>
                 <!-- initial mobile nav items -->
-                <div class="navbar-az-fullscreen-modal-menu-nav-col col-12">
+                <div class="navbar-az-fullscreen-modal-menu-nav-col navbar-az-fullscreen-modal-menu-nav-col-primary col-12 col-lg-4">
                   <nav class="nav navbar-az-fullscreen-nav-primary" aria-label="Main navigation sections">
                     <div class="nav-item">
                       <a class="nav-link" href="{{< ref "admissions" >}}">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
@@ -411,7 +411,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
                   </li>
                 </ul>
                 <!-- initial mobile nav items -->
-                <div class="navbar-az-fullscreen-modal-menu-nav-col col-12">
+                <div class="navbar-az-fullscreen-modal-menu-nav-col navbar-az-fullscreen-modal-menu-nav-col-primary col-12 col-lg-4">
                   <nav class="nav navbar-az-fullscreen-nav-primary" aria-label="Main navigation sections">
                     <div class="nav-item">
                       <a class="nav-link" href="{{< ref "admissions" >}}">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
@@ -411,7 +411,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
                   </li>
                 </ul>
                 <!-- initial mobile nav items -->
-                <div class="navbar-az-fullscreen-modal-menu-nav-col col-12">
+                <div class="navbar-az-fullscreen-modal-menu-nav-col navbar-az-fullscreen-modal-menu-nav-col-primary col-12 col-lg-4">
                   <nav class="nav navbar-az-fullscreen-nav-primary" aria-label="Main navigation sections">
                     <div class="nav-item">
                       <a class="nav-link" href="{{< ref "admissions" >}}">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
@@ -411,7 +411,7 @@ title: AZ Navbar Fullscreen - Business or Partner
                   </li>
                 </ul>
                 <!-- initial mobile nav items -->
-                <div class="navbar-az-fullscreen-modal-menu-nav-col col-12">
+                <div class="navbar-az-fullscreen-modal-menu-nav-col navbar-az-fullscreen-modal-menu-nav-col-primary col-12 col-lg-4">
                   <nav class="nav navbar-az-fullscreen-nav-primary" aria-label="Main navigation sections">
                     <div class="nav-item">
                       <a class="nav-link" href="{{< ref "admissions" >}}">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/phonebook/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/phonebook/_index.html
@@ -411,7 +411,7 @@ title: AZ Navbar Fullscreen - Phonebook
                   </li>
                 </ul>
                 <!-- initial mobile nav items -->
-                <div class="navbar-az-fullscreen-modal-menu-nav-col col-12">
+                <div class="navbar-az-fullscreen-modal-menu-nav-col navbar-az-fullscreen-modal-menu-nav-col-primary col-12 col-lg-4">
                   <nav class="nav navbar-az-fullscreen-nav-primary" aria-label="Main navigation sections">
                     <div class="nav-item">
                       <a class="nav-link" href="{{< ref "admissions" >}}">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
@@ -451,7 +451,7 @@ title: AZ Navbar Fullscreen - Tuition & Aid
                   </li>
                 </ul>
                 <!-- initial mobile nav items -->
-                <div class="navbar-az-fullscreen-modal-menu-nav-col col-12">
+                <div class="navbar-az-fullscreen-modal-menu-nav-col navbar-az-fullscreen-modal-menu-nav-col-primary col-12 col-lg-4">
                   <nav class="nav navbar-az-fullscreen-nav-primary" aria-label="Main navigation sections">
                     <div class="nav-item">
                       <a class="nav-link" href="{{< ref "admissions" >}}">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
@@ -411,7 +411,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
                   </li>
                 </ul>
                 <!-- initial mobile nav items -->
-                <div class="navbar-az-fullscreen-modal-menu-nav-col col-12">
+                <div class="navbar-az-fullscreen-modal-menu-nav-col navbar-az-fullscreen-modal-menu-nav-col-primary col-12 col-lg-4">
                   <nav class="nav navbar-az-fullscreen-nav-primary" aria-label="Main navigation sections">
                     <div class="nav-item">
                       <a class="nav-link" href="{{< ref "admissions" >}}">


### PR DESCRIPTION
## Changes
- Apply the existing desktop fade effect above the top footer to the mobile display as well.
- Mobile: Replace the top border on the list of menu items with a `::before` pseudo element.
- Mobile: Fix a missing class on the menu nav column element in the initial mobile nav elements.

## Related issue
 - #2137

Note: This issue includes a task for preventing the back button and submenu title from scrolling with the nav items. This task was already completed in #2125.

## Questions / Follow-ups:

1. Mobile: Confirm whether a fade effect is desired / necessary at the top of the list of menu items. (If so, complete "to do" item below for this PR or in a follow-up.)
    - Yes, let's implement the fade effect at the top as well, although this is not required for launch. 
2. Should we continue to hard-code the heading text in the footers? And should the colons be included?

## To do:
 - [x] Mobile: Add JavaScript to implement a fade effect at the top of the scrolling list of menu items, but only after the user has scrolled down. There does not appear to be a pure CSS solution that is suitable for this use case.

## How to test

1. Visit https://review.digital.arizona.edu/arizona-bootstrap/issue/2137/docs/5.1/examples/navbar-az-fullscreen/calendar/.
2. On desktop, compare the changes with the [main branch](https://review.digital.arizona.edu/arizona-bootstrap/main/docs/5.1/examples/navbar-az-fullscreen/) and confirm that there are no changes.
4. Simulating a mobile device, confirm that all functionality of the mobile display works as expected. In particular, you can test:
   - A fade effect is shown at the above the top footer, so menu items at the bottom of the list fade out.
   - When scrolling secondary and tertiary menu items in the mobile display, the border line below the nav menu heading remains visible.


