### PR TITLE
Closes #2074: AZ Navbar Fullscreen (mobile): Update modal footers to match the mockups

### DIFF
--- a/js/src/navbar-az-fullscreen-mobile-nav.js
+++ b/js/src/navbar-az-fullscreen-mobile-nav.js
@@ -12,9 +12,7 @@
 
 const IDS = {
   FOOTER_TOP: 'navbar-az-fullscreen-modal-footer-top',
-  FOOTER_TOP_HEADING: 'resources-for-label',
   FOOTER_BOTTOM: 'navbar-az-fullscreen-modal-footer-bottom',
-  FOOTER_BOTTOM_HEADING: 'helpful-links-label',
   MOBILE_COL: 'navbar-az-fullscreen-nav-mobile-col'
 }
 const LABELS = {
@@ -164,15 +162,9 @@ class NavbarAzFullscreenMobileNav {
       return
     }
 
-    const firstNavItem = footer.querySelector('.navbar-nav .nav-item')
-    if (!firstNavItem) {
-      return
-    }
-
     // Get the original heading element and extract its text and id
     const originalHeading = footer.querySelector('.nav-item > .navbar-brand')
     const headingText = originalHeading?.textContent.trim() || (footerPosition === 'top' ? LABELS.FOOTER_TOP_HEADING : LABELS.FOOTER_BOTTOM_HEADING)
-    const headingId = originalHeading?.id || (footerPosition === 'top' ? IDS.FOOTER_TOP_HEADING : IDS.FOOTER_BOTTOM_HEADING)
 
     // Save footer nav links to an array
     const footerLinksProperty = footerPosition === 'top' ? 'topFooterLinks' : 'bottomFooterLinks'
@@ -188,62 +180,24 @@ class NavbarAzFullscreenMobileNav {
       }
     })
 
-    // If a match was found in the this footer's links, display the menu page
+    // If a match was found in this footer's links, display the menu page
     if (!activeLinkFound && found) {
       this.showNavMenu(2, `#${footer.id}`, headingText)
     }
 
-    // Clone the first nav item
-    const clonedNavItem = firstNavItem.cloneNode(true)
-
-    // Get the first 3 link texts
-    const linkTexts = this[footerLinksProperty] ? this[footerLinksProperty].slice(0, 3).map(link => link.text) : []
+    // Get the first 2 link texts
+    const linkTexts = this[footerLinksProperty] ? this[footerLinksProperty].slice(0, 2).map(link => link.text) : []
 
     // Create the text with "and more..."
     const footerText = linkTexts.length > 0 ? `${linkTexts.join(', ')}, and more...` : 'View more...'
 
-    // Create aria-label text for the button
-    const ariaLabel = `Toggle ${headingText.replace(':', '').trim()} submenu`
-
-    const primaryButton = document.createElement('button')
-    primaryButton.type = 'button'
-    primaryButton.className = 'btn navbar-az-fullscreen-mobile-footer-btn navbar-az-fullscreen-mobile-footer-btn-text'
-    primaryButton.setAttribute('aria-controls', IDS.MOBILE_COL)
-    primaryButton.setAttribute('aria-label', ariaLabel)
-    primaryButton.setAttribute('data-az-menu-element', `#${footer.id}`)
-
-    const heading = document.createElement('h2')
-    heading.className = 'navbar-brand nav-link-text m-0'
-    heading.setAttribute('id', headingId)
-    heading.textContent = headingText
-    primaryButton.append(heading)
-
-    const footerTextNode = document.createElement('span')
-    footerTextNode.className = 'text-white'
-    footerTextNode.textContent = footerText
-    primaryButton.append(footerTextNode)
-
-    const toggleButton = document.createElement('button')
-    toggleButton.type = 'button'
-    toggleButton.className = 'btn nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn'
-    toggleButton.setAttribute('aria-controls', IDS.MOBILE_COL)
-    toggleButton.setAttribute('aria-label', ariaLabel)
-    toggleButton.setAttribute('data-az-menu-element', `#${footer.id}`)
-
-    const toggleIcon = document.createElement('span')
-    toggleIcon.className = 'nav-toggle-icon'
-    toggleIcon.setAttribute('aria-hidden', 'true')
-    toggleButton.append(toggleIcon)
-
-    clonedNavItem.replaceChildren(primaryButton, toggleButton)
-    clonedNavItem.classList.add('d-lg-none')
-
-    // Insert the cloned item as the first child of the parent
-    const parentNav = firstNavItem.parentElement
-    parentNav.insertBefore(clonedNavItem, parentNav.firstChild)
+    const footerMoreLinksText = footer.querySelector('.navbar-az-fullscreen-mobile-footer-btn-text .more-links-text')
+    if (footerMoreLinksText) {
+      footerMoreLinksText.textContent = footerText
+    }
 
     // Set up event listeners for footer buttons
-    const footerButtons = clonedNavItem.querySelectorAll(':scope .btn')
+    const footerButtons = footer.querySelectorAll(':scope .btn')
     for (const button of footerButtons) {
       button.addEventListener('click', e => {
         const targetId = button.getAttribute('data-az-menu-element')

--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -904,8 +904,7 @@
     }
 
     .container-lg {
-      padding-right: 20px;
-      padding-left: 20px;
+      padding: 2px 20px;
     }
 
     .navbar-az-fullscreen-modal-menu.container-lg {
@@ -1168,24 +1167,46 @@
   letter-spacing: .44px;
 }
 
-.nav-toggle.navbar-az-fullscreen-mobile-footer-btn {
-  --az-navbar-fullscreen-nav-toggle-size: 38px;
-  --az-navbar-fullscreen-nav-toggle-padding-y: 6px;
+.navbar-az-fullscreen-mobile-footer-btn {
+  --az-navbar-fullscreen-modal-footer-navbar-padding-y: 16px;
+  padding-right: 20px;
   padding-left: 20px;
-}
 
-.navbar-az-fullscreen-mobile-footer-btn > * {
-  pointer-events: none;
-}
+  &:focus-visible {
+    @include border-radius(2px);
+    outline: var(--az-navbar-fullscreen-focus-ring-width) solid var(--az-navbar-fullscreen-focus-ring-color);
+    outline-offset: -2px;
+    box-shadow: none;
+  }
 
-.navbar-az-fullscreen-mobile-footer-btn-text {
-  display: flex;
-  flex-grow: 1;
-  flex-direction: column;
-  padding: 0;
-  text-align: left;
+  .navbar-az-fullscreen-mobile-footer-btn-text {
+    display: flex;
+    flex-grow: 1;
+    flex-direction: column;
+    padding: 0;
+    text-align: left;
+    pointer-events: none;
 
-  > * {
+    .navbar-brand {
+      padding-top: 0;
+      padding-bottom: 0;
+      margin-right: 0;
+      margin-bottom: 4px;
+      pointer-events: none;
+    }
+
+    .more-links-text {
+      font-weight: initial;
+      line-height: 20px;
+      color: var(--bs-white);
+      pointer-events: none;
+    }
+  }
+
+  .navbar-az-fullscreen-mobile-footer-btn-icon {
+    --az-navbar-fullscreen-nav-toggle-size: 38px;
+    --az-navbar-fullscreen-nav-toggle-padding-y: 4px;
+    padding-left: 20px;
     pointer-events: none;
   }
 }

--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -1188,7 +1188,7 @@
     pointer-events: none;
 
     .navbar-brand {
-      --az-navbar-fullscreen-modal-footer-brand-letter-spacing: 0.18px;
+      --az-navbar-fullscreen-modal-footer-brand-letter-spacing: .18px;
       padding-top: 0;
       padding-bottom: 0;
       margin-right: 0;
@@ -1201,7 +1201,7 @@
       font-weight: initial;
       line-height: 20px;
       color: var(--bs-navbar-brand-color);
-      letter-spacing: 0.16px;
+      letter-spacing: .16px;
       pointer-events: none;
     }
   }

--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -1188,6 +1188,7 @@
     pointer-events: none;
 
     .navbar-brand {
+      --az-navbar-fullscreen-modal-footer-brand-letter-spacing: 0.18px;
       padding-top: 0;
       padding-bottom: 0;
       margin-right: 0;
@@ -1200,6 +1201,7 @@
       font-weight: initial;
       line-height: 20px;
       color: var(--bs-navbar-brand-color);
+      letter-spacing: 0.16px;
       pointer-events: none;
     }
   }

--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -1192,13 +1192,14 @@
       padding-bottom: 0;
       margin-right: 0;
       margin-bottom: 4px;
+      color: var(--bs-navbar-brand-color);
       pointer-events: none;
     }
 
     .more-links-text {
       font-weight: initial;
       line-height: 20px;
-      color: var(--bs-white);
+      color: var(--bs-navbar-brand-color);
       pointer-events: none;
     }
   }

--- a/site/content/docs/5.1/components/navbar.md
+++ b/site/content/docs/5.1/components/navbar.md
@@ -878,7 +878,7 @@ The Calls to Action menu provides greater visibility for certain high-value acti
         </div>
       </div>
       <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-        <nav class="navbar" aria-labelledby="resources-for-label">
+        <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
           <div class="container-lg">
               <ul class="navbar-nav">
                 <li class="nav-item">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
@@ -520,7 +520,7 @@ title: AZ Navbar Fullscreen - Home
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+              <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
             </div>
             <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
@@ -575,7 +575,7 @@ title: AZ Navbar Fullscreen - Home
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+              <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>
             </div>
             <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
@@ -519,13 +519,13 @@ title: AZ Navbar Fullscreen - Home
             </div>
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
-            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+            <span class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
-            </div>
-            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+            </span>
+            <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
               <span class="nav-toggle-icon" aria-hidden="true"></span>
-            </div>
+            </span>
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
@@ -574,13 +574,13 @@ title: AZ Navbar Fullscreen - Home
             </div>
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
-            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+            <span class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>
-            </div>
-            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+            </span>
+            <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
               <span class="nav-toggle-icon" aria-hidden="true"></span>
-            </div>
+            </span>
           </button>
         </div>
       </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
@@ -518,7 +518,7 @@ title: AZ Navbar Fullscreen - Home
                 </ul>
             </div>
           </nav>
-          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
@@ -573,7 +573,7 @@ title: AZ Navbar Fullscreen - Home
                 </ul>
             </div>
           </nav>
-          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
@@ -520,7 +520,7 @@ title: AZ Navbar Fullscreen - Home
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <span class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand">Resources For:</h2>
+              <span class="h2 navbar-brand">Resources For:</span>
               <span class="more-links-text"></span>
             </span>
             <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
@@ -575,7 +575,7 @@ title: AZ Navbar Fullscreen - Home
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <span class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand">Helpful Links:</h2>
+              <span class="h2 navbar-brand">Helpful Links:</span>
               <span class="more-links-text"></span>
             </span>
             <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
@@ -474,7 +474,7 @@ title: AZ Navbar Fullscreen - Home
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar" aria-labelledby="resources-for-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
@@ -518,9 +518,18 @@ title: AZ Navbar Fullscreen - Home
                 </ul>
             </div>
           </nav>
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
+            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+              <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+              <span class="more-links-text"></span>
+            </div>
+            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+              <span class="nav-toggle-icon" aria-hidden="true"></span>
+            </div>
+          </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar" aria-labelledby="helpful-links-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="helpful-links-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
@@ -564,6 +573,15 @@ title: AZ Navbar Fullscreen - Home
                 </ul>
             </div>
           </nav>
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
+            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+              <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+              <span class="more-links-text"></span>
+            </div>
+            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+              <span class="nav-toggle-icon" aria-hidden="true"></span>
+            </div>
+          </button>
         </div>
       </div>
     </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
@@ -458,7 +458,7 @@ title: AZ Navbar Fullscreen - Admissions
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar" aria-labelledby="resources-for-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
@@ -492,9 +492,18 @@ title: AZ Navbar Fullscreen - Admissions
                 </ul>
             </div>
           </nav>
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
+            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+              <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+              <span class="more-links-text"></span>
+            </div>
+            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+              <span class="nav-toggle-icon" aria-hidden="true"></span>
+            </div>
+          </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar" aria-labelledby="helpful-links-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="helpful-links-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
@@ -538,6 +547,15 @@ title: AZ Navbar Fullscreen - Admissions
                 </ul>
             </div>
           </nav>
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
+            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+              <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+              <span class="more-links-text"></span>
+            </div>
+            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+              <span class="nav-toggle-icon" aria-hidden="true"></span>
+            </div>
+          </button>
         </div>
       </div>
     </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
@@ -493,13 +493,13 @@ title: AZ Navbar Fullscreen - Admissions
             </div>
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
-            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+            <span class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
-            </div>
-            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+            </span>
+            <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
               <span class="nav-toggle-icon" aria-hidden="true"></span>
-            </div>
+            </span>
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
@@ -548,13 +548,13 @@ title: AZ Navbar Fullscreen - Admissions
             </div>
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
-            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+            <span class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>
-            </div>
-            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+            </span>
+            <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
               <span class="nav-toggle-icon" aria-hidden="true"></span>
-            </div>
+            </span>
           </button>
         </div>
       </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
@@ -492,7 +492,7 @@ title: AZ Navbar Fullscreen - Admissions
                 </ul>
             </div>
           </nav>
-          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
@@ -547,7 +547,7 @@ title: AZ Navbar Fullscreen - Admissions
                 </ul>
             </div>
           </nav>
-          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
@@ -494,7 +494,7 @@ title: AZ Navbar Fullscreen - Admissions
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <span class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand">Resources For:</h2>
+              <span class="h2 navbar-brand">Resources For:</span>
               <span class="more-links-text"></span>
             </span>
             <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
@@ -549,7 +549,7 @@ title: AZ Navbar Fullscreen - Admissions
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <span class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand">Helpful Links:</h2>
+              <span class="h2 navbar-brand">Helpful Links:</span>
               <span class="more-links-text"></span>
             </span>
             <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
@@ -494,7 +494,7 @@ title: AZ Navbar Fullscreen - Admissions
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+              <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
             </div>
             <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
@@ -549,7 +549,7 @@ title: AZ Navbar Fullscreen - Admissions
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+              <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>
             </div>
             <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
@@ -497,7 +497,7 @@ title: AZ Navbar Fullscreen - Apply
                 </ul>
             </div>
           </nav>
-          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
@@ -552,7 +552,7 @@ title: AZ Navbar Fullscreen - Apply
                 </ul>
             </div>
           </nav>
-          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
@@ -499,7 +499,7 @@ title: AZ Navbar Fullscreen - Apply
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <span class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand">Resources For:</h2>
+              <span class="h2 navbar-brand">Resources For:</span>
               <span class="more-links-text"></span>
             </span>
             <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
@@ -554,7 +554,7 @@ title: AZ Navbar Fullscreen - Apply
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <span class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand">Helpful Links:</h2>
+              <span class="h2 navbar-brand">Helpful Links:</span>
               <span class="more-links-text"></span>
             </span>
             <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
@@ -463,7 +463,7 @@ title: AZ Navbar Fullscreen - Apply
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar" aria-labelledby="resources-for-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
@@ -497,9 +497,18 @@ title: AZ Navbar Fullscreen - Apply
                 </ul>
             </div>
           </nav>
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
+            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+              <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+              <span class="more-links-text"></span>
+            </div>
+            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+              <span class="nav-toggle-icon" aria-hidden="true"></span>
+            </div>
+          </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar" aria-labelledby="helpful-links-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="helpful-links-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
@@ -543,6 +552,15 @@ title: AZ Navbar Fullscreen - Apply
                 </ul>
             </div>
           </nav>
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
+            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+              <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+              <span class="more-links-text"></span>
+            </div>
+            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+              <span class="nav-toggle-icon" aria-hidden="true"></span>
+            </div>
+          </button>
         </div>
       </div>
     </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
@@ -499,7 +499,7 @@ title: AZ Navbar Fullscreen - Apply
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+              <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
             </div>
             <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
@@ -554,7 +554,7 @@ title: AZ Navbar Fullscreen - Apply
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+              <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>
             </div>
             <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
@@ -498,13 +498,13 @@ title: AZ Navbar Fullscreen - Apply
             </div>
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
-            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+            <span class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
-            </div>
-            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+            </span>
+            <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
               <span class="nav-toggle-icon" aria-hidden="true"></span>
-            </div>
+            </span>
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
@@ -553,13 +553,13 @@ title: AZ Navbar Fullscreen - Apply
             </div>
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
-            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+            <span class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>
-            </div>
-            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+            </span>
+            <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
               <span class="nav-toggle-icon" aria-hidden="true"></span>
-            </div>
+            </span>
           </button>
         </div>
       </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
@@ -494,7 +494,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <span class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand">Resources For:</h2>
+              <span class="h2 navbar-brand">Resources For:</span>
               <span class="more-links-text"></span>
             </span>
             <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
@@ -549,7 +549,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <span class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand">Helpful Links:</h2>
+              <span class="h2 navbar-brand">Helpful Links:</span>
               <span class="more-links-text"></span>
             </span>
             <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
@@ -494,7 +494,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+              <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
             </div>
             <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
@@ -549,7 +549,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+              <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>
             </div>
             <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
@@ -458,7 +458,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar" aria-labelledby="resources-for-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
@@ -492,9 +492,18 @@ title: AZ Navbar Fullscreen - Calendar & Events
                 </ul>
             </div>
           </nav>
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
+            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+              <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+              <span class="more-links-text"></span>
+            </div>
+            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+              <span class="nav-toggle-icon" aria-hidden="true"></span>
+            </div>
+          </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar" aria-labelledby="helpful-links-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="helpful-links-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
@@ -538,6 +547,15 @@ title: AZ Navbar Fullscreen - Calendar & Events
                 </ul>
             </div>
           </nav>
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
+            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+              <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+              <span class="more-links-text"></span>
+            </div>
+            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+              <span class="nav-toggle-icon" aria-hidden="true"></span>
+            </div>
+          </button>
         </div>
       </div>
     </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
@@ -493,13 +493,13 @@ title: AZ Navbar Fullscreen - Calendar & Events
             </div>
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
-            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+            <span class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
-            </div>
-            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+            </span>
+            <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
               <span class="nav-toggle-icon" aria-hidden="true"></span>
-            </div>
+            </span>
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
@@ -548,13 +548,13 @@ title: AZ Navbar Fullscreen - Calendar & Events
             </div>
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
-            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+            <span class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>
-            </div>
-            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+            </span>
+            <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
               <span class="nav-toggle-icon" aria-hidden="true"></span>
-            </div>
+            </span>
           </button>
         </div>
       </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
@@ -492,7 +492,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
                 </ul>
             </div>
           </nav>
-          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
@@ -547,7 +547,7 @@ title: AZ Navbar Fullscreen - Calendar & Events
                 </ul>
             </div>
           </nav>
-          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
@@ -458,7 +458,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar" aria-labelledby="resources-for-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
@@ -492,9 +492,18 @@ title: AZ Navbar Fullscreen - Campus Recreation
                 </ul>
             </div>
           </nav>
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
+            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+              <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+              <span class="more-links-text"></span>
+            </div>
+            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+              <span class="nav-toggle-icon" aria-hidden="true"></span>
+            </div>
+          </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar" aria-labelledby="helpful-links-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="helpful-links-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
@@ -538,6 +547,15 @@ title: AZ Navbar Fullscreen - Campus Recreation
                 </ul>
             </div>
           </nav>
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
+            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+              <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+              <span class="more-links-text"></span>
+            </div>
+            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+              <span class="nav-toggle-icon" aria-hidden="true"></span>
+            </div>
+          </button>
         </div>
       </div>
     </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
@@ -492,7 +492,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
                 </ul>
             </div>
           </nav>
-          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
@@ -547,7 +547,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
                 </ul>
             </div>
           </nav>
-          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
@@ -494,7 +494,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <span class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand">Resources For:</h2>
+              <span class="h2 navbar-brand">Resources For:</span>
               <span class="more-links-text"></span>
             </span>
             <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
@@ -549,7 +549,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <span class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand">Helpful Links:</h2>
+              <span class="h2 navbar-brand">Helpful Links:</span>
               <span class="more-links-text"></span>
             </span>
             <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
@@ -494,7 +494,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+              <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
             </div>
             <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
@@ -549,7 +549,7 @@ title: AZ Navbar Fullscreen - Campus Recreation
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+              <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>
             </div>
             <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
@@ -493,13 +493,13 @@ title: AZ Navbar Fullscreen - Campus Recreation
             </div>
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
-            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+            <span class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
-            </div>
-            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+            </span>
+            <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
               <span class="nav-toggle-icon" aria-hidden="true"></span>
-            </div>
+            </span>
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
@@ -548,13 +548,13 @@ title: AZ Navbar Fullscreen - Campus Recreation
             </div>
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
-            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+            <span class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>
-            </div>
-            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+            </span>
+            <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
               <span class="nav-toggle-icon" aria-hidden="true"></span>
-            </div>
+            </span>
           </button>
         </div>
       </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
@@ -494,7 +494,7 @@ title: AZ Navbar Fullscreen - Business or Partner
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+              <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
             </div>
             <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
@@ -549,7 +549,7 @@ title: AZ Navbar Fullscreen - Business or Partner
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+              <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>
             </div>
             <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
@@ -458,7 +458,7 @@ title: AZ Navbar Fullscreen - Business or Partner
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar" aria-labelledby="resources-for-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
@@ -492,9 +492,18 @@ title: AZ Navbar Fullscreen - Business or Partner
                 </ul>
             </div>
           </nav>
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
+            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+              <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+              <span class="more-links-text"></span>
+            </div>
+            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+              <span class="nav-toggle-icon" aria-hidden="true"></span>
+            </div>
+          </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar" aria-labelledby="helpful-links-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="helpful-links-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
@@ -538,6 +547,15 @@ title: AZ Navbar Fullscreen - Business or Partner
                 </ul>
             </div>
           </nav>
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
+            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+              <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+              <span class="more-links-text"></span>
+            </div>
+            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+              <span class="nav-toggle-icon" aria-hidden="true"></span>
+            </div>
+          </button>
         </div>
       </div>
     </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
@@ -492,7 +492,7 @@ title: AZ Navbar Fullscreen - Business or Partner
                 </ul>
             </div>
           </nav>
-          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
@@ -547,7 +547,7 @@ title: AZ Navbar Fullscreen - Business or Partner
                 </ul>
             </div>
           </nav>
-          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
@@ -494,7 +494,7 @@ title: AZ Navbar Fullscreen - Business or Partner
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <span class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand">Resources For:</h2>
+              <span class="h2 navbar-brand">Resources For:</span>
               <span class="more-links-text"></span>
             </span>
             <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
@@ -549,7 +549,7 @@ title: AZ Navbar Fullscreen - Business or Partner
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <span class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand">Helpful Links:</h2>
+              <span class="h2 navbar-brand">Helpful Links:</span>
               <span class="more-links-text"></span>
             </span>
             <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
@@ -493,13 +493,13 @@ title: AZ Navbar Fullscreen - Business or Partner
             </div>
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
-            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+            <span class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
-            </div>
-            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+            </span>
+            <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
               <span class="nav-toggle-icon" aria-hidden="true"></span>
-            </div>
+            </span>
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
@@ -548,13 +548,13 @@ title: AZ Navbar Fullscreen - Business or Partner
             </div>
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
-            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+            <span class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>
-            </div>
-            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+            </span>
+            <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
               <span class="nav-toggle-icon" aria-hidden="true"></span>
-            </div>
+            </span>
           </button>
         </div>
       </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/phonebook/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/phonebook/_index.html
@@ -494,7 +494,7 @@ title: AZ Navbar Fullscreen - Phonebook
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+              <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
             </div>
             <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
@@ -549,7 +549,7 @@ title: AZ Navbar Fullscreen - Phonebook
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+              <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>
             </div>
             <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/phonebook/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/phonebook/_index.html
@@ -492,7 +492,7 @@ title: AZ Navbar Fullscreen - Phonebook
                 </ul>
             </div>
           </nav>
-          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
@@ -547,7 +547,7 @@ title: AZ Navbar Fullscreen - Phonebook
                 </ul>
             </div>
           </nav>
-          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/phonebook/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/phonebook/_index.html
@@ -493,13 +493,13 @@ title: AZ Navbar Fullscreen - Phonebook
             </div>
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
-            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+            <span class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
-            </div>
-            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+            </span>
+            <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
               <span class="nav-toggle-icon" aria-hidden="true"></span>
-            </div>
+            </span>
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
@@ -548,13 +548,13 @@ title: AZ Navbar Fullscreen - Phonebook
             </div>
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
-            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+            <span class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>
-            </div>
-            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+            </span>
+            <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
               <span class="nav-toggle-icon" aria-hidden="true"></span>
-            </div>
+            </span>
           </button>
         </div>
       </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/phonebook/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/phonebook/_index.html
@@ -494,7 +494,7 @@ title: AZ Navbar Fullscreen - Phonebook
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <span class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand">Resources For:</h2>
+              <span class="h2 navbar-brand">Resources For:</span>
               <span class="more-links-text"></span>
             </span>
             <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
@@ -549,7 +549,7 @@ title: AZ Navbar Fullscreen - Phonebook
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <span class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand">Helpful Links:</h2>
+              <span class="h2 navbar-brand">Helpful Links:</span>
               <span class="more-links-text"></span>
             </span>
             <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/phonebook/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/phonebook/_index.html
@@ -458,7 +458,7 @@ title: AZ Navbar Fullscreen - Phonebook
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar" aria-labelledby="resources-for-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
@@ -492,9 +492,18 @@ title: AZ Navbar Fullscreen - Phonebook
                 </ul>
             </div>
           </nav>
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
+            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+              <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+              <span class="more-links-text"></span>
+            </div>
+            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+              <span class="nav-toggle-icon" aria-hidden="true"></span>
+            </div>
+          </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar" aria-labelledby="helpful-links-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="helpful-links-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
@@ -538,6 +547,15 @@ title: AZ Navbar Fullscreen - Phonebook
                 </ul>
             </div>
           </nav>
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
+            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+              <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+              <span class="more-links-text"></span>
+            </div>
+            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+              <span class="nav-toggle-icon" aria-hidden="true"></span>
+            </div>
+          </button>
         </div>
       </div>
     </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
@@ -498,7 +498,7 @@ title: AZ Navbar Fullscreen - Tuition & Aid
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar" aria-labelledby="resources-for-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
@@ -532,9 +532,18 @@ title: AZ Navbar Fullscreen - Tuition & Aid
                 </ul>
             </div>
           </nav>
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
+            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+              <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+              <span class="more-links-text"></span>
+            </div>
+            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+              <span class="nav-toggle-icon" aria-hidden="true"></span>
+            </div>
+          </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar" aria-labelledby="helpful-links-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="helpful-links-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
@@ -578,6 +587,15 @@ title: AZ Navbar Fullscreen - Tuition & Aid
                 </ul>
             </div>
           </nav>
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
+            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+              <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+              <span class="more-links-text"></span>
+            </div>
+            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+              <span class="nav-toggle-icon" aria-hidden="true"></span>
+            </div>
+          </button>
         </div>
       </div>
     </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
@@ -533,13 +533,13 @@ title: AZ Navbar Fullscreen - Tuition & Aid
             </div>
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
-            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+            <span class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
-            </div>
-            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+            </span>
+            <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
               <span class="nav-toggle-icon" aria-hidden="true"></span>
-            </div>
+            </span>
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
@@ -588,13 +588,13 @@ title: AZ Navbar Fullscreen - Tuition & Aid
             </div>
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
-            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+            <span class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>
-            </div>
-            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+            </span>
+            <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
               <span class="nav-toggle-icon" aria-hidden="true"></span>
-            </div>
+            </span>
           </button>
         </div>
       </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
@@ -534,7 +534,7 @@ title: AZ Navbar Fullscreen - Tuition & Aid
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <span class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand">Resources For:</h2>
+              <span class="h2 navbar-brand">Resources For:</span>
               <span class="more-links-text"></span>
             </span>
             <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
@@ -589,7 +589,7 @@ title: AZ Navbar Fullscreen - Tuition & Aid
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <span class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand">Helpful Links:</h2>
+              <span class="h2 navbar-brand">Helpful Links:</span>
               <span class="more-links-text"></span>
             </span>
             <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
@@ -534,7 +534,7 @@ title: AZ Navbar Fullscreen - Tuition & Aid
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+              <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
             </div>
             <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
@@ -589,7 +589,7 @@ title: AZ Navbar Fullscreen - Tuition & Aid
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+              <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>
             </div>
             <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
@@ -532,7 +532,7 @@ title: AZ Navbar Fullscreen - Tuition & Aid
                 </ul>
             </div>
           </nav>
-          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
@@ -587,7 +587,7 @@ title: AZ Navbar Fullscreen - Tuition & Aid
                 </ul>
             </div>
           </nav>
-          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
@@ -494,7 +494,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <span class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand">Resources For:</h2>
+              <span class="h2 navbar-brand">Resources For:</span>
               <span class="more-links-text"></span>
             </span>
             <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
@@ -549,7 +549,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <span class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand">Helpful Links:</h2>
+              <span class="h2 navbar-brand">Helpful Links:</span>
               <span class="more-links-text"></span>
             </span>
             <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
@@ -458,7 +458,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar" aria-labelledby="resources-for-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
@@ -492,9 +492,18 @@ title: AZ Navbar Fullscreen - Undergraduate Students
                 </ul>
             </div>
           </nav>
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
+            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+              <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+              <span class="more-links-text"></span>
+            </div>
+            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+              <span class="nav-toggle-icon" aria-hidden="true"></span>
+            </div>
+          </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar" aria-labelledby="helpful-links-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="helpful-links-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
@@ -538,6 +547,15 @@ title: AZ Navbar Fullscreen - Undergraduate Students
                 </ul>
             </div>
           </nav>
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
+            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+              <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+              <span class="more-links-text"></span>
+            </div>
+            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+              <span class="nav-toggle-icon" aria-hidden="true"></span>
+            </div>
+          </button>
         </div>
       </div>
     </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
@@ -493,13 +493,13 @@ title: AZ Navbar Fullscreen - Undergraduate Students
             </div>
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
-            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+            <span class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
-            </div>
-            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+            </span>
+            <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
               <span class="nav-toggle-icon" aria-hidden="true"></span>
-            </div>
+            </span>
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
@@ -548,13 +548,13 @@ title: AZ Navbar Fullscreen - Undergraduate Students
             </div>
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
-            <div class="navbar-az-fullscreen-mobile-footer-btn-text">
+            <span class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>
-            </div>
-            <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
+            </span>
+            <span class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
               <span class="nav-toggle-icon" aria-hidden="true"></span>
-            </div>
+            </span>
           </button>
         </div>
       </div>

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
@@ -494,7 +494,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+              <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
             </div>
             <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">
@@ -549,7 +549,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
           </nav>
           <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
-              <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+              <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>
             </div>
             <div class="nav-toggle collapsed navbar-az-fullscreen-mobile-footer-btn-icon">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
@@ -492,7 +492,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
                 </ul>
             </div>
           </nav>
-          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Resources For submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-top">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Resources For:</h2>
               <span class="more-links-text"></span>
@@ -547,7 +547,7 @@ title: AZ Navbar Fullscreen - Undergraduate Students
                 </ul>
             </div>
           </nav>
-          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
+          <button type="button" class="btn navbar navbar-az-fullscreen-mobile-footer-btn d-lg-none" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle Helpful Links submenu" data-az-menu-element="#navbar-az-fullscreen-modal-footer-bottom">
             <div class="navbar-az-fullscreen-mobile-footer-btn-text">
               <h2 class="navbar-brand">Helpful Links:</h2>
               <span class="more-links-text"></span>


### PR DESCRIPTION
## Changes
- Mobile: Updates the footers to have a single button for each footer instead of two. Some elements have been moved to the example HTML instead of being created by the JavaScript. (In Quickstart, these elements will be added in the AZ Navbar Fullscreen twig template.)
- Mobile: Updates styling of the footers to match the [mockups](https://xd.adobe.com/view/534efc74-d9f1-4c48-b286-815f5e95f08a-061d/grid).
- Mobile: Adds a focus visible styling for the footer button.
- Mobile: Reduces the number of resources / helpful links included in the "and more..." text from 3 to 2.

## Related issue
 - #2074

## Follow-ups

1. Fix focus styling for mobile "Back to..." button

## How to test

1. Visit https://review.digital.arizona.edu/arizona-bootstrap/issue/2074/docs/5.1/examples/navbar-az-fullscreen/.
2. On desktop, compare the changes with the [main branch](https://review.digital.arizona.edu/arizona-bootstrap/main/docs/5.1/examples/navbar-az-fullscreen/) and confirm that there are no changes.
3. Simulating a mobile device, confirm that the footers in the mobile display look and function as expected. In particular, you can test:
   - Confirm that each footer is now a single button.
   - Confirm that the focus visible styling for each footer button is appropriate.
   - Confirm that the "...and more" text in each footer is limited to two menu items instead of three.
   - Confirm that the footer styling matches the [mockups](https://xd.adobe.com/view/534efc74-d9f1-4c48-b286-815f5e95f08a-061d/grid).


