### PR TITLE
Closes #2086: Add support for serif style headings

### DIFF
--- a/scss/custom/_typography.scss
+++ b/scss/custom/_typography.scss
@@ -8,9 +8,35 @@
 }
 
 // >> Serif headings
-// Opt-in serif style; combine with headings, e.g. h1.az-serif or .h1.az-serif.
-.az-serif {
-  font-family: $font-family-serif;
+// Container classes: apply to a wrapper (e.g. <body>) to switch descendant headings to serif.
+.az-headings-mixed {
+  // Garamond for h1-h3 only; h4-h6 stay Proxima Nova.
+  h1,
+  h2,
+  h3,
+  .h1,
+  .h2,
+  .h3 {
+    font-family: garamond-premier-pro, Georgia, "Times New Roman", serif;
+  }
+}
+
+.az-headings-serif {
+  // Garamond for all heading levels.
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  .h1,
+  .h2,
+  .h3,
+  .h4,
+  .h5,
+  .h6 {
+    font-family: garamond-premier-pro, Georgia, "Times New Roman", serif;
+  }
 }
 
 // >> Lists

--- a/scss/custom/_typography.scss
+++ b/scss/custom/_typography.scss
@@ -7,6 +7,12 @@
   hyphens: auto;
 }
 
+// >> Serif headings
+// Opt-in serif style; combine with headings, e.g. h1.az-serif or .h1.az-serif.
+.az-serif {
+  font-family: $font-family-serif;
+}
+
 // >> Lists
 .az-list-triangles {
   overflow: hidden;

--- a/scss/custom/_variables.scss
+++ b/scss/custom/_variables.scss
@@ -387,7 +387,7 @@ $colors: (
 */
 // stylelint-disable value-keyword-case
 $font-family-sans-serif: proxima-nova, calibri, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-$headings-font-family-h1-h3: garamond-premier-pro, Georgia, "Times New Roman", serif;
+$font-family-serif: garamond-premier-pro, Georgia, "Times New Roman", serif;
 // stylelint-enable value-keyword-case
 
 $heading-margins: 1.042em 0 .667em;

--- a/scss/custom/_variables.scss
+++ b/scss/custom/_variables.scss
@@ -395,12 +395,12 @@ $heading-margins: 1.042em 0 .667em;
 // Mobile-first font-size/line-height/font-weight per heading level; h1-h3 pick up
 // larger font-size-lg/line-height-lg at the $lg breakpoint. h4-h6 stay constant.
 $headings-scale: (
-  1: (font-size: 3rem, line-height: 3.5rem, font-weight: 600, font-size-lg: 4.5rem, line-height-lg: 5.125rem),
+  1: (font-size: 3rem, line-height: 3.5rem, font-weight: 600, font-size-lg: 4rem, line-height-lg: 4.625rem),
   2: (font-size: 2.375rem, line-height: 2.875rem, font-weight: 600, font-size-lg: 3.25rem, line-height-lg: 3.875rem),
   3: (font-size: 1.875rem, line-height: 2.375rem, font-weight: 600, font-size-lg: 2.5rem, line-height-lg: 3.125rem),
-  4: (font-size: 1.75rem, line-height: 2.25rem, font-weight: 700),
-  5: (font-size: 1.375rem, line-height: 1.875rem, font-weight: 700),
-  6: (font-size: 1.125rem, line-height: 1.625rem, font-weight: 700)
+  4: (font-size: 1.75rem, line-height: 2.25rem, font-weight: 600),
+  5: (font-size: 1.375rem, line-height: 1.875rem, font-weight: 600),
+  6: (font-size: 1.125rem, line-height: 1.625rem, font-weight: 600)
 );
 
 /*

--- a/scss/custom/_variables.scss
+++ b/scss/custom/_variables.scss
@@ -387,10 +387,21 @@ $colors: (
 */
 // stylelint-disable value-keyword-case
 $font-family-sans-serif: proxima-nova, calibri, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-$font-family-serif: garamond-premier-pro, Georgia, "Times New Roman", serif;
 // stylelint-enable value-keyword-case
 
 $heading-margins: 1.042em 0 .667em;
+
+// >> Heading type scale
+// Mobile-first font-size/line-height/font-weight per heading level; h1-h3 pick up
+// larger font-size-lg/line-height-lg at the $lg breakpoint. h4-h6 stay constant.
+$headings-scale: (
+  1: (font-size: 3rem, line-height: 3.5rem, font-weight: 600, font-size-lg: 4.5rem, line-height-lg: 5.125rem),
+  2: (font-size: 2.375rem, line-height: 2.875rem, font-weight: 600, font-size-lg: 3.25rem, line-height-lg: 3.875rem),
+  3: (font-size: 1.875rem, line-height: 2.375rem, font-weight: 600, font-size-lg: 2.5rem, line-height-lg: 3.125rem),
+  4: (font-size: 1.75rem, line-height: 2.25rem, font-weight: 700),
+  5: (font-size: 1.375rem, line-height: 1.875rem, font-weight: 700),
+  6: (font-size: 1.125rem, line-height: 1.625rem, font-weight: 700)
+);
 
 /*
 * > COMPONENTS

--- a/scss/custom/_variables.scss
+++ b/scss/custom/_variables.scss
@@ -387,6 +387,7 @@ $colors: (
 */
 // stylelint-disable value-keyword-case
 $font-family-sans-serif: proxima-nova, calibri, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+$headings-font-family-h1-h3: garamond-premier-pro, Georgia, "Times New Roman", serif;
 // stylelint-enable value-keyword-case
 
 $heading-margins: 1.042em 0 .667em;

--- a/scss/override/_typography.scss
+++ b/scss/override/_typography.scss
@@ -53,6 +53,13 @@ h3,
   font-family: $headings-font-family-h1-h3;
 }
 
+// >> display-1 - display-3 use the same serif family as h1-h3; display-4-6 stay sans-serif
+.display-1,
+.display-2,
+.display-3 {
+  font-family: $headings-font-family-h1-h3;
+}
+
 /*
 * > LINKS
 */

--- a/scss/override/_typography.scss
+++ b/scss/override/_typography.scss
@@ -50,14 +50,14 @@ h3,
 .h1,
 .h2,
 .h3 {
-  font-family: $headings-font-family-h1-h3;
+  font-family: $font-family-serif;
 }
 
 // >> display-1 - display-3 use the same serif family as h1-h3; display-4-6 stay sans-serif
 .display-1,
 .display-2,
 .display-3 {
-  font-family: $headings-font-family-h1-h3;
+  font-family: $font-family-serif;
 }
 
 /*

--- a/scss/override/_typography.scss
+++ b/scss/override/_typography.scss
@@ -43,6 +43,16 @@ h6,
   color: $blue;
 }
 
+// >> h1 - h3 use a distinct serif family from the h4-h6/body sans-serif default
+h1,
+h2,
+h3,
+.h1,
+.h2,
+.h3 {
+  font-family: $headings-font-family-h1-h3;
+}
+
 /*
 * > LINKS
 */

--- a/scss/override/_typography.scss
+++ b/scss/override/_typography.scss
@@ -41,6 +41,28 @@ h6,
 .h6 {
   margin: $heading-margins;
   color: $blue;
+  letter-spacing: 0;
+}
+
+@each $level, $props in $headings-scale {
+  h#{$level},
+  .h#{$level} {
+    font-size: map-get($props, font-size);
+    font-weight: map-get($props, font-weight);
+    line-height: map-get($props, line-height);
+  }
+}
+
+@include media-breakpoint-up(lg) {
+  @each $level, $props in $headings-scale {
+    @if map-has-key($props, font-size-lg) {
+      h#{$level},
+      .h#{$level} {
+        font-size: map-get($props, font-size-lg);
+        line-height: map-get($props, line-height-lg);
+      }
+    }
+  }
 }
 
 /*

--- a/scss/override/_typography.scss
+++ b/scss/override/_typography.scss
@@ -43,23 +43,6 @@ h6,
   color: $blue;
 }
 
-// >> h1 - h3 use a distinct serif family from the h4-h6/body sans-serif default
-h1,
-h2,
-h3,
-.h1,
-.h2,
-.h3 {
-  font-family: $font-family-serif;
-}
-
-// >> display-1 - display-3 use the same serif family as h1-h3; display-4-6 stay sans-serif
-.display-1,
-.display-2,
-.display-3 {
-  font-family: $font-family-serif;
-}
-
 /*
 * > LINKS
 */

--- a/site/content/docs/5.1/content/typography.md
+++ b/site/content/docs/5.1/content/typography.md
@@ -53,6 +53,43 @@ All HTML headings, `<h1>` through `<h6>`, are available.
 <p class="h6">h6. Bootstrap heading</p>
 {{< /example >}}
 
+### Serif headings
+
+<span class="badge badge-az-custom">Custom Arizona Bootstrap Class</span>
+
+Add the `.az-serif` class alongside a heading element or `.h1`-`.h6` class to switch that heading to the serif type stack.
+
+{{< bs-table >}}
+| Heading | Example |
+| --- | --- |
+| `<h1 class="az-serif"></h1>` | <span class="h1 az-serif d-inline-block">h1. Bootstrap heading</span> |
+| `<h2 class="az-serif"></h2>` | <span class="h2 az-serif d-inline-block">h2. Bootstrap heading</span> |
+| `<h3 class="az-serif"></h3>` | <span class="h3 az-serif d-inline-block">h3. Bootstrap heading</span> |
+| `<h4 class="az-serif"></h4>` | <span class="h4 az-serif d-inline-block">h4. Bootstrap heading</span> |
+| `<h5 class="az-serif"></h5>` | <span class="h5 az-serif d-inline-block">h5. Bootstrap heading</span> |
+| `<h6 class="az-serif"></h6>` | <span class="h6 az-serif d-inline-block">h6. Bootstrap heading</span> |
+{{< /bs-table >}}
+
+```html
+<h1 class="az-serif">h1. Bootstrap heading</h1>
+<h2 class="az-serif">h2. Bootstrap heading</h2>
+<h3 class="az-serif">h3. Bootstrap heading</h3>
+<h4 class="az-serif">h4. Bootstrap heading</h4>
+<h5 class="az-serif">h5. Bootstrap heading</h5>
+<h6 class="az-serif">h6. Bootstrap heading</h6>
+```
+
+`.h1` through `.h6` classes can also be combined with `.az-serif`, for when you want to match the serif heading styling but cannot use the associated HTML element.
+
+{{< example >}}
+<p class="h1 az-serif">h1. Bootstrap heading</p>
+<p class="h2 az-serif">h2. Bootstrap heading</p>
+<p class="h3 az-serif">h3. Bootstrap heading</p>
+<p class="h4 az-serif">h4. Bootstrap heading</p>
+<p class="h5 az-serif">h5. Bootstrap heading</p>
+<p class="h6 az-serif">h6. Bootstrap heading</p>
+{{< /example >}}
+
 ### Customizing headings
 
 Use the included utility classes to recreate the small secondary heading text from Bootstrap 3.

--- a/site/content/docs/5.1/content/typography.md
+++ b/site/content/docs/5.1/content/typography.md
@@ -70,17 +70,6 @@ Add the `.az-headings-mixed` class to a container (such as `<body>` or any wrapp
 </div>
 {{< /example >}}
 
-```html
-<div class="az-headings-mixed">
-  <h1>h1. Bootstrap heading</h1>
-  <h2>h2. Bootstrap heading</h2>
-  <h3>h3. Bootstrap heading</h3>
-  <h4>h4. Bootstrap heading</h4>
-  <h5>h5. Bootstrap heading</h5>
-  <h6>h6. Bootstrap heading</h6>
-</div>
-```
-
 `.h1` through `.h6` classes can also be used in place of the associated HTML element within a container using `.az-headings-mixed`.
 
 {{< example >}}
@@ -110,17 +99,6 @@ Add the `.az-headings-serif` class to a container (such as `<body>` or any wrapp
   <h6>h6. Bootstrap heading</h6>
 </div>
 {{< /example >}}
-
-```html
-<div class="az-headings-serif">
-  <h1>h1. Bootstrap heading</h1>
-  <h2>h2. Bootstrap heading</h2>
-  <h3>h3. Bootstrap heading</h3>
-  <h4>h4. Bootstrap heading</h4>
-  <h5>h5. Bootstrap heading</h5>
-  <h6>h6. Bootstrap heading</h6>
-</div>
-```
 
 `.h1` through `.h6` classes can also be used in place of the associated HTML element within a container using `.az-headings-serif`.
 

--- a/site/content/docs/5.1/content/typography.md
+++ b/site/content/docs/5.1/content/typography.md
@@ -53,41 +53,86 @@ All HTML headings, `<h1>` through `<h6>`, are available.
 <p class="h6">h6. Bootstrap heading</p>
 {{< /example >}}
 
+### Mixed headings
+
+<span class="badge badge-az-custom">Custom Arizona Bootstrap Class</span>
+
+Add the `.az-headings-mixed` class to a container (such as `<body>` or any wrapping element) to switch that container's `<h1>`-`<h3>` and `.h1`-`.h3` to the serif type stack, leaving `<h4>`-`<h6>` and `.h4`-`.h6` on Proxima Nova.
+
+{{< example >}}
+<div class="az-headings-mixed">
+  <h1>h1. Bootstrap heading</h1>
+  <h2>h2. Bootstrap heading</h2>
+  <h3>h3. Bootstrap heading</h3>
+  <h4>h4. Bootstrap heading</h4>
+  <h5>h5. Bootstrap heading</h5>
+  <h6>h6. Bootstrap heading</h6>
+</div>
+{{< /example >}}
+
+```html
+<div class="az-headings-mixed">
+  <h1>h1. Bootstrap heading</h1>
+  <h2>h2. Bootstrap heading</h2>
+  <h3>h3. Bootstrap heading</h3>
+  <h4>h4. Bootstrap heading</h4>
+  <h5>h5. Bootstrap heading</h5>
+  <h6>h6. Bootstrap heading</h6>
+</div>
+```
+
+`.h1` through `.h6` classes can also be used in place of the associated HTML element within a container using `.az-headings-mixed`.
+
+{{< example >}}
+<div class="az-headings-mixed">
+  <p class="h1">h1. Bootstrap heading</p>
+  <p class="h2">h2. Bootstrap heading</p>
+  <p class="h3">h3. Bootstrap heading</p>
+  <p class="h4">h4. Bootstrap heading</p>
+  <p class="h5">h5. Bootstrap heading</p>
+  <p class="h6">h6. Bootstrap heading</p>
+</div>
+{{< /example >}}
+
 ### Serif headings
 
 <span class="badge badge-az-custom">Custom Arizona Bootstrap Class</span>
 
-Add the `.az-serif` class alongside a heading element or `.h1`-`.h6` class to switch that heading to the serif type stack.
-
-{{< bs-table >}}
-| Heading | Example |
-| --- | --- |
-| `<h1 class="az-serif"></h1>` | <span class="h1 az-serif d-inline-block">h1. Bootstrap heading</span> |
-| `<h2 class="az-serif"></h2>` | <span class="h2 az-serif d-inline-block">h2. Bootstrap heading</span> |
-| `<h3 class="az-serif"></h3>` | <span class="h3 az-serif d-inline-block">h3. Bootstrap heading</span> |
-| `<h4 class="az-serif"></h4>` | <span class="h4 az-serif d-inline-block">h4. Bootstrap heading</span> |
-| `<h5 class="az-serif"></h5>` | <span class="h5 az-serif d-inline-block">h5. Bootstrap heading</span> |
-| `<h6 class="az-serif"></h6>` | <span class="h6 az-serif d-inline-block">h6. Bootstrap heading</span> |
-{{< /bs-table >}}
-
-```html
-<h1 class="az-serif">h1. Bootstrap heading</h1>
-<h2 class="az-serif">h2. Bootstrap heading</h2>
-<h3 class="az-serif">h3. Bootstrap heading</h3>
-<h4 class="az-serif">h4. Bootstrap heading</h4>
-<h5 class="az-serif">h5. Bootstrap heading</h5>
-<h6 class="az-serif">h6. Bootstrap heading</h6>
-```
-
-`.h1` through `.h6` classes can also be combined with `.az-serif`, for when you want to match the serif heading styling but cannot use the associated HTML element.
+Add the `.az-headings-serif` class to a container (such as `<body>` or any wrapping element) to switch all of that container's `<h1>`-`<h6>` and `.h1`-`.h6` to the serif type stack.
 
 {{< example >}}
-<p class="h1 az-serif">h1. Bootstrap heading</p>
-<p class="h2 az-serif">h2. Bootstrap heading</p>
-<p class="h3 az-serif">h3. Bootstrap heading</p>
-<p class="h4 az-serif">h4. Bootstrap heading</p>
-<p class="h5 az-serif">h5. Bootstrap heading</p>
-<p class="h6 az-serif">h6. Bootstrap heading</p>
+<div class="az-headings-serif">
+  <h1>h1. Bootstrap heading</h1>
+  <h2>h2. Bootstrap heading</h2>
+  <h3>h3. Bootstrap heading</h3>
+  <h4>h4. Bootstrap heading</h4>
+  <h5>h5. Bootstrap heading</h5>
+  <h6>h6. Bootstrap heading</h6>
+</div>
+{{< /example >}}
+
+```html
+<div class="az-headings-serif">
+  <h1>h1. Bootstrap heading</h1>
+  <h2>h2. Bootstrap heading</h2>
+  <h3>h3. Bootstrap heading</h3>
+  <h4>h4. Bootstrap heading</h4>
+  <h5>h5. Bootstrap heading</h5>
+  <h6>h6. Bootstrap heading</h6>
+</div>
+```
+
+`.h1` through `.h6` classes can also be used in place of the associated HTML element within a container using `.az-headings-serif`.
+
+{{< example >}}
+<div class="az-headings-serif">
+  <p class="h1">h1. Bootstrap heading</p>
+  <p class="h2">h2. Bootstrap heading</p>
+  <p class="h3">h3. Bootstrap heading</p>
+  <p class="h4">h4. Bootstrap heading</p>
+  <p class="h5">h5. Bootstrap heading</p>
+  <p class="h6">h6. Bootstrap heading</p>
+</div>
 {{< /example >}}
 
 ### Customizing headings


### PR DESCRIPTION
### Motivation

The arizona.edu redesign specifies an exact type scale (font-size, line-height,
font-weight, letter-spacing per breakpoint) for headings, and introduces Garamond Premier Pro as an opt-in serif style for headings. Proxima Nova remains the default font-family for all headings. See #2086.

### Changes

**1. New heading type scale (h1-h6, `.h1`-`.h6`)**
Applied the exact font-size/line-height/font-weight/letter-spacing spec for Proxima Nova headings:

| Level | Weight | Mobile (<992px) | Desktop (≥992px) |
| --- | --- | --- | --- |
| h1 | 600 | 48px / 56px | 64px / 74px |
| h2 | 600 | 38px / 46px | 52px / 62px |
| h3 | 600 | 30px / 38px | 40px / 50px |
| h4 | 600 | 28px / 36px (all widths) | — |
| h5 | 600 | 22px / 30px (all widths) | — |
| h6 | 600 | 18px / 26px (all widths) | — |

- h1-h3 are responsive at the `lg` (992px) breakpoint; h4-h6 are constant at all viewport widths (no mobile-specific spec was provided for h4-h6).
- Letter-spacing is explicitly `0` at all levels, matching the spec.
- Color remains AZ Blue by default; white-on-dark-background behavior is unchanged, handled by the existing `az-color-contrast()` mixin.
- Implemented via a new `$headings-scale` Sass map (`scss/custom/_variables.scss`) and an `@each` loop in `scss/override/_typography.scss`, rather than overriding Bootstrap's own `$h1-font-size`...`$h6-font-size` variables, to avoid unintentionally changing the `.fs-1`-`.fs-6` text utility classes (which are unrelated to actual headings but derive from the same Bootstrap variables) and to allow exact fixed sizing rather than Bootstrap's fluid RFS scaling.

**2. Opt-in serif (Garamond) container classes**
Two new container-level classes to opt any part of a page into serif headings:

- **`.az-headings-mixed`** — apply to `<body>` or any wrapper; switches only `h1`-`h3`/`.h1`-`.h3` to Garamond, leaving `h4`-`h6` on Proxima Nova.
- **`.az-headings-serif`** — apply to `<body>` or any wrapper; switches all of `h1`-`h6`/`.h1`-`.h6` to Garamond.

Both classes use the same font-size/line-height/font-weight/letter-spacing spec as Proxima Nova — only `font-family` changes.

**3. Documentation**
`docs/5.1/content/typography/` adds two new sections:
- **Mixed headings** (shown first) — documents `.az-headings-mixed`.
- **Serif headings** — documents `.az-headings-serif`.

**Update (8/26):** Per Tom's feedback in the Bootstrap 5.2.0 Touch Base meeting, H1 desktop size changed from 72px/82px to 64px/74px line-height, and H4-H6 weight changed from bold (700) to semibold (600). These changes apply to both Proxima Nova and Garamond headings, since size/weight are shared via `$headings-scale` and only `font-family` differs between the two.

### Questions

- Are the fallback fonts acceptable?

### How to test
- Review site: https://review.digital.arizona.edu/arizona-bootstrap/issue/2086/
- Typography: https://review.digital.arizona.edu/arizona-bootstrap/issue/2086/docs/5.1/content/typography/
    - Headings: https://review.digital.arizona.edu/arizona-bootstrap/issue/2086/docs/5.1/content/typography/#headings
    - Mixed headings: https://review.digital.arizona.edu/arizona-bootstrap/issue/2086/docs/5.1/content/typography/#mixed-headings
    - Serif headings: https://review.digital.arizona.edu/arizona-bootstrap/issue/2086/docs/5.1/content/typography/#serif-headings
