### PR TITLE
Closes #2174: Expose --az-navbar-fullscreen-height at :root for page-level layout rules

### DIFF
--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -1,7 +1,10 @@
-// Experimental custom az-fullscreen navbar
-.navbar-az-fullscreen {
+:root {
   // scss-docs-start navbar-az-fullscreen-css-vars
   --az-navbar-fullscreen-height: 100px;
+}
+
+// Experimental custom az-fullscreen navbar
+.navbar-az-fullscreen {
   --az-navbar-fullscreen-bg: var(--bs-blue);
   --az-navbar-fullscreen-bottom-border-color: var(--bs-red);
   --az-navbar-fullscreen-bottom-border-width: 3px;
@@ -95,11 +98,7 @@
 
 // Optional helper to offset content when using `.fixed-top` with fullscreen navbar.
 .navbar-az-fullscreen-fixed-top-offset {
-  padding-top: 100px;
-
-  @include media-breakpoint-down(lg) {
-    padding-top: 69px;
-  }
+  padding-top: var(--az-navbar-fullscreen-height);
 }
 
 .navbar-az-fullscreen-actions {
@@ -761,8 +760,11 @@
 
 /* Mobile Nav styling */
 @include media-breakpoint-down(lg) {
-  .navbar-az-fullscreen {
+  :root {
     --az-navbar-fullscreen-height: 69px;
+  }
+
+  .navbar-az-fullscreen {
     --az-navbar-fullscreen-brand-height: 45px;
     --az-navbar-fullscreen-toggler-icon-size: 24px;
     --bs-navbar-brand-padding-x: 12px;

--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -1,5 +1,5 @@
+// scss-docs-start navbar-az-fullscreen-css-vars
 :root {
-  // scss-docs-start navbar-az-fullscreen-css-vars
   --az-navbar-fullscreen-height: 100px;
 }
 

--- a/site/content/docs/5.1/components/navbar.md
+++ b/site/content/docs/5.1/components/navbar.md
@@ -969,7 +969,7 @@ Because fixed navbars are removed from normal document flow, also add `.navbar-a
 ### CSS Variables
 The following properties are set and used:
 
-On the `.navbar-az-fullscreen` custom class:
+The `--az-navbar-fullscreen-height` token is available globally on `:root` for page-level layout rules such as fixed-top content offsets. The remaining fullscreen navbar variables continue to be scoped to the `.navbar-az-fullscreen` custom class.
 
 {{< scss-docs name="navbar-az-fullscreen-css-vars" file="custom/_navbar-fullscreen.scss" scssroot="scss" >}}
 


### PR DESCRIPTION
## Changes

- Move `--az-navbar-fullscreen-height` to `:root`, with the existing responsive mobile override preserved.
Reason why: this makes the token available outside `.navbar-az-fullscreen`, which is required for page-level spacing rules such as `body` or main-content offsets.

- Update `.navbar-az-fullscreen-fixed-top-offset` to use `var(--az-navbar-fullscreen-height)` instead of hard-coded `100px` and `69px` values.
Reason why: this removes duplicated height values and keeps the helper aligned with the actual navbar token across breakpoints.

- Keep the remaining fullscreen navbar CSS variables scoped to `.navbar-az-fullscreen`.
Reason why: the issue only calls for exposing the height token globally, so this keeps the public token surface narrow and avoids widening component API unnecessarily.

- Refresh the fullscreen navbar docs text to clarify that `--az-navbar-fullscreen-height` is global, while the rest of the fullscreen navbar variables remain component-scoped.
Reason why: without the docs update, the current CSS variable section would describe the scope incorrectly.

## How to test
[Review site](https://review.digital.arizona.edu/arizona-bootstrap/issue/2174/)

1. Confirm no change to [AZ Navbar Fullscreen](https://review.digital.arizona.edu/arizona-bootstrap/issue/2174/docs/5.1/examples/navbar-az-fullscreen/). The [Campus Recreation](https://review.digital.arizona.edu/arizona-bootstrap/issue/2174/docs/5.1/examples/navbar-az-fullscreen/campus-rec/) page intentionally has a lengthy page to test the fixed navbar behavior.
2. Verify updated [docs subsection](https://review.digital.arizona.edu/arizona-bootstrap/issue/2174/docs/5.1/components/navbar/#css-variables) related to this root-level variable.
