### PR TITLE
Closes #2209: AZ Navbar Fullscreen: Update active states for CTA and footer nav links

### DIFF
--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -341,6 +341,7 @@
     }
 
     .nav-link {
+      --bs-nav-link-font-weight: 600;
       padding-top: var(--bs-nav-link-padding-y);
       padding-bottom: var(--bs-nav-link-padding-y);
       white-space: nowrap;

--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -889,7 +889,6 @@
       padding: 0 30px;
       font-size: 20px;
       line-height: 38px;
-      color: var(--bs-sky);
 
       &::after {
         top: 0;

--- a/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
+++ b/site/content/docs/5.1/examples/navbar-az-fullscreen/apply/_index.html
@@ -400,7 +400,7 @@ title: AZ Navbar Fullscreen - Apply
                 <!-- call-to-action items -->
                 <ul class="navbar-nav navbar-az-fullscreen-actions">
                   <li class="nav-item">
-                    <a class="nav-link" href="{{< ref "apply" >}}">
+                    <a class="nav-link active" href="{{< ref "apply" >}}">
                       <span class="nav-link-text">Apply</span>
                     </a>
                   </li>


### PR DESCRIPTION
## Changes

- Desktop: Sets `--bs-nav-link-font-weight` to 600 for footer links to ensure that footer links with the `.active` class are identical to other footer links.
- Mobile: Removes default sky color from call-to-action links to ensure that they are white by default (matching the desktop appearance).
- Mobile: Fix missing `.active` class on the mobile call-to-action link for "Apply" on the Apply example page.

## Related issue
 - #2209

## How to test

1. Go to https://review.digital.arizona.edu/arizona-bootstrap/issue/2209/docs/5.1/examples/navbar-az-fullscreen/partner/.
2. On desktop, confirm that the "Business or Partner" link in the footer has font-weight 600, matching the other footer links.
3. Go to https://review.digital.arizona.edu/arizona-bootstrap/issue/2209/docs/5.1/examples/navbar-az-fullscreen/apply/.
4. On mobile, confirm that CTA links are white by default.
5. On mobile, confirm that the "Apply" link is sky due to the `.active` class. (Note: the `.active` class gives this link a font-weight of 700 instead of 600.)
6. On mobile, confirm that activating one of the other CTA links turns it to sky due to the `:active` pseudo-class.