### PR TITLE
Fix nav column divider stretching to footer in fullscreen navbar

### DIFF
--- a/js/src/navbar-az-fullscreen.js
+++ b/js/src/navbar-az-fullscreen.js
@@ -96,6 +96,7 @@ function clearNavColumnHeights(modalElement) {
   for (const column of allColumns) {
     if (column instanceof HTMLElement) {
       column.style.height = ''
+      column.style.maxHeight = ''
     }
   }
 }
@@ -171,7 +172,10 @@ function synchronizeNavColumnHeights(modalElement) {
   const visibleColumns = isCollapseTransitioning ? getDesktopVisibleNavColumns(modalElement) : getUniqueColumns(activeTargets)
 
   for (const column of visibleColumns) {
+    // Cap the height so `flex-grow` on secondary/tertiary columns can't stretch
+    // the divider past the tallest content while still filling up to it.
     column.style.height = `${syncedHeight}px`
+    column.style.maxHeight = `${syncedHeight}px`
   }
 }
 

--- a/js/src/navbar-az-fullscreen.js
+++ b/js/src/navbar-az-fullscreen.js
@@ -172,8 +172,8 @@ function synchronizeNavColumnHeights(modalElement) {
   const visibleColumns = isCollapseTransitioning ? getDesktopVisibleNavColumns(modalElement) : getUniqueColumns(activeTargets)
 
   for (const column of visibleColumns) {
-    // Cap the height so `flex-grow` on secondary/tertiary columns can't stretch
-    // the divider past the tallest content while still filling up to it.
+    // Cap each column's height so flex layout can't stretch the divider past the tallest visible content.
+    // Columns can still scroll normally when content exceeds available vertical space.
     column.style.height = `${syncedHeight}px`
     column.style.maxHeight = `${syncedHeight}px`
   }


### PR DESCRIPTION
Possible fix for [my review comment](https://github.com/az-digital/arizona-bootstrap/pull/2265#issuecomment-5362138116) on #2265.

I believe this will set the height of the secondary nav col right separator while preserving the top fade added on mobile.

https://review.digital.arizona.edu/arizona-bootstrap/issue/2159-djcelaya/docs/5.1/examples/navbar-az-fullscreen/

## Regression

On desktop, the earlier `flex: 1 1 auto` change (added to preserve the middle
column's scroll position) let the secondary/tertiary nav columns grow to fill
the entire modal body. Because the vertical divider between columns is a
`border-image` on `.navbar-az-fullscreen-modal-menu-nav-col`, its length tracks
the column's box height — so a short column (e.g. **Admissions → Undergraduate /
Gra### Regression

On desktop, the earlier `flex: 1 1 auto` change (added to preserve the middle column's scroll position) let the secondary/tertiary nav columns grow to fill the entire modal body. Because the vertical divider between columns is a `border-image` on `.navbar-az-fullscreen-modal-menu-nav-col`, its length tracks the column's box height — so a short column (e.g. **Admissions → Undergraduate / Graduate / Online Students**) drew its divider all the way down to the footer instead of stopping at the tallest column's content.

The root cause is that `flex-grow` overrode the inline `height` the JS sets in `synchronizeNavColumnHeights()`: the column reported `height: 520px` inline but a computed height of `611px` (the full modal body).

## Solution

Keep `flex: 1 1 auto` (it's what preserves scroll position) but also set an inline `max-height` equal to the synced tallest-content height whenever the JS sets the `height`, and clear it alongside `height` in `clearNavColumnHeights()`. `max-height` caps `flex-grow`, so:

- **Short columns** stop at the synced height — the divider aligns with the tallest column instead of the footer.
- **Long, scrolling columns** still fill the full available height and scroll normally, and expanding a nested submenu no longer resets the scroll position.

Verified in the review site (desktop): the short Admissions column now caps at `max-height: 520px` (matching the primary column), while the long Campus Life column keeps its full height and preserves `scrollTop` when a tertiary submenu is expanded.