### PR TITLE
Closes #2201: AZ Navbar Fullscreen: Make footer IDs generic for customizable footer headings

### DIFF
--- a/site/content/docs/5.1/components/navbar.md
+++ b/site/content/docs/5.1/components/navbar.md
@@ -883,11 +883,11 @@ For standalone usage and full component guidance, see [Search]({{< docsref "/com
         </div>
       </div>
       <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-        <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
+        <nav class="navbar d-none d-lg-flex" aria-labelledby="navbar-az-fullscreen-modal-footer-top-label">
           <div class="container-lg">
               <ul class="navbar-nav">
                 <li class="nav-item">
-                  <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
+                  <h2 class="navbar-brand" id="navbar-az-fullscreen-modal-footer-top-label">Resources For:</h2>
                 </li>
                 <li class="nav-item">
                   <a class="nav-link" href="#">

--- a/site/content/docs/5.1/components/navbar.md
+++ b/site/content/docs/5.1/components/navbar.md
@@ -883,11 +883,11 @@ For standalone usage and full component guidance, see [Search]({{< docsref "/com
         </div>
       </div>
       <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-        <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
+        <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
           <div class="container-lg">
               <ul class="navbar-nav">
                 <li class="nav-item">
-                  <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+                  <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
                 </li>
                 <li class="nav-item">
                   <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
@@ -474,11 +474,11 @@ title: AZ Navbar Fullscreen - Home
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="navbar-az-fullscreen-modal-footer-top-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
+                    <h2 class="navbar-brand" id="navbar-az-fullscreen-modal-footer-top-label">Resources For:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">
@@ -528,11 +528,11 @@ title: AZ Navbar Fullscreen - Home
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-bottom-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="navbar-az-fullscreen-modal-footer-bottom-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="footer-bottom-label">Helpful Links:</h2>
+                    <h2 class="navbar-brand" id="navbar-az-fullscreen-modal-footer-bottom-label">Helpful Links:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
@@ -474,11 +474,11 @@ title: AZ Navbar Fullscreen - Home
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+                    <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html
@@ -528,11 +528,11 @@ title: AZ Navbar Fullscreen - Home
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="helpful-links-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-bottom-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+                    <h2 class="navbar-brand" id="footer-bottom-label">Helpful Links:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
@@ -458,11 +458,11 @@ title: AZ Navbar Fullscreen - Admissions
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="navbar-az-fullscreen-modal-footer-top-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
+                    <h2 class="navbar-brand" id="navbar-az-fullscreen-modal-footer-top-label">Resources For:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">
@@ -502,11 +502,11 @@ title: AZ Navbar Fullscreen - Admissions
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-bottom-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="navbar-az-fullscreen-modal-footer-bottom-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="footer-bottom-label">Helpful Links:</h2>
+                    <h2 class="navbar-brand" id="navbar-az-fullscreen-modal-footer-bottom-label">Helpful Links:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
@@ -502,11 +502,11 @@ title: AZ Navbar Fullscreen - Admissions
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="helpful-links-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-bottom-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+                    <h2 class="navbar-brand" id="footer-bottom-label">Helpful Links:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/admissions/_index.html
@@ -458,11 +458,11 @@ title: AZ Navbar Fullscreen - Admissions
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+                    <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
@@ -463,11 +463,11 @@ title: AZ Navbar Fullscreen - Apply
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+                    <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
@@ -507,11 +507,11 @@ title: AZ Navbar Fullscreen - Apply
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="helpful-links-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-bottom-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+                    <h2 class="navbar-brand" id="footer-bottom-label">Helpful Links:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
@@ -463,11 +463,11 @@ title: AZ Navbar Fullscreen - Apply
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="navbar-az-fullscreen-modal-footer-top-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
+                    <h2 class="navbar-brand" id="navbar-az-fullscreen-modal-footer-top-label">Resources For:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">
@@ -507,11 +507,11 @@ title: AZ Navbar Fullscreen - Apply
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-bottom-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="navbar-az-fullscreen-modal-footer-bottom-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="footer-bottom-label">Helpful Links:</h2>
+                    <h2 class="navbar-brand" id="navbar-az-fullscreen-modal-footer-bottom-label">Helpful Links:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
@@ -458,11 +458,11 @@ title: AZ Navbar Fullscreen - Calendar & Events
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+                    <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
@@ -502,11 +502,11 @@ title: AZ Navbar Fullscreen - Calendar & Events
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="helpful-links-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-bottom-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+                    <h2 class="navbar-brand" id="footer-bottom-label">Helpful Links:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/calendar/_index.html
@@ -458,11 +458,11 @@ title: AZ Navbar Fullscreen - Calendar & Events
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="navbar-az-fullscreen-modal-footer-top-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
+                    <h2 class="navbar-brand" id="navbar-az-fullscreen-modal-footer-top-label">Resources For:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">
@@ -502,11 +502,11 @@ title: AZ Navbar Fullscreen - Calendar & Events
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-bottom-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="navbar-az-fullscreen-modal-footer-bottom-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="footer-bottom-label">Helpful Links:</h2>
+                    <h2 class="navbar-brand" id="navbar-az-fullscreen-modal-footer-bottom-label">Helpful Links:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
@@ -458,11 +458,11 @@ title: AZ Navbar Fullscreen - Campus Recreation
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="navbar-az-fullscreen-modal-footer-top-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
+                    <h2 class="navbar-brand" id="navbar-az-fullscreen-modal-footer-top-label">Resources For:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">
@@ -502,11 +502,11 @@ title: AZ Navbar Fullscreen - Campus Recreation
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-bottom-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="navbar-az-fullscreen-modal-footer-bottom-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="footer-bottom-label">Helpful Links:</h2>
+                    <h2 class="navbar-brand" id="navbar-az-fullscreen-modal-footer-bottom-label">Helpful Links:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
@@ -458,11 +458,11 @@ title: AZ Navbar Fullscreen - Campus Recreation
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+                    <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/campus-rec/_index.html
@@ -502,11 +502,11 @@ title: AZ Navbar Fullscreen - Campus Recreation
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="helpful-links-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-bottom-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+                    <h2 class="navbar-brand" id="footer-bottom-label">Helpful Links:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
@@ -502,11 +502,11 @@ title: AZ Navbar Fullscreen - Business or Partner
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="helpful-links-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-bottom-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+                    <h2 class="navbar-brand" id="footer-bottom-label">Helpful Links:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
@@ -458,11 +458,11 @@ title: AZ Navbar Fullscreen - Business or Partner
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="navbar-az-fullscreen-modal-footer-top-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
+                    <h2 class="navbar-brand" id="navbar-az-fullscreen-modal-footer-top-label">Resources For:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">
@@ -502,11 +502,11 @@ title: AZ Navbar Fullscreen - Business or Partner
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-bottom-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="navbar-az-fullscreen-modal-footer-bottom-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="footer-bottom-label">Helpful Links:</h2>
+                    <h2 class="navbar-brand" id="navbar-az-fullscreen-modal-footer-bottom-label">Helpful Links:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/partner/_index.html
@@ -458,11 +458,11 @@ title: AZ Navbar Fullscreen - Business or Partner
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+                    <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/phonebook/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/phonebook/_index.html
@@ -458,11 +458,11 @@ title: AZ Navbar Fullscreen - Phonebook
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+                    <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/phonebook/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/phonebook/_index.html
@@ -458,11 +458,11 @@ title: AZ Navbar Fullscreen - Phonebook
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="navbar-az-fullscreen-modal-footer-top-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
+                    <h2 class="navbar-brand" id="navbar-az-fullscreen-modal-footer-top-label">Resources For:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">
@@ -502,11 +502,11 @@ title: AZ Navbar Fullscreen - Phonebook
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-bottom-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="navbar-az-fullscreen-modal-footer-bottom-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="footer-bottom-label">Helpful Links:</h2>
+                    <h2 class="navbar-brand" id="navbar-az-fullscreen-modal-footer-bottom-label">Helpful Links:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/phonebook/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/phonebook/_index.html
@@ -502,11 +502,11 @@ title: AZ Navbar Fullscreen - Phonebook
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="helpful-links-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-bottom-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+                    <h2 class="navbar-brand" id="footer-bottom-label">Helpful Links:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
@@ -498,11 +498,11 @@ title: AZ Navbar Fullscreen - Tuition & Aid
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="navbar-az-fullscreen-modal-footer-top-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
+                    <h2 class="navbar-brand" id="navbar-az-fullscreen-modal-footer-top-label">Resources For:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">
@@ -542,11 +542,11 @@ title: AZ Navbar Fullscreen - Tuition & Aid
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-bottom-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="navbar-az-fullscreen-modal-footer-bottom-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="footer-bottom-label">Helpful Links:</h2>
+                    <h2 class="navbar-brand" id="navbar-az-fullscreen-modal-footer-bottom-label">Helpful Links:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
@@ -498,11 +498,11 @@ title: AZ Navbar Fullscreen - Tuition & Aid
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+                    <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/tuition/_index.html
@@ -542,11 +542,11 @@ title: AZ Navbar Fullscreen - Tuition & Aid
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="helpful-links-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-bottom-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+                    <h2 class="navbar-brand" id="footer-bottom-label">Helpful Links:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
@@ -458,11 +458,11 @@ title: AZ Navbar Fullscreen - Undergraduate Students
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="resources-for-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="resources-for-label">Resources For:</h2>
+                    <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
@@ -502,11 +502,11 @@ title: AZ Navbar Fullscreen - Undergraduate Students
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="helpful-links-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-bottom-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="helpful-links-label">Helpful Links:</h2>
+                    <h2 class="navbar-brand" id="footer-bottom-label">Helpful Links:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/undergraduate/_index.html
@@ -458,11 +458,11 @@ title: AZ Navbar Fullscreen - Undergraduate Students
         </div>
 
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-top">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-top-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="navbar-az-fullscreen-modal-footer-top-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="footer-top-label">Resources For:</h2>
+                    <h2 class="navbar-brand" id="navbar-az-fullscreen-modal-footer-top-label">Resources For:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">
@@ -502,11 +502,11 @@ title: AZ Navbar Fullscreen - Undergraduate Students
           </button>
         </div>
         <div class="modal-footer d-lg-flex" id="navbar-az-fullscreen-modal-footer-bottom">
-          <nav class="navbar d-none d-lg-flex" aria-labelledby="footer-bottom-label">
+          <nav class="navbar d-none d-lg-flex" aria-labelledby="navbar-az-fullscreen-modal-footer-bottom-label">
             <div class="container-lg">
                 <ul class="navbar-nav">
                   <li class="nav-item">
-                    <h2 class="navbar-brand" id="footer-bottom-label">Helpful Links:</h2>
+                    <h2 class="navbar-brand" id="navbar-az-fullscreen-modal-footer-bottom-label">Helpful Links:</h2>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="#">


### PR DESCRIPTION
## Changes

- Replaces the `resources-for-label` and `helpful-links-label` IDs with `navbar-az-fullscreen-modal-footer-top-label` and `navbar-az-fullscreen-modal-footer-bottom-label` in the examples for AZ Navbar Fullscreen.

## Related issue
 - #2201

## How to test

1. Go to https://review.digital.arizona.edu/arizona-bootstrap/issue/2201/docs/5.1/examples/navbar-az-fullscreen/ (and other example pages if you wish).
2. Confirm the changes to the IDs of the footer heading elements.
