### PR TITLE
Closes #2166: AZ Navbar Fullscreen (mobile): Fix regression with container padding

### DIFF
--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -792,7 +792,8 @@
     }
 
     .container-lg {
-      padding: 2px 20px;
+      padding-right: 20px;
+      padding-left: 20px;
     }
 
     .navbar-az-fullscreen-modal-menu.container-lg {


### PR DESCRIPTION
## Changes
- Mobile: Revert incorrect padding change for `.navbar-az-fullscreen-modal .container-lg` from #2156

## Related issue
 - #2166

## How to test

1. Visit https://review.digital.arizona.edu/arizona-bootstrap/bug/2166/docs/5.1/examples/navbar-az-fullscreen/.
2. Simulating a mobile device, confirm that the height of the header does not change when opening and closing the modal. Extra top and bottom padding is also removed from the nav menu in the modal. Compare with the incorrect behavior here: https://review.digital.arizona.edu/arizona-bootstrap/main/docs/5.1/examples/navbar-az-fullscreen/


