### PR TITLE
Closes #2180: AZ Navbar Fullscreen: Refine focus states on desktop

### DIFF
--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -418,7 +418,6 @@
     border: 0;
     @include border-radius(0);
 
-    &:focus,
     &:focus-visible {
       @include border-radius(2px);
       outline: var(--az-navbar-fullscreen-focus-ring-width) solid var(--az-navbar-fullscreen-focus-ring-color);
@@ -456,7 +455,6 @@
     position: relative;
     padding-left: var(--az-navbar-fullscreen-nav-toggle-separator-offset);
 
-    &:focus::before,
     &:focus-visible::before {
       background-color: transparent;
     }

--- a/scss/custom/_search.scss
+++ b/scss/custom/_search.scss
@@ -84,7 +84,6 @@
       mask-size: contain;
     }
 
-    &:focus,
     &:focus-visible {
       border-color: var(--az-search-focus-ring-color);
       outline: 0;
@@ -102,7 +101,6 @@
     border: var(--az-search-border-width) solid var(--az-search-border-color);
     border-left: 0;
 
-    &:focus,
     &:focus-visible,
     &:active {
       border-color: var(--az-search-focus-ring-color);


### PR DESCRIPTION
## Changes
 - Removes focus styles from `.nav-toggle` buttons. Now the buttons will only display a focus ring with keyboard navigation.
 - Removes focus styles from the search `<input>` element. This change has no effect: clicking on an input element automatically applies both :focus and :focus-visible. Currently, I don't believe there is a solution to having different behavior on a mouse click versus navigating to the input field by keyboard. I propose removing the :focus style anyway since that was our intention and perhaps we can find a solution in the future.

## Related issue
 - #2180 

## How to test

1. Visit https://review.digital.arizona.edu/arizona-bootstrap/issue/2180/docs/5.1/examples/navbar-az-fullscreen/.
2. Compare the changes with the [main branch](https://review.digital.arizona.edu/arizona-bootstrap/main/docs/5.1/examples/navbar-az-fullscreen/) and confirm that the focus ring has been removed when clicking on the buttons to expand/collapse the secondary and tertiary menus.
3. Confirm that there are no other changes related to the nav toggle buttons or search input field with desktop and mobile devices.