### PR TITLE
Docs suggestions for Accordion Anchor Links

### DIFF
--- a/scss/custom/_accordion.scss
+++ b/scss/custom/_accordion.scss
@@ -2,9 +2,10 @@
 // > Arizona Accordion custom component
 //
 
-// Scroll offset reflects the header size with some extra top padding
+// No offset by default - most consumer sites have no fixed/sticky header.
+// Sites that do have one should override this variable to match its height.
 :root {
-  --az-accordion-anchor-scroll-offset: 86px;
+  --az-accordion-anchor-scroll-offset: 0;
 }
 
 // Flex alignment/spacing (icon and text can differ arbitrarily in height -

--- a/site/assets/scss/_scrolling.scss
+++ b/site/assets/scss/_scrolling.scss
@@ -14,3 +14,10 @@ main {
     scroll-margin-bottom: 100px;
   }
 }
+
+// This docs site has a sticky header - restore the accordion anchor scroll
+// offset the component itself defaults to 0, since most consumer sites
+// don't have one.
+:root {
+  --az-accordion-anchor-scroll-offset: 86px;
+}

--- a/site/content/docs/5.1/components/accordion.md
+++ b/site/content/docs/5.1/components/accordion.md
@@ -151,19 +151,20 @@ Omit the `data-bs-parent` attribute on each `.accordion-collapse` to make accord
 {{< /example >}}
 
 ### Anchored
-Anchored links allow users to click to copy links directly to accordions. The copied link will auto-scroll to the referenced accordion and open it. Useful for longer pages or pages with a lot of accordions, such as FAQs.
 
-On page load, the page will scroll to the anchor with the offset set by the variable <code>--az-static-scroll-offset</code>.
+Give each `.accordion-header` a unique `id`, then add a `.az-accordion-anchor` link inside its `.accordion-body` whose `href` points at that `id`. Clicking the link copies the item's full URL to the clipboard; visiting that URL opens the item and scrolls to it.
+
+This is built into Arizona Bootstrap's JavaScript, so no additional script is required — though the "Copied!" confirmation depends on [Bootstrap's tooltip plugin]({{< docsref "/components/tooltips" >}}) being initialized on the page.
 
 <div class="bd-callout bd-callout-warning">
-  <p>Anchored accordions use the <strong>Always Open</strong> accordion style by default. If anchors are used with a <code>data-bs-parent</code> tag, loading anchored pages may cause unintentional autoscrolling issues.</p>
+  <p>Anchored accordions work best in the <strong>Always open</strong> style — omit <code>data-bs-parent</code>, as the example below does. With <code>data-bs-parent</code>, opening a linked item also collapses its sibling, and on a fresh page load the browser jumps to the anchor before that collapse finishes, which can read as a stutter as the position corrects.</p>
 </div>
 
 {{< example >}}
 <div class="accordion" id="accordionAnchorExample">
   <div class="accordion-item">
-    <h2 class="accordion-header" id="AnchoredAccordion1">
-      <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseAnchor1" tabindex="0" aria-expanded="true" aria-controls="collapseAnchor1">
+    <h2 class="accordion-header" id="accordionAnchor1">
+      <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseAnchor1" aria-expanded="true" aria-controls="collapseAnchor1">
         Accordion Item #1
       </button>
     </h2>
@@ -171,7 +172,7 @@ On page load, the page will scroll to the anchor with the offset set by the vari
       <div class="accordion-body">
         <strong>This is the first item's accordion body.</strong> It is shown by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. It's also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
         <div class="pt-2">
-          <a class="az-accordion-anchor icon-link" href="#AnchoredAccordion1" tabindex="0" data-bs-toggle="tooltip" data-bs-title="Copied!" data-bs-trigger="click">
+          <a class="az-accordion-anchor icon-link" href="#accordionAnchor1" data-bs-toggle="tooltip" data-bs-title="Copied!" data-bs-trigger="click">
             <span class="material-symbols-rounded" aria-hidden="true">link</span>
             <span>Copy link</span>
           </a>
@@ -180,8 +181,8 @@ On page load, the page will scroll to the anchor with the offset set by the vari
     </div>
   </div>
   <div class="accordion-item">
-    <h2 class="accordion-header" id="AnchoredAccordion2">
-      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseAnchor2" aria-expanded="true" aria-controls="collapseAnchor2">
+    <h2 class="accordion-header" id="accordionAnchor2">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseAnchor2" aria-expanded="false" aria-controls="collapseAnchor2">
         Accordion Item #2
       </button>
     </h2>
@@ -189,7 +190,7 @@ On page load, the page will scroll to the anchor with the offset set by the vari
       <div class="accordion-body">
         <strong>This is the second item's accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. It's also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
         <div class="pt-2">
-          <a class="az-accordion-anchor icon-link" href="#AnchoredAccordion2" tabindex="0" data-bs-toggle="tooltip" data-bs-title="Copied!" data-bs-trigger="click">
+          <a class="az-accordion-anchor icon-link" href="#accordionAnchor2" data-bs-toggle="tooltip" data-bs-title="Copied!" data-bs-trigger="click">
             <span class="material-symbols-rounded" aria-hidden="true">link</span>
             <span>Copy link</span>
           </a>
@@ -198,8 +199,8 @@ On page load, the page will scroll to the anchor with the offset set by the vari
     </div>
   </div>
   <div class="accordion-item">
-    <h2 class="accordion-header" id="AnchoredAccordion3">
-      <button class="accordion-button collapsed" type="button" tabindex="0" data-bs-toggle="collapse" data-bs-target="#collapseAnchor3" aria-expanded="true" aria-controls="collapseAnchor3">
+    <h2 class="accordion-header" id="accordionAnchor3">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseAnchor3" aria-expanded="false" aria-controls="collapseAnchor3">
         Accordion Item #3
       </button>
     </h2>
@@ -207,7 +208,7 @@ On page load, the page will scroll to the anchor with the offset set by the vari
       <div class="accordion-body">
         <strong>This is the third item's accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. It's also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
         <div class="pt-2">
-          <a class="az-accordion-anchor icon-link" href="#AnchoredAccordion3" tabindex="0" data-bs-toggle="tooltip" data-bs-title="Copied!" data-bs-trigger="click">
+          <a class="az-accordion-anchor icon-link" href="#accordionAnchor3" data-bs-toggle="tooltip" data-bs-title="Copied!" data-bs-trigger="click">
             <span class="material-symbols-rounded" aria-hidden="true">link</span>
             <span>Copy link</span>
           </a>
@@ -218,6 +219,19 @@ On page load, the page will scroll to the anchor with the offset set by the vari
 </div>
 {{< /example >}}
 
+#### Scroll offset
+
+If your site has a fixed or sticky header, set the `--az-accordion-anchor-scroll-offset` CSS variable in your own site's CSS to that header's height — plus a little more, if you want some breathing room — so it doesn't cover the accordion item when a hash-linked item scrolls into view:
+
+```css
+:root {
+  --az-accordion-anchor-scroll-offset: 64px; /* match your header's height */
+}
+```
+
+Most sites don't need this — the offset defaults to `0`. The scroll happens both on page load and afterward, whenever the page's hash changes again (from another in-page link, or the browser's back/forward buttons).
+
+The Arizona Bootstrap docs site overrides this property to `86px`, which is approximately 66px for the fixed navbar height and another 20px for breathing room.
 
 ## Accessibility
 


### PR DESCRIPTION
See #2247.

## Changes
- Fixed a wrong variable name in the Anchored section — it referenced `--az-static-scroll-offset`, which doesn't exist anywhere in the codebase. The real one is `--az-accordion-anchor-scroll-offset`.
- Fixed `aria-expanded="true"` on the two collapsed items in the Anchored example; both should be `false` to match their actual state.
- Rewrote the Anchored intro to state the `id` ↔ `href` wiring explicitly, and to note that the "Copied!" confirmation depends on Bootstrap's tooltip plugin being initialized (the bundle doesn't auto-initialize it).
- Reworded the warning callout — `data-bs-parent` is an attribute rather than a "tag," and the symptom described now matches the actual load-time behavior.
- Renamed the example ids from `AnchoredAccordionN` to `accordionAnchorN` to match the camelCase convention used elsewhere in the file, and dropped redundant `tabindex="0"` from natively focusable buttons and links.
- Added a `#### Scroll offset` subsection documenting the variable, its default, and how to override it downstream.
- Changed the `--az-accordion-anchor-scroll-offset` default from `86px` to `0` — that value only makes sense on a site with a fixed header, which most consumer sites don't have.
- Added a docs-site-only override restoring `86px` in `site/assets/scss/_scrolling.scss`, since this docs site does have a sticky navbar.

To be merged into #2247.

https://review.digital.arizona.edu/arizona-bootstrap/issue-295-docs/docs/5.1/components/accordion/#anchored
