### PR TITLE
Closes #2088: AZ Navbar Fullscreen (mobile): Improve detection of active menu item

### DIFF
--- a/js/src/navbar-az-fullscreen-mobile-nav.js
+++ b/js/src/navbar-az-fullscreen-mobile-nav.js
@@ -53,6 +53,11 @@ class NavbarAzFullscreenMobileNav {
     this.initialMenuParentLabel = null
     this.initialMenuParentElementId = null
 
+    // Initialize window location variable
+    this.cleanWindowLocation = new URL(window.location.href)
+    this.cleanWindowLocation.search = ''
+    this.cleanWindowLocation.hash = ''
+
     this.init()
   }
 
@@ -75,7 +80,7 @@ class NavbarAzFullscreenMobileNav {
     // Check active tertiary links for a match with the current pathname
     const activeTertiaryLinks = document.querySelectorAll('.navbar-az-fullscreen-nav-tertiary a.nav-link.active')
     for (const link of activeTertiaryLinks) {
-      if (link.href === window.location.href) {
+      if (link.href === this.cleanWindowLocation.href) {
         const tertiaryPanel = link.closest('.navbar-az-fullscreen-modal-menu-secondary-submenu')
         if (!tertiaryPanel) {
           continue
@@ -97,7 +102,7 @@ class NavbarAzFullscreenMobileNav {
     if (!activeLinkFound) {
       const activeSecondaryLinks = document.querySelectorAll('.navbar-az-fullscreen-modal-menu-nav-col-secondary a.nav-link.active')
       for (const link of activeSecondaryLinks) {
-        if (link.href === window.location.href) {
+        if (link.href === this.cleanWindowLocation.href) {
           const secondaryContent = link.closest('.navbar-az-fullscreen-modal-menu-primary-submenu.show')
           const targetId = secondaryContent?.getAttribute('id') || ''
           const label = link.closest('.navbar-az-fullscreen-nav-secondary')?.getAttribute('aria-label') || ''
@@ -170,7 +175,7 @@ class NavbarAzFullscreenMobileNav {
     const footerLinksProperty = footerPosition === 'top' ? 'topFooterLinks' : 'bottomFooterLinks'
     let found = false
     this[footerLinksProperty] = Array.from(document.querySelectorAll(`#${footer.id} .nav-link`)).map(link => {
-      if (!activeLinkFound && !found && link.href === window.location.href) {
+      if (!activeLinkFound && !found && link.href === this.cleanWindowLocation.href) {
         found = true
       }
 
@@ -393,7 +398,7 @@ class NavbarAzFullscreenMobileNav {
 
         const anchor = document.createElement('a')
         anchor.className = 'nav-link'
-        if (link.href === window.location.href) {
+        if (link.href === this.cleanWindowLocation.href) {
           anchor.classList.add('active')
         }
 


### PR DESCRIPTION
## Changes

- Mobile: The JavaScript for determining if a menu link is an active link now matches against a clean browser URL that has had all anchors and query parameters removed.

## Related issue
 - #2088

## How to test

1. To first see the issue, simulate a mobile device and go to these URLs from the main branch:
   - https://review.digital.arizona.edu/arizona-bootstrap/main/docs/5.1/examples/navbar-az-fullscreen/partner/#
   - https://review.digital.arizona.edu/arizona-bootstrap/main/docs/5.1/examples/navbar-az-fullscreen/partner/?foo=bar
2. Still simulating a mobile device, go to the example pages for this PR and confirm that the active menu link is correctly indicated as "Business or Partner":
   -  https://review.digital.arizona.edu/arizona-bootstrap/issue/2088/docs/5.1/examples/navbar-az-fullscreen/partner/#
   -  https://review.digital.arizona.edu/arizona-bootstrap/issue/2088/docs/5.1/examples/navbar-az-fullscreen/partner/?foo=bar
 3. Test with other pages as appropriate.
