### PR TITLE
Closes #2086: Add serif style headings via CSS custom properties

### DIFF
--- a/scss/custom/_navbar-fullscreen.scss
+++ b/scss/custom/_navbar-fullscreen.scss
@@ -493,7 +493,7 @@
   --az-navbar-fullscreen-modal-menu-primary-font-weight: 600;
   --az-navbar-fullscreen-modal-menu-primary-font-size: 48px;
   --az-navbar-fullscreen-modal-menu-primary-line-height: 48px;
-  --az-navbar-fullscreen-modal-menu-primary-font-family: garamond-premier-pro;
+  --az-navbar-fullscreen-modal-menu-primary-font-family: #{$font-family-serif};
   --az-navbar-fullscreen-modal-menu-primary-font: normal normal var(--az-navbar-fullscreen-modal-menu-primary-font-weight) var(--az-navbar-fullscreen-modal-menu-primary-font-size) / var(--az-navbar-fullscreen-modal-menu-primary-line-height) var(--az-navbar-fullscreen-modal-menu-primary-font-family);
   --az-navbar-fullscreen-modal-menu-primary-letter-spacing: .1px;
   --az-navbar-fullscreen-modal-menu-primary-color: var(--az-navbar-fullscreen-modal-menu-color);

--- a/scss/custom/_typography.scss
+++ b/scss/custom/_typography.scss
@@ -9,23 +9,26 @@
 
 // >> Serif headings
 // Container classes: apply to a wrapper (e.g. <body>) to switch descendant headings
-// to serif. Overrides the --az-h#{n}-font-family custom property each heading level
-// reads in scss/override/_typography.scss, rather than restating font-family against
-// the full h1-h6/.h1-.h6 selector list per class.
-@each $level in 1, 2, 3 {
-  .az-headings-mixed h#{$level},
-  .az-headings-mixed .h#{$level} {
-    // Garamond for h1-h3 only; h4-h6 stay Proxima Nova.
-    --az-h#{$level}-font-family: #{$font-family-serif};
-  }
+// to serif. Both set the single shared --az-heading-font-family custom property
+// (see scss/override/_typography.scss) once and let inheritance carry it to every
+// descendant heading - not once per level, since every level they touch gets the
+// same value.
+.az-headings-serif {
+  // Garamond for all heading levels. Inherits to every descendant, so no need to
+  // enumerate h1-h6/.h1-.h6 here at all.
+  --az-heading-font-family: #{$font-family-serif};
 }
 
-@each $level in 1, 2, 3, 4, 5, 6 {
-  .az-headings-serif h#{$level},
-  .az-headings-serif .h#{$level} {
-    // Garamond for all heading levels.
-    --az-h#{$level}-font-family: #{$font-family-serif};
-  }
+.az-headings-mixed h1,
+.az-headings-mixed h2,
+.az-headings-mixed h3,
+.az-headings-mixed .h1,
+.az-headings-mixed .h2,
+.az-headings-mixed .h3 {
+  // Garamond for h1-h3 only; h4-h6 stay Proxima Nova, so (unlike .az-headings-serif
+  // above) this can't just set the property on the container and rely on inheritance -
+  // it has to target the specific levels that should change.
+  --az-heading-font-family: #{$font-family-serif};
 }
 
 // >> Lists

--- a/scss/custom/_typography.scss
+++ b/scss/custom/_typography.scss
@@ -8,6 +8,12 @@
 }
 
 // >> Serif headings
+// Default: headings track the body font via the live --bs-body-font-family
+// custom property, so overriding that alone also changes heading font.
+:root {
+  --az-heading-font-family: var(--#{$prefix}body-font-family);
+}
+
 // Container classes: apply to a wrapper (e.g. <body>) to switch descendant
 // headings to serif, by overriding the --az-heading-font-family custom
 // property each heading reads (see scss/override/_typography.scss).

--- a/scss/custom/_typography.scss
+++ b/scss/custom/_typography.scss
@@ -16,15 +16,17 @@
   --az-heading-font-family: #{$font-family-serif};
 }
 
-.az-headings-mixed h1,
-.az-headings-mixed h2,
-.az-headings-mixed h3,
-.az-headings-mixed .h1,
-.az-headings-mixed .h2,
-.az-headings-mixed .h3 {
+.az-headings-mixed {
   // h1-h3 only; h4-h6 stay Proxima Nova, so this has to target those levels
   // directly rather than relying on inheritance from the container.
-  --az-heading-font-family: #{$font-family-serif};
+  h1,
+  h2,
+  h3,
+  .h1,
+  .h2,
+  .h3 {
+    --az-heading-font-family: #{$font-family-serif};
+  }
 }
 
 // >> Lists

--- a/scss/custom/_typography.scss
+++ b/scss/custom/_typography.scss
@@ -8,14 +8,11 @@
 }
 
 // >> Serif headings
-// Container classes: apply to a wrapper (e.g. <body>) to switch descendant headings
-// to serif. Both set the single shared --az-heading-font-family custom property
-// (see scss/override/_typography.scss) once and let inheritance carry it to every
-// descendant heading - not once per level, since every level they touch gets the
-// same value.
+// Container classes: apply to a wrapper (e.g. <body>) to switch descendant
+// headings to serif, by overriding the --az-heading-font-family custom
+// property each heading reads (see scss/override/_typography.scss).
 .az-headings-serif {
-  // Garamond for all heading levels. Inherits to every descendant, so no need to
-  // enumerate h1-h6/.h1-.h6 here at all.
+  // All heading levels. Set once and inherited - no need to target h1-h6 individually.
   --az-heading-font-family: #{$font-family-serif};
 }
 
@@ -25,9 +22,8 @@
 .az-headings-mixed .h1,
 .az-headings-mixed .h2,
 .az-headings-mixed .h3 {
-  // Garamond for h1-h3 only; h4-h6 stay Proxima Nova, so (unlike .az-headings-serif
-  // above) this can't just set the property on the container and rely on inheritance -
-  // it has to target the specific levels that should change.
+  // h1-h3 only; h4-h6 stay Proxima Nova, so this has to target those levels
+  // directly rather than relying on inheritance from the container.
   --az-heading-font-family: #{$font-family-serif};
 }
 

--- a/scss/custom/_typography.scss
+++ b/scss/custom/_typography.scss
@@ -7,6 +7,27 @@
   hyphens: auto;
 }
 
+// >> Serif headings
+// Container classes: apply to a wrapper (e.g. <body>) to switch descendant headings
+// to serif. Overrides the --az-h#{n}-font-family custom property each heading level
+// reads in scss/override/_typography.scss, rather than restating font-family against
+// the full h1-h6/.h1-.h6 selector list per class.
+@each $level in 1, 2, 3 {
+  .az-headings-mixed h#{$level},
+  .az-headings-mixed .h#{$level} {
+    // Garamond for h1-h3 only; h4-h6 stay Proxima Nova.
+    --az-h#{$level}-font-family: #{$font-family-serif};
+  }
+}
+
+@each $level in 1, 2, 3, 4, 5, 6 {
+  .az-headings-serif h#{$level},
+  .az-headings-serif .h#{$level} {
+    // Garamond for all heading levels.
+    --az-h#{$level}-font-family: #{$font-family-serif};
+  }
+}
+
 // >> Lists
 .az-list-triangles {
   overflow: hidden;

--- a/scss/custom/_variables.scss
+++ b/scss/custom/_variables.scss
@@ -387,9 +387,25 @@ $colors: (
 */
 // stylelint-disable value-keyword-case
 $font-family-sans-serif: proxima-nova, calibri, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+$font-family-serif: garamond-premier-pro, Georgia, "Times New Roman", serif;
 // stylelint-enable value-keyword-case
 
 $heading-margins: 1.042em 0 .667em;
+
+// >> Heading type scale
+// Mobile-first font-size/line-height/font-weight per heading level; h1-h3 pick up
+// larger font-size-lg/line-height-lg at the $lg breakpoint. h4-h6 stay constant.
+// Consumed via CSS custom properties (--az-h#{n}-font-size etc.) in
+// scss/override/_typography.scss, not applied directly, so a page can override
+// a single level's value without a Sass rebuild.
+$headings-scale: (
+  1: (font-size: 3rem, line-height: 3.5rem, font-weight: 600, font-size-lg: 4rem, line-height-lg: 4.625rem),
+  2: (font-size: 2.375rem, line-height: 2.875rem, font-weight: 600, font-size-lg: 3.25rem, line-height-lg: 3.875rem),
+  3: (font-size: 1.875rem, line-height: 2.375rem, font-weight: 600, font-size-lg: 2.5rem, line-height-lg: 3.125rem),
+  4: (font-size: 1.75rem, line-height: 2.25rem, font-weight: 600),
+  5: (font-size: 1.375rem, line-height: 1.875rem, font-weight: 600),
+  6: (font-size: 1.125rem, line-height: 1.625rem, font-weight: 600)
+);
 
 /*
 * > COMPONENTS

--- a/scss/custom/_variables.scss
+++ b/scss/custom/_variables.scss
@@ -395,9 +395,7 @@ $heading-margins: 1.042em 0 .667em;
 // >> Heading type scale
 // Mobile-first font-size/line-height/font-weight per heading level; h1-h3 pick up
 // larger font-size-lg/line-height-lg at the $lg breakpoint. h4-h6 stay constant.
-// Consumed via CSS custom properties (--az-h#{n}-font-size etc.) in
-// scss/override/_typography.scss, not applied directly, so a page can override
-// a single level's value without a Sass rebuild.
+// Consumed in scss/override/_typography.scss.
 $headings-scale: (
   1: (font-size: 3rem, line-height: 3.5rem, font-weight: 600, font-size-lg: 4rem, line-height-lg: 4.625rem),
   2: (font-size: 2.375rem, line-height: 2.875rem, font-weight: 600, font-size-lg: 3.25rem, line-height-lg: 3.875rem),

--- a/scss/custom/_variables.scss
+++ b/scss/custom/_variables.scss
@@ -397,7 +397,8 @@ $heading-margins: 1.042em 0 .667em;
 // larger font-size-lg/line-height-lg at the $lg breakpoint. h4-h6 stay constant.
 // Consumed in scss/override/_typography.scss.
 $headings-scale: (
-  1: (font-size: 3rem, line-height: 3.5rem, font-weight: 600, font-size-lg: 4rem, line-height-lg: 4.625rem),
+  // margin-top matches margin-bottom so h1 spacing is symmetrical, unlike h2-h6.
+  1: (font-size: 3rem, line-height: 3.5rem, font-weight: 600, font-size-lg: 4rem, line-height-lg: 4.625rem, margin-top: .667em),
   2: (font-size: 2.375rem, line-height: 2.875rem, font-weight: 600, font-size-lg: 3.25rem, line-height-lg: 3.875rem),
   3: (font-size: 1.875rem, line-height: 2.375rem, font-weight: 600, font-size-lg: 2.5rem, line-height-lg: 3.125rem),
   4: (font-size: 1.75rem, line-height: 2.25rem, font-weight: 600),

--- a/scss/override/_typography.scss
+++ b/scss/override/_typography.scss
@@ -27,13 +27,11 @@ figure:has(blockquote) > :last-child {
 */
 
 // >> h1 - h6
-// font-family is a shared, inherited custom property (not a plain value)
-// so .az-headings-mixed/.az-headings-serif can set it once per container
+// font-family is a shared, inherited custom property (not a plain value),
+// defaulted at :root (see scss/custom/_typography.scss), so
+// .az-headings-mixed/.az-headings-serif can override it once per container
 // instead of once per heading level, and so a single heading can override it
-// directly (e.g. style="--az-heading-font-family: ..."). Falls back to
-// --bs-body-font-family - Bootstrap's own live custom property for this,
-// rather than a separately compiled value - so overriding that alone also
-// changes headings' default font.
+// directly (e.g. style="--az-heading-font-family: ...").
 h1,
 h2,
 h3,
@@ -47,7 +45,7 @@ h6,
 .h5,
 .h6 {
   margin: $heading-margins;
-  font-family: var(--az-heading-font-family, var(--#{$prefix}body-font-family));
+  font-family: var(--az-heading-font-family);
   color: $blue;
   letter-spacing: 0;
 }

--- a/scss/override/_typography.scss
+++ b/scss/override/_typography.scss
@@ -44,18 +44,22 @@ h6,
   letter-spacing: 0;
 }
 
-// Each level's font-size/line-height/font-family are CSS custom properties, not
-// applied directly, so a page can override a single level (e.g. just --az-h2-font-size)
-// without a Sass rebuild, and so .az-headings-mixed/.az-headings-serif below can
-// swap font-family with a one-line property override instead of restating this
-// whole selector list per opt-in class.
+// Each level's font-size/line-height are CSS custom properties, not applied
+// directly, so a single level can be adjusted (e.g. just --az-h2-font-size)
+// without a Sass rebuild. font-family reads a single shared, inherited
+// --az-heading-font-family instead - not one custom property per level, since
+// .az-headings-mixed/.az-headings-serif below only ever need to set the same
+// value across every level they touch. A single heading can still be
+// overridden on its own (e.g. style="--az-heading-font-family: ...") without a
+// second property: set directly on an element, it wins over any inherited
+// value the normal way, no nested var() fallback required.
 @each $level, $props in $headings-scale {
   h#{$level},
   .h#{$level} {
     --az-h#{$level}-font-size: #{map-get($props, font-size)};
     --az-h#{$level}-line-height: #{map-get($props, line-height)};
 
-    font-family: var(--az-h#{$level}-font-family, #{$headings-font-family});
+    font-family: var(--az-heading-font-family, #{$headings-font-family});
     font-size: var(--az-h#{$level}-font-size);
     font-weight: #{map-get($props, font-weight)};
     line-height: var(--az-h#{$level}-line-height);

--- a/scss/override/_typography.scss
+++ b/scss/override/_typography.scss
@@ -60,6 +60,9 @@ h6,
     font-size: map-get($props, font-size);
     font-weight: #{map-get($props, font-weight)};
     line-height: map-get($props, line-height);
+    @if map-has-key($props, margin-top) {
+      margin-top: map-get($props, margin-top);
+    }
   }
 }
 

--- a/scss/override/_typography.scss
+++ b/scss/override/_typography.scss
@@ -27,6 +27,13 @@ figure:has(blockquote) > :last-child {
 */
 
 // >> h1 - h6
+// font-family is a shared, inherited custom property (not a plain value)
+// so .az-headings-mixed/.az-headings-serif can set it once per container
+// instead of once per heading level, and so a single heading can override it
+// directly (e.g. style="--az-heading-font-family: ..."). Falls back to
+// --bs-body-font-family - Bootstrap's own live custom property for this,
+// rather than a separately compiled value - so overriding that alone also
+// changes headings' default font.
 h1,
 h2,
 h3,
@@ -40,27 +47,16 @@ h6,
 .h5,
 .h6 {
   margin: $heading-margins;
+  font-family: var(--az-heading-font-family, var(--#{$prefix}body-font-family));
   color: $blue;
   letter-spacing: 0;
 }
 
-// font-family reads a single shared, inherited --az-heading-font-family custom
-// property (rather than a plain Sass value) specifically because
-// .az-headings-mixed/.az-headings-serif below need to set the same value
-// across several heading levels at once - a custom property on a container,
-// inherited down, does that in one declaration; plain CSS can't. A single
-// heading can also be overridden this way (e.g. style="--az-heading-font-family:
-// ..."), since setting it directly on an element wins over an inherited value
-// the normal way.
-//
-// font-size/line-height stay plain values - there's no equivalent case for
-// them (each level's size is already different, and a page overriding one
-// heading's size can just write font-size directly), so a custom property
-// here would just restate the same value on the same selector for no reason.
+// font-size/line-height/font-weight vary by level, so no custom property here -
+// a page overriding one heading's size can already write font-size directly.
 @each $level, $props in $headings-scale {
   h#{$level},
   .h#{$level} {
-    font-family: var(--az-heading-font-family, #{$headings-font-family});
     font-size: map-get($props, font-size);
     font-weight: #{map-get($props, font-weight)};
     line-height: map-get($props, line-height);

--- a/scss/override/_typography.scss
+++ b/scss/override/_typography.scss
@@ -44,25 +44,26 @@ h6,
   letter-spacing: 0;
 }
 
-// Each level's font-size/line-height are CSS custom properties, not applied
-// directly, so a single level can be adjusted (e.g. just --az-h2-font-size)
-// without a Sass rebuild. font-family reads a single shared, inherited
-// --az-heading-font-family instead - not one custom property per level, since
-// .az-headings-mixed/.az-headings-serif below only ever need to set the same
-// value across every level they touch. A single heading can still be
-// overridden on its own (e.g. style="--az-heading-font-family: ...") without a
-// second property: set directly on an element, it wins over any inherited
-// value the normal way, no nested var() fallback required.
+// font-family reads a single shared, inherited --az-heading-font-family custom
+// property (rather than a plain Sass value) specifically because
+// .az-headings-mixed/.az-headings-serif below need to set the same value
+// across several heading levels at once - a custom property on a container,
+// inherited down, does that in one declaration; plain CSS can't. A single
+// heading can also be overridden this way (e.g. style="--az-heading-font-family:
+// ..."), since setting it directly on an element wins over an inherited value
+// the normal way.
+//
+// font-size/line-height stay plain values - there's no equivalent case for
+// them (each level's size is already different, and a page overriding one
+// heading's size can just write font-size directly), so a custom property
+// here would just restate the same value on the same selector for no reason.
 @each $level, $props in $headings-scale {
   h#{$level},
   .h#{$level} {
-    --az-h#{$level}-font-size: #{map-get($props, font-size)};
-    --az-h#{$level}-line-height: #{map-get($props, line-height)};
-
     font-family: var(--az-heading-font-family, #{$headings-font-family});
-    font-size: var(--az-h#{$level}-font-size);
+    font-size: map-get($props, font-size);
     font-weight: #{map-get($props, font-weight)};
-    line-height: var(--az-h#{$level}-line-height);
+    line-height: map-get($props, line-height);
   }
 }
 
@@ -71,8 +72,8 @@ h6,
     @if map-has-key($props, font-size-lg) {
       h#{$level},
       .h#{$level} {
-        --az-h#{$level}-font-size: #{map-get($props, font-size-lg)};
-        --az-h#{$level}-line-height: #{map-get($props, line-height-lg)};
+        font-size: map-get($props, font-size-lg);
+        line-height: map-get($props, line-height-lg);
       }
     }
   }

--- a/scss/override/_typography.scss
+++ b/scss/override/_typography.scss
@@ -41,6 +41,37 @@ h6,
 .h6 {
   margin: $heading-margins;
   color: $blue;
+  letter-spacing: 0;
+}
+
+// Each level's font-size/line-height/font-family are CSS custom properties, not
+// applied directly, so a page can override a single level (e.g. just --az-h2-font-size)
+// without a Sass rebuild, and so .az-headings-mixed/.az-headings-serif below can
+// swap font-family with a one-line property override instead of restating this
+// whole selector list per opt-in class.
+@each $level, $props in $headings-scale {
+  h#{$level},
+  .h#{$level} {
+    --az-h#{$level}-font-size: #{map-get($props, font-size)};
+    --az-h#{$level}-line-height: #{map-get($props, line-height)};
+
+    font-family: var(--az-h#{$level}-font-family, #{$headings-font-family});
+    font-size: var(--az-h#{$level}-font-size);
+    font-weight: #{map-get($props, font-weight)};
+    line-height: var(--az-h#{$level}-line-height);
+  }
+}
+
+@include media-breakpoint-up(lg) {
+  @each $level, $props in $headings-scale {
+    @if map-has-key($props, font-size-lg) {
+      h#{$level},
+      .h#{$level} {
+        --az-h#{$level}-font-size: #{map-get($props, font-size-lg)};
+        --az-h#{$level}-line-height: #{map-get($props, line-height-lg)};
+      }
+    }
+  }
 }
 
 /*

--- a/site/content/docs/5.1/content/font.md
+++ b/site/content/docs/5.1/content/font.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Font
-description: The Proxima Nova font suite is available for official use by University of Arizona employees through a license with Adobe.
+description: Additional fonts are available for official use by University of Arizona employees through a license with Adobe.
 group: content
 toc: true
 extra_js:
@@ -11,13 +11,11 @@ extra_js:
 
 <div class="alert alert-warning" role="alert">
   <p class="h4 mt-0">Heads Up!</p>
-  If you're using Arizona Bootstrap, Proxima Nova will still need to be added to
-  your project.
+  If you're using Arizona Bootstrap, Proxima Nova and Garamond Premier Pro will still need to be added to your project.
 </div>
 
 ## How to Use
-The Proxima Nova font suite is available for official use by University of Arizona
-employees through a license with Adobe Typekit.
+The Proxima Nova and Garamond Premier Pro font suites are available for official use by University of Arizona employees through a license with Adobe Typekit.
 
 ### Reference link
 
@@ -27,8 +25,18 @@ manage our font reference links within Arizona Bootstrap.
 Put this within your `<head>` tag **above** the reference to Arizona Bootstrap.
 
 ```html
+<!-- Proxima Nova + Garamond Premier Pro reference. -->
+<link href="https://use.typekit.net/sgx0zzg.css" rel="stylesheet" crossorigin="anonymous">
+<!-- Arizona Bootstrap reference. -->
+<link rel="stylesheet" href="{{< param "cdn.css" >}}" crossorigin="anonymous">
+```
+
+Previous versions of Arizona Bootstrap required only Proxima Nova (and Garamond Premier Pro if AZ Navbar Fullscreen was used). Arizona Bootstrap 5.2 now requires both Proxima Nova and Garamond Premier Pro. If your application requires a lower version of Arizona Bootstrap than 5.2, use the legacy embed code(s).
+```html
 <!-- Proxima Nova reference. -->
 <link href="https://use.typekit.net/emv3zbo.css" rel="stylesheet" crossorigin="anonymous">
+<!-- Garamond Premier Pro reference (only needed for AZ Navbar Fullscreen). -->
+<link href="https://use.typekit.net/eyf6fhr.css" rel="stylesheet" crossorigin="anonymous">
 <!-- Arizona Bootstrap reference. -->
 <link rel="stylesheet" href="{{< param "cdn.css" >}}" crossorigin="anonymous">
 ```

--- a/site/content/docs/5.1/content/font.md
+++ b/site/content/docs/5.1/content/font.md
@@ -41,7 +41,7 @@ Previous versions of Arizona Bootstrap required only Proxima Nova (and Garamond 
 <link rel="stylesheet" href="{{< param "cdn.css" >}}" crossorigin="anonymous">
 ```
 
-## Centrally-managed Typekit Webfont
+## Centrally-managed Typekit Webfonts
 
 For ease of integration into web projects around campus, the Arizona Digital
 team manages a Typekit webfont project that can be referenced by your site.

--- a/site/content/docs/5.1/content/typography.md
+++ b/site/content/docs/5.1/content/typography.md
@@ -115,7 +115,7 @@ Add the `.az-headings-serif` class to a container (such as `<body>` or any wrapp
 
 ### Switching a single heading's font without a wrapper
 
-Heading font-family reads a shared `--az-heading-font-family` custom property — the same one `.az-headings-mixed`/`.az-headings-serif` above set on a container. Setting it directly on one heading works the same way, for a one-off case that doesn't need a wrapping element or a new utility class.
+Heading font-family reads a shared `--az-heading-font-family` custom property — the same one `.az-headings-serif` sets on a container and `.az-headings-mixed` sets on its `h1`–`h3`/`.h1`–`.h3` descendants above. Setting it directly on one heading works the same way, for a one-off case that doesn't need a wrapping element or a new utility class.
 
 {{< example >}}
 <h2 style="--az-heading-font-family: garamond-premier-pro, Georgia, 'Times New Roman', serif;">h2. Just this heading, in serif</h2>

--- a/site/content/docs/5.1/content/typography.md
+++ b/site/content/docs/5.1/content/typography.md
@@ -115,10 +115,10 @@ Add the `.az-headings-serif` class to a container (such as `<body>` or any wrapp
 
 ### Overriding a single heading level
 
-Each heading level's font-size, line-height, and font-family are CSS custom properties (`--az-h1-font-size`, `--az-h1-line-height`, `--az-h1-font-family`, and so on through `h6`) rather than fixed values, so a single level can be adjusted on a specific page or component without a Sass rebuild — no new utility class needed for one-off cases.
+Each heading level's font-size and line-height are CSS custom properties (`--az-h1-font-size`, `--az-h1-line-height`, and so on through `h6`) rather than fixed values, and font-family reads a shared `--az-heading-font-family` (the same one `.az-headings-mixed`/`.az-headings-serif` above set), so any of these can be adjusted on a specific page or component without a Sass rebuild — no new utility class needed for one-off cases.
 
 {{< example >}}
-<h2 style="--az-h2-font-family: garamond-premier-pro, Georgia, 'Times New Roman', serif;">h2. Just this heading, in serif</h2>
+<h2 style="--az-heading-font-family: garamond-premier-pro, Georgia, 'Times New Roman', serif;">h2. Just this heading, in serif</h2>
 {{< /example >}}
 
 ### Customizing headings

--- a/site/content/docs/5.1/content/typography.md
+++ b/site/content/docs/5.1/content/typography.md
@@ -53,6 +53,74 @@ All HTML headings, `<h1>` through `<h6>`, are available.
 <p class="h6">h6. Bootstrap heading</p>
 {{< /example >}}
 
+### Mixed headings
+
+<span class="badge badge-az-custom">Custom Arizona Bootstrap Class</span>
+
+Add the `.az-headings-mixed` class to a container (such as `<body>` or any wrapping element) to switch that container's `<h1>`-`<h3>` and `.h1`-`.h3` to the serif type stack, leaving `<h4>`-`<h6>` and `.h4`-`.h6` on Proxima Nova.
+
+{{< example >}}
+<div class="az-headings-mixed">
+  <h1>h1. Bootstrap heading</h1>
+  <h2>h2. Bootstrap heading</h2>
+  <h3>h3. Bootstrap heading</h3>
+  <h4>h4. Bootstrap heading</h4>
+  <h5>h5. Bootstrap heading</h5>
+  <h6>h6. Bootstrap heading</h6>
+</div>
+{{< /example >}}
+
+`.h1` through `.h6` classes can also be used in place of the associated HTML element within a container using `.az-headings-mixed`.
+
+{{< example >}}
+<div class="az-headings-mixed">
+  <p class="h1">h1. Bootstrap heading</p>
+  <p class="h2">h2. Bootstrap heading</p>
+  <p class="h3">h3. Bootstrap heading</p>
+  <p class="h4">h4. Bootstrap heading</p>
+  <p class="h5">h5. Bootstrap heading</p>
+  <p class="h6">h6. Bootstrap heading</p>
+</div>
+{{< /example >}}
+
+### Serif headings
+
+<span class="badge badge-az-custom">Custom Arizona Bootstrap Class</span>
+
+Add the `.az-headings-serif` class to a container (such as `<body>` or any wrapping element) to switch all of that container's `<h1>`-`<h6>` and `.h1`-`.h6` to the serif type stack.
+
+{{< example >}}
+<div class="az-headings-serif">
+  <h1>h1. Bootstrap heading</h1>
+  <h2>h2. Bootstrap heading</h2>
+  <h3>h3. Bootstrap heading</h3>
+  <h4>h4. Bootstrap heading</h4>
+  <h5>h5. Bootstrap heading</h5>
+  <h6>h6. Bootstrap heading</h6>
+</div>
+{{< /example >}}
+
+`.h1` through `.h6` classes can also be used in place of the associated HTML element within a container using `.az-headings-serif`.
+
+{{< example >}}
+<div class="az-headings-serif">
+  <p class="h1">h1. Bootstrap heading</p>
+  <p class="h2">h2. Bootstrap heading</p>
+  <p class="h3">h3. Bootstrap heading</p>
+  <p class="h4">h4. Bootstrap heading</p>
+  <p class="h5">h5. Bootstrap heading</p>
+  <p class="h6">h6. Bootstrap heading</p>
+</div>
+{{< /example >}}
+
+### Overriding a single heading level
+
+Each heading level's font-size, line-height, and font-family are CSS custom properties (`--az-h1-font-size`, `--az-h1-line-height`, `--az-h1-font-family`, and so on through `h6`) rather than fixed values, so a single level can be adjusted on a specific page or component without a Sass rebuild — no new utility class needed for one-off cases.
+
+{{< example >}}
+<h2 style="--az-h2-font-family: garamond-premier-pro, Georgia, 'Times New Roman', serif;">h2. Just this heading, in serif</h2>
+{{< /example >}}
+
 ### Customizing headings
 
 Use the included utility classes to recreate the small secondary heading text from Bootstrap 3.

--- a/site/content/docs/5.1/content/typography.md
+++ b/site/content/docs/5.1/content/typography.md
@@ -113,9 +113,9 @@ Add the `.az-headings-serif` class to a container (such as `<body>` or any wrapp
 </div>
 {{< /example >}}
 
-### Overriding a single heading level
+### Switching a single heading's font without a wrapper
 
-Each heading level's font-size and line-height are CSS custom properties (`--az-h1-font-size`, `--az-h1-line-height`, and so on through `h6`) rather than fixed values, and font-family reads a shared `--az-heading-font-family` (the same one `.az-headings-mixed`/`.az-headings-serif` above set), so any of these can be adjusted on a specific page or component without a Sass rebuild — no new utility class needed for one-off cases.
+Heading font-family reads a shared `--az-heading-font-family` custom property — the same one `.az-headings-mixed`/`.az-headings-serif` above set on a container. Setting it directly on one heading works the same way, for a one-off case that doesn't need a wrapping element or a new utility class.
 
 {{< example >}}
 <h2 style="--az-heading-font-family: garamond-premier-pro, Georgia, 'Times New Roman', serif;">h2. Just this heading, in serif</h2>

--- a/site/layouts/partials/stylesheet.html
+++ b/site/layouts/partials/stylesheet.html
@@ -1,7 +1,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,1,0" rel="stylesheet">
 <link href="https://cdn.digital.arizona.edu/lib/az-icons/main/az-icons-styles.css" rel="stylesheet">
-<link href="https://use.typekit.net/emv3zbo.css" rel="stylesheet" crossorigin="anonymous">
-<link href="https://use.typekit.net/eyf6fhr.css" rel="stylesheet" crossorigin="anonymous">
+<!-- Proxima Nova and Garamond Premier Pro style sheet. -->
+<link href="https://use.typekit.net/sgx0zzg.css" rel="stylesheet" crossorigin="anonymous">
 {{ if hugo.IsProduction -}}
 {{ if eq .Page.Params.direction "rtl" -}}
 <link href="{{- (printf `docs/%s%s` $.Site.Params.docs_version `/dist/css/arizona-bootstrap.rtl.min.css`) | relURL -}}" rel="stylesheet">


### PR DESCRIPTION
Original description:
~~Alternate implementation to #2240, same feature (heading type scale +
.az-headings-mixed/.az-headings-serif opt-in serif classes), different
mechanism: each heading level's font-size, line-height, and font-family
are CSS custom properties (--az-h1-font-size, --az-h1-font-family, etc.)
rather than values compiled directly into each selector.~~

~~This means:~~
- ~~The two opt-in classes are one-line custom property overrides per
  level instead of restating the full h1-h6/.h1-.h6 selector list with
  the font-family value baked in twice (once per class).~~
- ~~A single heading level can be overridden inline or scoped to one
  page/component (e.g. style="--az-h2-font-family: ...") without a
  Sass rebuild or a new utility class - not possible with #2240's
  approach, which only exposes two fixed states (mixed, serif).~~
- ~~Matches the existing --az-list-marker precedent in
  scss/mixins/_az-color-contrast.scss, which already uses a custom
  property so a value can be swapped per-context.~~

Updated:
Alternate implementation to #2240, same feature (heading type scale +
.az-headings-mixed/.az-headings-serif opt-in serif classes), different
mechanism: font-family is exposed as a shared, inherited CSS custom property
(--az-heading-font-family, falling back to Bootstrap's own
--bs-body-font-family) rather than baked into each selector. font-size/
line-height/font-weight still vary per level and are compiled from the
$headings-scale Sass map, since overriding one heading's size can already be
done directly with font-size.

This means:
- The two opt-in classes are one-line custom property overrides
  (.az-headings-serif on the container; .az-headings-mixed on its
  h1-h3/.h1-.h3 descendants) instead of restating the full h1-h6/.h1-.h6
  selector list with the font-family value baked in twice (once per class).
- A single heading can have its font-family overridden inline or scoped to
  one page/component (e.g. style="--az-heading-font-family: ...") without a
  Sass rebuild or a new utility class - not possible with #2240's approach,
  which only exposes two fixed states (mixed, serif).
- Matches the existing --az-list-marker precedent in
  scss/mixins/_az-color-contrast.scss, which already uses a custom property
  so a value can be swapped per-context.

Verified live against the docs dev server: type scale (mobile + lg
breakpoint), both opt-in classes (including that .az-headings-mixed
correctly leaves h4-h6 on Proxima Nova), and the single-heading
override all render correctly. Full lint suite (stylelint, fusv,
eslint) passes clean.

## How to test
- [Review site](https://review.digital.arizona.edu/arizona-bootstrap/issue/2086-css-custom-properties/)
- [Typography](https://review.digital.arizona.edu/arizona-bootstrap/issue/2086-css-custom-properties/docs/5.1/content/typography/)
    - [Headings](https://review.digital.arizona.edu/arizona-bootstrap/issue/2086-css-custom-properties/docs/5.1/content/typography/#headings)
    - [Mixed headings](https://review.digital.arizona.edu/arizona-bootstrap/issue/2086-css-custom-properties/docs/5.1/content/typography/#mixed-headings)
    - [Serif headings](https://review.digital.arizona.edu/arizona-bootstrap/issue/2086-css-custom-properties/docs/5.1/content/typography/#serif-headings)
    - [Switching a single heading's font without a wrapper](https://review.digital.arizona.edu/arizona-bootstrap/issue/2086-css-custom-properties/docs/5.1/content/typography/#switching-a-single-headings-font-without-a-wrapper)