### PR TITLE
Closes #2297: Remove experimental status from the blue Arizona Header

### DIFF
--- a/site/content/docs/5.1/components/arizona-header.md
+++ b/site/content/docs/5.1/components/arizona-header.md
@@ -16,33 +16,6 @@ The Arizona Header is to be used on all subdomains of arizona.edu.
   <p class="mb-0">The wordmark logo without a Block "A" header should only be used when near a Block "A" logo. Typically, the Block "A" logo is included as part of the site branding just below the Arizona Header.</p>
 </div>
 
-<div class="arizona-header bg-red">
-  <div class="container">
-    <div class="row">
-      <a class="arizona-logo col-auto" href="https://www.arizona.edu" title="The University of Arizona homepage">
-        <img class="arizona-line-logo" alt="The University of Arizona Wordmark Line Logo White" src="https://cdn.digital.arizona.edu/logos/v1.0.0/ua_wordmark_line_logo_white_rgb.min.svg" fetchpriority="high">
-      </a>
-    </div>
-  </div>
-</div>
-
-```html
-<div class="arizona-header az-fixed-header-on-mobile bg-red" id="header_arizona">
-  <div class="container">
-    <div class="row">
-      <a class="arizona-logo col-auto" href="https://www.arizona.edu" title="The University of Arizona homepage">
-        <img class="arizona-line-logo" alt="The University of Arizona Wordmark Line Logo White" src="https://cdn.digital.arizona.edu/logos/v1.0.0/ua_wordmark_line_logo_white_rgb.min.svg" fetchpriority="high">
-      </a>
-    </div>
-  </div>
-</div>
-```
-
-### Blue header
-<span class="badge badge-az-experimental mt-0">Arizona Bootstrap Experimental Feature</span>
-
-The blue Arizona Header is to be used on marketing-approved subdomains of arizona.edu. This functionality should not be used until the flagship arizona.edu website is using a blue header.
-
 <div class="arizona-header bg-blue">
   <div class="container">
     <div class="row">
@@ -54,7 +27,33 @@ The blue Arizona Header is to be used on marketing-approved subdomains of arizon
 </div>
 
 ```html
-<div class="arizona-header az-fixed-header-on-mobile bg-blue" id="header_arizona_2">
+<div class="arizona-header az-fixed-header-on-mobile bg-blue" id="header_arizona">
+  <div class="container">
+    <div class="row">
+      <a class="arizona-logo col-auto" href="https://www.arizona.edu" title="The University of Arizona homepage">
+        <img class="arizona-line-logo" alt="The University of Arizona Wordmark Line Logo White" src="https://cdn.digital.arizona.edu/logos/v1.0.0/ua_wordmark_line_logo_white_rgb.min.svg" fetchpriority="high">
+      </a>
+    </div>
+  </div>
+</div>
+```
+
+### Original red header
+
+The original red Arizona Header will be deprecated in a future release.
+
+<div class="arizona-header bg-red">
+  <div class="container">
+    <div class="row">
+      <a class="arizona-logo col-auto" href="https://www.arizona.edu" title="The University of Arizona homepage">
+        <img class="arizona-line-logo" alt="The University of Arizona Wordmark Line Logo White" src="https://cdn.digital.arizona.edu/logos/v1.0.0/ua_wordmark_line_logo_white_rgb.min.svg" fetchpriority="high">
+      </a>
+    </div>
+  </div>
+</div>
+
+```html
+<div class="arizona-header az-fixed-header-on-mobile bg-red" id="header_arizona_2">
   <div class="container">
     <div class="row">
       <a class="arizona-logo col-auto" href="https://www.arizona.edu" title="The University of Arizona homepage">
@@ -70,7 +69,7 @@ The blue Arizona Header is to be used on marketing-approved subdomains of arizon
 The Arizona Header can be extended with off-canvas search and navigation for mobile devices, as shown in the example below.
 
 {{< example >}}
-<div class="arizona-header az-fixed-header-on-mobile bg-red" id="header_arizona_example_1">
+<div class="arizona-header az-fixed-header-on-mobile bg-blue" id="header_arizona_example_1">
   <div class="container">
     <div class="row">
       <a class="arizona-logo col-auto" href="https://www.arizona.edu" title="The University of Arizona homepage">
@@ -112,7 +111,7 @@ In most cases, the Arizona Header element is intended to be fixed to the top of 
 **Note:** For this documentation site, this fixed-position behavior has been overridden to prevent the example Arizona Headers from disappearing behind the existing Arizona Bootstrap navbar above.
 
 {{< example >}}
-<div class="arizona-header bg-red" id="header_arizona_example_2">
+<div class="arizona-header bg-blue" id="header_arizona_example_2">
   <div class="container">
     <div class="row">
       <a class="arizona-logo col-auto" href="https://www.arizona.edu" title="The University of Arizona homepage">


### PR DESCRIPTION
## Changes
 - Updates the Arizona Header docs page to make the blue Arizona Header the default and remove its experimental status.

## How to test
 - Confirm the changes in https://review.digital.arizona.edu/arizona-bootstrap/issue/2297/docs/5.1/components/arizona-header/.