### PR TITLE
Test 5.2.x into main

### DIFF
--- a/site/assets/scss/_custom-docs.scss
+++ b/site/assets/scss/_custom-docs.scss
@@ -52,7 +52,7 @@
   --#{$prefix}nav-link-color: var(--#{$prefix}navbar-color);
 
   &::after {
-    background-image: linear-gradient(var(--bs-chili), var(--bs-chili) 95%);
+    background-image: linear-gradient(var(--bs-blue), var(--bs-blue) 95%);
   }
 }
 


### PR DESCRIPTION
* Add blue header example with logo to Arizona Header documentation

* Remove empty <p> tags and add blue header description

* Refactor blue header example to simplify markup by removing unnecessary classes

* Blue navbar for docs site

* Restore az-fixed-header-on-mobile class in blue header code snippet

* Add unique id to be consistent with existing examples

(cherry picked from commit 322a183d4dedbbf68cb8a9a3becb7b02bc0adc48)