### PR TITLE
Suggested edits

### DIFF
--- a/scss/arizona-bootstrap.scss
+++ b/scss/arizona-bootstrap.scss
@@ -1,6 +1,8 @@
 // Upstream Bootstrap functions before anything else.
 @import "../node_modules/bootstrap/scss/functions";
 
+@import "custom/scrolling";
+
 // Arizona Bootstrap custom variables.
 @import "custom/variables";
 

--- a/scss/custom/_accordion.scss
+++ b/scss/custom/_accordion.scss
@@ -2,12 +2,6 @@
 // > Arizona Accordion custom component
 //
 
-// No offset by default - most consumer sites have no fixed/sticky header.
-// Sites that do have one should override this variable to match its height.
-:root {
-  --az-accordion-anchor-scroll-offset: 0;
-}
-
 // Flex alignment/spacing (icon and text can differ arbitrarily in height -
 // the Material Symbols icon is a fixed 24px, unrelated to $font-size-base,
 // while the text scales with it) comes from Bootstrap's .icon-link helper

--- a/scss/custom/_arizona-header.scss
+++ b/scss/custom/_arizona-header.scss
@@ -18,11 +18,7 @@
 @media screen and (max-width: 992px) {
   body:has(.az-fixed-header-on-mobile) {
     padding-top: 50px;
-    :target {
-      scroll-behavior: var(--az-scroll-behavior);
-      scroll-margin-top: var(--az-scroll-margin-top);
-      scroll-margin-bottom: var(--az-scroll-margin-bottom);
-    }
+    --az-scroll-margin-top: 58px;
   }
   .arizona-header {
     height: 50px;

--- a/scss/custom/_arizona-header.scss
+++ b/scss/custom/_arizona-header.scss
@@ -18,9 +18,10 @@
 @media screen and (max-width: 992px) {
   body:has(.az-fixed-header-on-mobile) {
     padding-top: 50px;
-
     :target {
-      scroll-margin-top: 58px;
+      scroll-behavior: var(--az-scroll-behavior);
+      scroll-margin-top: var(--az-scroll-margin-top);
+      scroll-margin-bottom: var(--az-scroll-margin-bottom);
     }
   }
   .arizona-header {

--- a/scss/custom/_arizona-header.scss
+++ b/scss/custom/_arizona-header.scss
@@ -17,8 +17,8 @@
 
 @media screen and (max-width: 992px) {
   body:has(.az-fixed-header-on-mobile) {
-    padding-top: 50px;
     --az-scroll-margin-top: 58px;
+    padding-top: 50px;
   }
   .arizona-header {
     height: 50px;

--- a/scss/custom/_scrolling.scss
+++ b/scss/custom/_scrolling.scss
@@ -1,0 +1,8 @@
+/*
+* > SCROLLING
+*/
+:root {
+    --az-scroll-behavior: smooth;
+    --az-scroll-margin-top: 0px;
+    --az-scroll-margin-bottom: 0px;
+}

--- a/scss/custom/_scrolling.scss
+++ b/scss/custom/_scrolling.scss
@@ -8,17 +8,17 @@
 }
 
 main {
-    a,
-    button,
-    input,
-    select,
-    textarea,
-    h2,
-    h3,
-    h4,
-    [tabindex="0"] {
-      scroll-behavior: var(--az-scroll-behavior);
+  a,
+  button,
+  input,
+  select,
+  textarea,
+  h2,
+  h3,
+  h4,
+  [tabindex="0"] {
+     scroll-behavior: var(--az-scroll-behavior);
       scroll-margin-top: var(--az-scroll-margin-top);
       scroll-margin-bottom: var(--az-scroll-margin-bottom);
-    }
+  }
 }

--- a/scss/custom/_scrolling.scss
+++ b/scss/custom/_scrolling.scss
@@ -2,7 +2,7 @@
 * > SCROLLING
 */
 :root {
-    --az-scroll-behavior: smooth;
-    --az-scroll-margin-top: 0px;
-    --az-scroll-margin-bottom: 0px;
+  --az-scroll-behavior: smooth;
+  --az-scroll-margin-top: 0px;
+  --az-scroll-margin-bottom: 0px;
 }

--- a/scss/custom/_scrolling.scss
+++ b/scss/custom/_scrolling.scss
@@ -17,8 +17,8 @@ main {
   h3,
   h4,
   [tabindex="0"] {
-     scroll-behavior: var(--az-scroll-behavior);
-      scroll-margin-top: var(--az-scroll-margin-top);
-      scroll-margin-bottom: var(--az-scroll-margin-bottom);
+    scroll-behavior: var(--az-scroll-behavior);
+    scroll-margin-top: var(--az-scroll-margin-top);
+    scroll-margin-bottom: var(--az-scroll-margin-bottom);
   }
 }

--- a/scss/custom/_scrolling.scss
+++ b/scss/custom/_scrolling.scss
@@ -17,8 +17,8 @@ main {
     h3,
     h4,
     [tabindex="0"] {
-        scroll-behavior: var(--az-scroll-behavior);
-        scroll-margin-top: var(--az-scroll-margin-top);
-        scroll-margin-bottom: var(--az-scroll-margin-bottom);
+      scroll-behavior: var(--az-scroll-behavior);
+      scroll-margin-top: var(--az-scroll-margin-top);
+      scroll-margin-bottom: var(--az-scroll-margin-bottom);
     }
 }

--- a/scss/custom/_scrolling.scss
+++ b/scss/custom/_scrolling.scss
@@ -7,18 +7,8 @@
   --az-scroll-margin-bottom: 0px;
 }
 
-main {
-  a,
-  button,
-  input,
-  select,
-  textarea,
-  h2,
-  h3,
-  h4,
-  [tabindex="0"] {
-    scroll-behavior: var(--az-scroll-behavior);
-    scroll-margin-top: var(--az-scroll-margin-top);
-    scroll-margin-bottom: var(--az-scroll-margin-bottom);
-  }
+:target {
+  scroll-behavior: var(--az-scroll-behavior);
+  scroll-margin-top: var(--az-scroll-margin-top);
+  scroll-margin-bottom: var(--az-scroll-margin-bottom);
 }

--- a/scss/custom/_scrolling.scss
+++ b/scss/custom/_scrolling.scss
@@ -6,3 +6,19 @@
   --az-scroll-margin-top: 0px;
   --az-scroll-margin-bottom: 0px;
 }
+
+main {
+    a,
+    button,
+    input,
+    select,
+    textarea,
+    h2,
+    h3,
+    h4,
+    [tabindex="0"] {
+        scroll-behavior: var(--az-scroll-behavior);
+        scroll-margin-top: var(--az-scroll-margin-top);
+        scroll-margin-bottom: var(--az-scroll-margin-bottom);
+    }
+}

--- a/scss/custom/_variables.scss
+++ b/scss/custom/_variables.scss
@@ -383,6 +383,15 @@ $colors: (
 // scss-docs-end colors-map
 
 /*
+* > SCROLLING
+*/
+:root {
+  --az-scroll-behavior: smooth;
+  --az-scroll-margin-top: 0px;
+  --az-scroll-margin-bottom: 0px;
+}
+
+/*
 * > FONTS
 */
 // stylelint-disable value-keyword-case

--- a/scss/custom/_variables.scss
+++ b/scss/custom/_variables.scss
@@ -383,15 +383,6 @@ $colors: (
 // scss-docs-end colors-map
 
 /*
-* > SCROLLING
-*/
-:root {
-  --az-scroll-behavior: smooth;
-  --az-scroll-margin-top: 0px;
-  --az-scroll-margin-bottom: 0px;
-}
-
-/*
 * > FONTS
 */
 // stylelint-disable value-keyword-case

--- a/scss/override/_accordion.scss
+++ b/scss/override/_accordion.scss
@@ -16,6 +16,4 @@
   line-height: inherit;
   color: inherit;
   letter-spacing: normal;
-  scroll-margin-top: var(--az-scroll-margin-top);
-  scroll-behavior: var(--az-scroll-behavior);
 }

--- a/scss/override/_accordion.scss
+++ b/scss/override/_accordion.scss
@@ -16,6 +16,6 @@
   line-height: inherit;
   color: inherit;
   letter-spacing: normal;
-  scroll-margin-top: var(--az-accordion-anchor-scroll-offset);
-  scroll-behavior: smooth;
+  scroll-margin-top: var(--az-scroll-margin-top);
+  scroll-behavior: var(--az-scroll-behavior);
 }

--- a/site/assets/scss/_scrolling.scss
+++ b/site/assets/scss/_scrolling.scss
@@ -1,10 +1,4 @@
 // When navigating with the keyboard, prevent focus from landing behind the sticky header
-:root {
-  --az-scroll-behavior: smooth;
-  --az-scroll-margin-top: 80px;
-  --az-scroll-margin-bottom: 100px;
-}
-
 main {
   a,
   button,
@@ -15,7 +9,8 @@ main {
   h3,
   h4,
   [tabindex="0"] {
-    scroll-margin-top: var(--az-scroll-margin-top);
-    scroll-margin-bottom: var(--az-scroll-margin-bottom);
+    --az-scroll-behavior: smooth;
+    --az-scroll-margin-top: 86px;
+    --az-scroll-margin-bottom: 100px;
   }
 }

--- a/site/assets/scss/_scrolling.scss
+++ b/site/assets/scss/_scrolling.scss
@@ -1,16 +1,6 @@
 // When navigating with the keyboard, prevent focus from landing behind the sticky header
-main {
-  a,
-  button,
-  input,
-  select,
-  textarea,
-  h2,
-  h3,
-  h4,
-  [tabindex="0"] {
-    --az-scroll-behavior: smooth;
-    --az-scroll-margin-top: 86px;
-    --az-scroll-margin-bottom: 100px;
-  }
+:root {
+  --az-scroll-behavior: smooth;
+  --az-scroll-margin-top: 86px;
+  --az-scroll-margin-bottom: 100px;
 }

--- a/site/assets/scss/_scrolling.scss
+++ b/site/assets/scss/_scrolling.scss
@@ -1,4 +1,9 @@
 // When navigating with the keyboard, prevent focus from landing behind the sticky header
+:root {
+  --az-scroll-behavior: smooth;
+  --az-scroll-margin-top: 80px;
+  --az-scroll-margin-bottom: 100px;
+}
 
 main {
   a,
@@ -10,14 +15,7 @@ main {
   h3,
   h4,
   [tabindex="0"] {
-    scroll-margin-top: 80px;
-    scroll-margin-bottom: 100px;
+    scroll-margin-top: var(--az-scroll-margin-top);
+    scroll-margin-bottom: var(--az-scroll-margin-bottom);
   }
-}
-
-// This docs site has a sticky header - restore the accordion anchor scroll
-// offset the component itself defaults to 0, since most consumer sites
-// don't have one.
-:root {
-  --az-accordion-anchor-scroll-offset: 86px;
 }


### PR DESCRIPTION
## Summary

Generalizes the sticky-header scroll-offset fix that lived only in the docs site into a reusable feature of the Arizona Bootstrap library itself.

- **New `scss/custom/_scrolling.scss`** (library-level): defines `--az-scroll-behavior`, `--az-scroll-margin-top`, `--az-scroll-margin-bottom` custom properties (defaulting to `smooth` / `0px` / `0px`) and applies them as `scroll-behavior`/`scroll-margin-*` to focusable elements and headings (`a, button, input, select, textarea, h2, h3, h4, [tabindex="0"]`) inside `main`. Imported into `scss/arizona-bootstrap.scss` right after Bootstrap's functions import.
- **Accordion cleanup**: removed the accordion-specific `--az-accordion-anchor-scroll-offset` variable from `scss/custom/_accordion.scss`; `scss/override/_accordion.scss` now uses the new generic `--az-scroll-margin-top` / `--az-scroll-behavior` variables instead.
- **Docs site simplified**: `site/assets/scss/_scrolling.scss` no longer duplicates the selector list and rules (now inherited from the library) — it just overrides the three variables (`86px` top margin, `100px` bottom margin) to account for the docs site's sticky header.

**Net effect:** any consumer site with a sticky/fixed header can now fix focus-scroll-behind-header by overriding three well-named CSS variables, instead of the fix being baked into docs-only CSS and an accordion-only variable name that didn't reflect its actual general purpose.

