### PR TITLE
Fixes #2164: AZ Navbar Fullscreen (mobile): Correct search icon width in the non-modal instance

### DIFF
--- a/scss/custom/_search.scss
+++ b/scss/custom/_search.scss
@@ -41,6 +41,7 @@
     overflow: visible;
 
     .btn {
+      min-width: var(--az-search-height);
       padding: var(--az-search-btn-padding);
       border-width: var(--az-search-border-width);
     }
@@ -101,7 +102,6 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-width: var(--az-search-height);
     margin: 0;
     color: var(--az-search-color);
     border: var(--az-search-border-width) solid var(--az-search-border-color);


### PR DESCRIPTION
In #2124, the mobile non-modal search icon width regressed from 45px to 60px. The root cause is a CSS specificity conflict in `_search.scss`: `min-width: var(--az-search-height)` was applied to all `.az-search .btn` elements, including the standalone `.navbar-toggler-search` mobile toggle button. Because `.navbar-az-fullscreen .az-search` sets `--az-search-height: 60px` at desktop with specificity `(0,2,0)` — higher than the mobile override's `(0,1,0)` — the variable resolved to `60px` on mobile, making the toggle button 60×45px instead of the expected 45×45px.

## Proposed resolution

Scope `min-width: var(--az-search-height)` to `.az-search .input-group .btn` only. This confines the rule to the expanded search form's submit button (where squareness is intentional) and leaves the standalone mobile toggle button sized by its content (icon + padding = 45×45px).

## How to test
[Review site](https://review.digital.arizona.edu/arizona-bootstrap/issue/2164/)

1. Navigate to [AZ Navbar Fullscreen](https://review.digital.arizona.edu/arizona-bootstrap/issue/2164/docs/5.1/examples/navbar-az-fullscreen/) example pages at `/docs/5.1/examples/navbar-az-fullscreen/`.
2. Verify that `.az-search .input-group .btn`(button of the search/magnifying glass icon) remains 60x60px in the non-modal and modal views.
3. Simulate or view on a mobile device and verify that `.navbar-toggler-search` (button of the search icon) is 45x45px in the non-modal view.
4. Simulate or view on a mobile device and verify that `.az-search .input-group .btn` (button of search icon) remains the previously accepted 59x51px in the modal view.
5. Verify no changes in [AZ Search documentation](https://review.digital.arizona.edu/arizona-bootstrap/issue/2164/docs/5.1/components/search/) at `/docs/5.1/components/search`.

## Possible Follow ups

1. Should the search icon button be square-like in the mobile, modal context?
2. Should AZ Search adopt the styling of AZ Navbar Fullscreen when at a mobile breakpoint?

Fixes #2164 
