### PR TITLE
Fixes #2309: Monsoon background pattern doesn't scale down on narrow viewports

### DIFF
--- a/scss/custom/_background-wrapper.scss
+++ b/scss/custom/_background-wrapper.scss
@@ -94,6 +94,12 @@
 // >>> Monsoon
 // Pattern is rendered on a pseudo-element so opacity fades only the
 // decorative image, not the wrapper's text content.
+//
+// The pseudo-element is a band pinned to one edge, not the full wrapper, so
+// the pattern stays a proportional accent rather than washing across the
+// whole element on narrow viewports. Each side pins only its own edge and
+// leaves the opposite one auto: setting both would over-constrain `width`,
+// which resolves by dropping a different edge under ltr than under rtl.
 .bg-monsoon-sky-start,
 .bg-monsoon-sky-end {
   position: relative;
@@ -102,8 +108,10 @@
 
   &::before {
     position: absolute;
-    inset: 0;
     z-index: -1;
+    width: 20%;
+    min-width: 75px;
+    max-width: 200px;
     content: "";
     opacity: .4;
     background: {
@@ -115,9 +123,11 @@
 }
 
 .bg-monsoon-sky-start::before {
+  inset: 0 auto 0 0;
   background-position: top left;
 }
 
 .bg-monsoon-sky-end::before {
+  inset: 0 0 0 auto;
   background-position: top right;
 }


### PR DESCRIPTION
The pattern's pseudo-element used `inset: 0`, so it filled the whole wrapper and nothing clipped the 300px tile. The pattern therefore occupied a fixed 300px at every viewport - a ~16% accent at 1920px, but 94% of the element at 320px, washing across the text on phones.

Pin the pseudo-element to a single edge and clamp its width to 20% (75px-200px), matching the upstream component this was ported from. The band now holds ~10-23% at every viewport.

Each side pins only its own edge and leaves the opposite one auto. Setting both alongside a non-auto width over-constrains the box, which CSS resolves by dropping a different edge under ltr than under rtl.

## How to test
[Review site](https://review.digital.arizona.edu/arizona-bootstrap/bug/monsoon-mobile-band/)

1. Navigate to the [Background wrappers](https://review.digital.arizona.edu/arizona-bootstrap/bug/monsoon-mobile-band/docs/5.2/components/background-wrappers/) page at `/docs/5.2/components/background-wrappers/`.
2. Select an **Azurite** background and the **Monsoon Sky Start** pattern option.
3. Reduce the width of your browser to a mobile size (500px wide for example). [It should look about like this](https://github.com/user-attachments/assets/35a5580b-db11-4267-a8ac-0eb4499549e7).
4. Compare with [main](https://review.digital.arizona.edu/arizona-bootstrap/main/docs/5.2/components/background-wrappers/) at the same resolution and [observe the pattern does not reduce in size](https://github.com/user-attachments/assets/b17d8d94-c0b0-4bab-95fe-226a8e77ef25) at the smaller viewport.
5. Now compare with arizona.edu at the same resolution and [observe the reduction in size is the same](https://github.com/user-attachments/assets/14d394bd-6051-4ba5-aad4-206bb169fd75).

_Note: Since this is a CSS-only change, no additional follow up is needed in AZQS. The fix will be applied automatically when AZQS is updated to AZBS 5.2.1._