### PR TITLE
Fixes #2291: .bd-title changes font-size on docs site

### DIFF
--- a/site/assets/scss/_content.scss
+++ b/site/assets/scss/_content.scss
@@ -103,7 +103,6 @@
 
 .bd-title {
   --bs-heading-color: var(--bs-emphasis-color);
-  @include font-size(3rem);
 }
 
 .bd-lead {

--- a/site/assets/scss/_content.scss
+++ b/site/assets/scss/_content.scss
@@ -103,6 +103,7 @@
 
 .bd-title {
   --bs-heading-color: var(--bs-emphasis-color);
+  @include font-size(3rem);
 }
 
 .bd-lead {

--- a/site/assets/scss/_custom-docs.scss
+++ b/site/assets/scss/_custom-docs.scss
@@ -285,6 +285,19 @@
 // > CONTENT
 //
 
+// >> Page title
+// Upstream Bootstrap's docs pin .bd-title to a flat, RFS-scaled 3rem, which
+// beats Arizona Bootstrap's own h1 sizing (3rem, growing to 4rem at $lg).
+// .bd-title is only ever applied to an h1, so re-assert the h1 values from
+// $headings-scale and let docs page titles match headings everywhere else.
+.bd-title {
+  font-size: map-get(map-get($headings-scale, 1), font-size);
+
+  @include media-breakpoint-up(lg) {
+    font-size: map-get(map-get($headings-scale, 1), font-size-lg);
+  }
+}
+
 // >> Font
 .proxima-nova-bold {
   font-family: proxima-nova, sans-serif;


### PR DESCRIPTION
See #2291

_Note: `.bd-*` classes are Bootstrap docs specific styles._

## How to test
[Review site](https://review.digital.arizona.edu/arizona-bootstrap/bug/2291/)
1. Confirm that H1s with the `.bd-title` class are bigger than H2s. This regression was first observed on the [Buttons](https://review.digital.arizona.edu/arizona-bootstrap/bug/2291/docs/5.1/components/buttons/) docs page.
2. The `.bd-title` class no longer sets a font size, which should allow the new heading styles to come through. For H1s, the font size should be 64px and the line height should be 74px per #2240.