### PR TITLE
Closes #2283: Typography changes

### DIFF
--- a/scss/override/_typography.scss
+++ b/scss/override/_typography.scss
@@ -34,7 +34,7 @@ figure:has(blockquote) > :last-child {
 */
 small,
 .small {
-  line-height: 1.5; // 24px at $small-font-size (16px)
+  line-height: 1.5; // 24px when small computes to 16px (e.g. 18px body context)
 }
 
 /*

--- a/scss/override/_typography.scss
+++ b/scss/override/_typography.scss
@@ -23,6 +23,21 @@ figure:has(blockquote) > :last-child {
 }
 
 /*
+* > LEAD
+*/
+.lead {
+  line-height: 1.5; // 30px at $lead-font-size (20px)
+}
+
+/*
+* > SMALL
+*/
+small,
+.small {
+  line-height: 1.5; // 24px at $small-font-size (16px)
+}
+
+/*
 * > HEADINGS
 */
 

--- a/scss/override/_variables.scss
+++ b/scss/override/_variables.scss
@@ -34,10 +34,13 @@ $enable-dark-mode: false;
 * > FONTS
 */
 $font-size-base: 1.125rem;
+$line-height-base: 1.5556; // 28px at $font-size-base (18px)
 $link-color: $red;
 $link-hover-color: $chili;
 // fusv-disable
-$lead-font-weight: 400;
+$lead-font-size: 1.25rem; // 20px
+$lead-font-weight: 500;
+$small-font-size: .8889em; // 16px at $font-size-base (18px)
 // fusv-enable
 
 /*

--- a/scss/override/_variables.scss
+++ b/scss/override/_variables.scss
@@ -40,7 +40,7 @@ $link-hover-color: $chili;
 // fusv-disable
 $lead-font-size: 1.25rem; // 20px
 $lead-font-weight: 500;
-$small-font-size: .8889em; // 16px at $font-size-base (18px)
+$small-font-size: 1rem;
 // fusv-enable
 
 /*


### PR DESCRIPTION
Closes #2283.

### Summary
Updates body copy, lead copy, and small copy to match the updated character styles ([Adobe XD spec](https://xd.adobe.com/view/5e5859af-459f-438c-83e0-963b6791dd91-0b0b/screen/58e05317-d33a-431b-a368-84cffa69e074/)), completing the typography work started in #2273.

### Conditions of satisfaction
- [x] Body copy line-height is 28px (was 27px — this ratio was mistakenly left out of #2273, which only updated `$font-size-base`)
- [x] Lead copy is 20px / 30px, weight 500 (was 22.5px / 33.75px, weight 400)
- [x] Small Body Copy is 16px / 24px (was ~15.75px / 23.6px)

### Changes
**`scss/override/_variables.scss`**
- Added `$line-height-base: 1.5556;` (28px at the 18px `$font-size-base`)
- Added `$lead-font-size: 1.25rem;` (20px, explicit instead of the default `$font-size-base * 1.25` multiplier)
- Changed `$lead-font-weight` from `400` to `500`
- ~~Added `$small-font-size: .8889em;` (16px within the default 18px body-copy context)~~ _On Sept 1 at the Bootstrap 5.2 Touch Base meeting, we decided to implement this with 1rem (still 16px)_

**`scss/override/_typography.scss`**
- Added `.lead { line-height: 1.5; }` → 30px at the new 20px lead font-size
- Added `small, .small { line-height: 1.5; }` → 24px at the new 16px small font-size

### Decisions
- **Overrode the shared `$line-height-base` Sass variable** (rather than a scoped `body` rule) to match the precedent set by #2273 for `$font-size-base`. This also affects nav-link height, navbar-brand height, modal title line-height, form-check sizing, and the custom `.az-list-focus-points`/`.az-list-checkmarks` marker height, since those all derive from `$line-height-base` at compile time. Explicit `.lead` and `small`/`.small` overrides were added because their target ratio (1.5) differs from the new body ratio (1.5556) and would otherwise inherit the wrong line-height.
- ~~**`$small-font-size` stays proportional (em-based)** rather than a fixed px/rem value, matching Bootstrap's existing relative-sizing convention for `<small>`/`.small` so it still scales down correctly when nested in larger text (e.g. headings).~~
- **Text color (Tinta #03132E / White) is out of scope** — not part of the issue's conditions of satisfaction checklist, only shown for reference in the design image.
- `site/assets/scss/_masthead.scss`'s own `.lead` overrides (docs-site marketing hero styling) are intentionally untouched.

### Notes
- At the Sept 1 Bootstrap 5.2.0 Touch Base meeting, we were interested in changing $line-height-base to 1.75rem (16 (px) * 1.75rem = 28px). Bootstrap does not compile with this change. Here is the Claude explanation:
    - $line-height-base must stay unitless, not 1.75rem. Bootstrap consumes it as a plain multiplier in several derived calculations — e.g. $font-size-base * $line-height-base (used for $nav-link-height, $navbar-brand-height, $form-check-min-height, etc.). Sass cannot multiply two dimensioned values together (calc(1.75rem * 1em) is not a valid CSS value), so setting it to 1.75rem breaks the build entirely.

### How to test
1. See review site: https://review.digital.arizona.edu/arizona-bootstrap/issue/2283/
2. On the [Typography](https://review.digital.arizona.edu/arizona-bootstrap/issue/2283/docs/5.1/content/typography/) doc page, confirm:
   - Body paragraphs render at 18px / 28px line-height
   - `.lead` paragraphs render at 20px / 30px, medium weight (500)
   - `<small>` / `.small` text renders at 16px / 24px
3. Spot-check components that derive sizing from `$line-height-base` to confirm no _signficant_ visual regressions:
   - Navbar (nav-link height, brand height)
   - Buttons and form inputs
   - Modal title spacing
   - Checkbox/radio vertical alignment (`.form-check`)
   - Focus-point and checkmark list markers (`.az-list-focus-points`, `.az-list-checkmarks`)