### PR TITLE
Forward slash is read aloud

### DIFF
--- a/scss/override/_variables.scss
+++ b/scss/override/_variables.scss
@@ -104,7 +104,7 @@ $breadcrumb-padding-x: .609rem;
 $breadcrumb-padding-y: .75rem;
 $breadcrumb-active-color: $azurite;
 $breadcrumb-divider-color: $bloom;
-$breadcrumb-divider: quote("/");
+$breadcrumb-divider: quote("/") / "";
 // fusv-enable
 
 // >> Buttons


### PR DESCRIPTION
Adds alternative text for the pseudo-element content field--which I had no idea you could do.

https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/content#accessibility

To be included with #2256. Corrects for the forward slash being read aloud by screenreaders.

https://review.digital.arizona.edu/arizona-bootstrap/issue/2250-djcelaya/docs/5.1/components/breadcrumb/