### PR TITLE
Additional fixes for badge background

### DIFF
--- a/scss/custom/_background.scss
+++ b/scss/custom/_background.scss
@@ -6,7 +6,7 @@
 [class*=" text-bg-"] {
   --bs-bg-color: var(--bs-body-color);
   --bs-bg-color-rgb: var(--bs-body-color-rgb);
-  --bs-bg-bg: rgb(var(--bs-body-rgb-bg) / var(--bs-bg-opacity));
+  --bs-bg-bg: rgba(var(--bs-body-bg-rgb), var(--bs-bg-opacity, 1));
   --bs-heading-color: var(--bs-bg-color);
   color: var(--bs-bg-color);
   background-color: var(--bs-bg-bg);

--- a/scss/override/_badge.scss
+++ b/scss/override/_badge.scss
@@ -1,5 +1,9 @@
+// `.text-bg-light` is a Bootstrap theme color emitted with `!important`, so the
+// var-driven color/background must also be `!important` to be consumed on hover.
 /* stylelint-disable declaration-no-important */
 .text-bg-light {
+  --bs-bg-bg: rgba(var(--bs-light-rgb), var(--bs-bg-opacity, 1));
   color: var(--bs-bg-color) !important;
+  background-color: var(--bs-bg-bg) !important;
 }
 /* stylelint-enable declaration-no-important */


### PR DESCRIPTION
To be merged into #2258.

## Changes
- Fixed the shared `--bs-bg-bg` default on `.text-bg-*` in `scss/custom/_background.scss`. It referenced a non-existent variable and used invalid `rgb()` slash-syntax without an opacity fallback (`rgb(var(--bs-body-rgb-bg) / var(--bs-bg-opacity))`); corrected to `rgba(var(--bs-body-bg-rgb), var(--bs-bg-opacity, 1))` so the fallback background resolves to a valid value.
- Restored the light badge hover background. `.text-bg-light` is a Bootstrap theme color emitted with `!important`, so the hover-provided `--bs-bg-bg` was never applied. `scss/override/_badge.scss` now re-declares `background-color: var(--bs-bg-bg) !important` and sets a matching default `--bs-bg-bg`, so `.badge-link.text-bg-light` darkens on hover/focus while the resting state is unchanged.

## How to test
- [Review site](https://review.digital.arizona.edu/arizona-bootstrap/refactor-text-bg-color-djcelaya/)
- [Badge links](https://review.digital.arizona.edu/arizona-bootstrap/refactor-text-bg-color-djcelaya/docs/5.1/components/badge/#badge-links)
