### PR TITLE
Closes #2216: modify Hugo's configuration file, allowing a version bump of hugo-bin to 0.161.0.

### DIFF
--- a/hugo_template.yml
+++ b/hugo_template.yml
@@ -4,6 +4,8 @@ baseURL:                "{{az_site_host}}{{az_site_base_url}}"
 enableInlineShortcodes: true
 
 security:
+  allowContent:
+    - "^text/html$"
   enableInlineShortcodes: true
   funcs:
     getenv:

--- a/hugo_template.yml
+++ b/hugo_template.yml
@@ -6,6 +6,7 @@ enableInlineShortcodes: true
 security:
   allowContent:
     - "^text/html$"
+    - "^text/markdown$"
   enableInlineShortcodes: true
   funcs:
     getenv:

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "eslint-plugin-unicorn": "56.0.1",
     "find-unused-sass-variables": "^6.2.0",
     "globby": "^16.2.2",
-    "hugo-bin": "^0.149.2",
+    "hugo-bin": "^0.161.0",
     "jquery": "3.7.1",
     "js-yaml": "^5.2.2",
     "linkinator": "^7.6.1",


### PR DESCRIPTION
Hugo introduced a new `allowContent` configuration setting in its v0.162.0
https://gohugo.io/configuration/security/#allowcontent
and development on the hugo-bin npm package started using this binary on 2026-05-26, The default setting is just `"! ^text/html$"`, documented as “By default, the HTML content format (media type text/html) is denied. Hugo emits HTML file content verbatim, which could allow arbitrary JavaScript execution.” But the Arizona Bootstrap documentation requires this, the security implications are minimal in practice, and a further explicit media type is needed to allow Markdown content.