### PR TITLE
Closes #2223: AZ Search is stable

### DIFF
--- a/site/content/docs/5.1/components/search.md
+++ b/site/content/docs/5.1/components/search.md
@@ -1,12 +1,12 @@
 ---
 layout: docs
 title: Search
-description: <span class="badge badge-az-experimental mt-3">Arizona Bootstrap Experimental Feature</span>
+description: <span class="badge badge-az-custom mt-3">Custom Arizona Bootstrap Component</span>
 group: components
 toc: true
 ---
 
-The AZ Search component provides a stylized search field built with Bootstrap form controls and input groups. It is intended to be reusable in AZ Navbar Fullscreen and other page regions where a prominent site search is needed.
+The AZ Search component provides a stylized search field built with Bootstrap form controls and input groups. It is intended to be used in AZ Navbar Fullscreen and other page regions where a prominent site search is needed.
 
 ## Example
 


### PR DESCRIPTION
See #2223. Replaces **Experimental** with **Custom**, inferring stability. Also changed a word in the description that sounded a little awkward.

## How to test
1. Compare [AZ Search (this PR)](https://review.digital.arizona.edu/arizona-bootstrap/issue/2223/docs/5.1/components/search/) with [AZ Search (main)](https://review.digital.arizona.edu/arizona-bootstrap/main/docs/5.1/components/search/). The **Experimental** badge is replaced with **Custom**.